### PR TITLE
WebUI: Create new $ alias for selecting elements by ID

### DIFF
--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -289,7 +289,7 @@
             });
             // synchronize header scrolling to table body
             $("bulkRenameFilesTableDiv").onscroll = function() {
-                const length = $(this).scrollLeft;
+                const length = this.scrollLeft;
                 $("bulkRenameFilesTableFixedHeaderDiv").scrollLeft = length;
             };
 

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -316,7 +316,7 @@ window.addEventListener("DOMContentLoaded", () => {
     };
 
     toggleFilterDisplay = (filterListID) => {
-        const filterList = document.getElementById(filterListID);
+        const filterList = $(filterListID);
         const filterTitle = filterList.previousElementSibling;
         const toggleIcon = filterTitle.firstElementChild;
         toggleIcon.classList.toggle("rotate");
@@ -460,7 +460,7 @@ window.addEventListener("DOMContentLoaded", () => {
     };
 
     const updateFilter = (filter, filterTitle) => {
-        const filterEl = document.getElementById(`${filter}_filter`);
+        const filterEl = $(`${filter}_filter`);
         const filterTorrentCount = torrentsTable.getFilteredTorrentsNumber(filter, CATEGORIES_ALL, TAGS_ALL, TRACKERS_ALL);
         if (useAutoHideZeroStatusFilters) {
             const hideFilter = (filterTorrentCount === 0) && (filter !== "all");
@@ -485,25 +485,25 @@ window.addEventListener("DOMContentLoaded", () => {
         updateFilter("checking", "QBT_TR(Checking (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
         updateFilter("moving", "QBT_TR(Moving (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
         updateFilter("errored", "QBT_TR(Errored (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
-        if (useAutoHideZeroStatusFilters && document.getElementById(`${selectedStatus}_filter`).classList.contains("invisible"))
+        if (useAutoHideZeroStatusFilters && $(`${selectedStatus}_filter`).classList.contains("invisible"))
             setStatusFilter("all");
     };
 
     const highlightSelectedStatus = () => {
-        const statusFilter = document.getElementById("statusFilterList");
+        const statusFilter = $("statusFilterList");
         const filterID = `${selectedStatus}_filter`;
         for (const status of statusFilter.children)
             status.classList.toggle("selectedFilter", (status.id === filterID));
     };
 
     const updateCategoryList = () => {
-        const categoryList = document.getElementById("categoryFilterList");
+        const categoryList = $("categoryFilterList");
         if (!categoryList)
             return;
 
         [...categoryList.children].forEach((el) => { el.destroy(); });
 
-        const categoryItemTemplate = document.getElementById("categoryFilterItem");
+        const categoryItemTemplate = $("categoryFilterItem");
 
         const createLink = (category, text, count) => {
             const categoryFilterItem = categoryItemTemplate.content.cloneNode(true).firstElementChild;
@@ -609,7 +609,7 @@ window.addEventListener("DOMContentLoaded", () => {
     };
 
     const highlightSelectedCategory = () => {
-        const categoryList = document.getElementById("categoryFilterList");
+        const categoryList = $("categoryFilterList");
         if (!categoryList)
             return;
 
@@ -624,7 +624,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
         [...tagFilterList.children].forEach((el) => { el.destroy(); });
 
-        const tagItemTemplate = document.getElementById("tagFilterItem");
+        const tagItemTemplate = $("tagFilterItem");
 
         const createLink = (tag, text, count) => {
             const tagFilterItem = tagItemTemplate.content.cloneNode(true).firstElementChild;
@@ -662,7 +662,7 @@ window.addEventListener("DOMContentLoaded", () => {
     };
 
     const highlightSelectedTag = () => {
-        const tagFilterList = document.getElementById("tagFilterList");
+        const tagFilterList = $("tagFilterList");
         if (!tagFilterList)
             return;
 
@@ -677,7 +677,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
         [...trackerFilterList.children].forEach((el) => { el.destroy(); });
 
-        const trackerItemTemplate = document.getElementById("trackerFilterItem");
+        const trackerItemTemplate = $("trackerFilterItem");
 
         const createLink = (host, text, count) => {
             const trackerFilterItem = trackerItemTemplate.content.cloneNode(true).firstElementChild;
@@ -721,7 +721,7 @@ window.addEventListener("DOMContentLoaded", () => {
     };
 
     const highlightSelectedTracker = () => {
-        const trackerFilterList = document.getElementById("trackerFilterList");
+        const trackerFilterList = $("trackerFilterList");
         if (!trackerFilterList)
             return;
 
@@ -982,7 +982,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
         $("freeSpaceOnDisk").textContent = "QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]".replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.free_space_on_disk));
 
-        const externalIPsElement = document.getElementById("externalIPs");
+        const externalIPsElement = $("externalIPs");
         if (window.qBittorrent.Cache.preferences.get().status_bar_external_ip) {
             const lastExternalAddressV4 = serverState.last_external_address_v4;
             const lastExternalAddressV6 = serverState.last_external_address_v6;
@@ -1004,7 +1004,7 @@ window.addEventListener("DOMContentLoaded", () => {
             externalIPsElement.previousElementSibling.classList.add("invisible");
         }
 
-        const dhtElement = document.getElementById("DHTNodes");
+        const dhtElement = $("DHTNodes");
         if (window.qBittorrent.Cache.preferences.get().dht) {
             dhtElement.textContent = "QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]".replace("%1", serverState.dht_nodes);
             dhtElement.classList.remove("invisible");
@@ -1016,7 +1016,7 @@ window.addEventListener("DOMContentLoaded", () => {
         }
 
         // Statistics dialog
-        if (document.getElementById("statisticsContent")) {
+        if ($("statisticsContent")) {
             $("AlltimeDL").textContent = window.qBittorrent.Misc.friendlyUnit(serverState.alltime_dl, false);
             $("AlltimeUL").textContent = window.qBittorrent.Misc.friendlyUnit(serverState.alltime_ul, false);
             $("TotalWastedSession").textContent = window.qBittorrent.Misc.friendlyUnit(serverState.total_wasted_session, false);
@@ -1605,12 +1605,12 @@ window.addEventListener("DOMContentLoaded", () => {
                 updatePropertiesPanel();
 
                 const showFilesFilter = (selectedTab.id === "propFilesLink") && !this.isCollapsed;
-                document.getElementById("torrentFilesFilterToolbar").classList.toggle("invisible", !showFilesFilter);
+                $("torrentFilesFilterToolbar").classList.toggle("invisible", !showFilesFilter);
             });
 
             const showFilesFilter = (lastUsedTab === "propFilesLink") && !this.isCollapsed;
             if (showFilesFilter)
-                document.getElementById("torrentFilesFilterToolbar").classList.remove("invisible");
+                $("torrentFilesFilterToolbar").classList.remove("invisible");
         },
         column: "mainColumn",
         height: prop_h
@@ -1626,7 +1626,7 @@ window.addEventListener("DOMContentLoaded", () => {
         }, window.qBittorrent.Misc.FILTER_INPUT_DELAY);
     });
 
-    document.getElementById("torrentsFilterToolbar").addEventListener("change", (e) => { torrentsTable.updateTable(); });
+    $("torrentsFilterToolbar").addEventListener("change", (e) => { torrentsTable.updateTable(); });
 
     $("transfersTabLink").addEventListener("click", () => { showTransfersTab(); });
     $("searchTabLink").addEventListener("click", () => { showSearchTab(); });

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -127,7 +127,11 @@ window.qBittorrent.Client.setup();
 // TODO: move global functions/variables into some namespace/scope
 
 this.torrentsTable = new window.qBittorrent.DynamicTable.TorrentsTable();
-
+/**
+ * Shorthand for selecting DOM elements by ID
+ * Mootools $ is used to maintain compatibility with MochaUI
+ */
+const $ = (x) => (typeof x === "string") ? document.getElementById(x) : this.$(x);
 let updatePropertiesPanel = () => {};
 
 this.updateMainData = () => {};

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -190,7 +190,7 @@ window.qBittorrent.ContextMenu ??= (() => {
                 e.stopPropagation();
             }
             // record this as the trigger
-            this.options.element = $(el);
+            this.options.element = el;
             this.adjustMenuPosition(e);
             // show the menu
             this.show();
@@ -219,7 +219,7 @@ window.qBittorrent.ContextMenu ??= (() => {
             });
 
             // hide on body click
-            $(document.body).addEventListener("click", () => {
+            document.body.addEventListener("click", () => {
                 this.hide();
                 this.options.element = null;
             });

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -467,7 +467,7 @@ window.qBittorrent.ContextMenu ??= (() => {
                 checkbox.checked = (hasCount ? !isLesser : false);
             }
 
-            const contextCategoryList = document.getElementById("contextCategoryList");
+            const contextCategoryList = $("contextCategoryList");
             for (const category of categoryMap.keys()) {
                 const categoryIcon = contextCategoryList.querySelector(`a[href$="#Category/${category}"] img`);
                 const count = categoryCount.get(category);

--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -131,7 +131,7 @@ window.qBittorrent.Download ??= (() => {
         }
     };
 
-    $(window).addEventListener("load", async () => {
+    window.addEventListener("load", async () => {
         // user might load this page directly (via browser magnet handler)
         // so wait for crucial initialization to complete
         await window.parent.qBittorrent.Client.initializeCaches();

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -74,7 +74,7 @@ window.qBittorrent.DynamicTable ??= (() => {
         setup: function(dynamicTableDivId, dynamicTableFixedHeaderDivId, contextMenu) {
             this.dynamicTableDivId = dynamicTableDivId;
             this.dynamicTableFixedHeaderDivId = dynamicTableFixedHeaderDivId;
-            this.dynamicTableDiv = document.getElementById(dynamicTableDivId);
+            this.dynamicTableDiv = $(dynamicTableDivId);
             this.fixedTableHeader = document.querySelector(`#${dynamicTableFixedHeaderDivId} thead tr`);
             this.hiddenTableHeader = this.dynamicTableDiv.querySelector(`thead tr`);
             this.tableBody = this.dynamicTableDiv.querySelector(`tbody`);
@@ -374,7 +374,7 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         _calculateColumnBodyWidth: function(column) {
             const columnIndex = this.getColumnPos(column.name);
-            const bodyColumn = document.getElementById(this.dynamicTableDivId).querySelectorAll("tr>th")[columnIndex];
+            const bodyColumn = $(this.dynamicTableDivId).querySelectorAll("tr>th")[columnIndex];
             const canvas = document.createElement("canvas");
             const context = canvas.getContext("2d");
             context.font = window.getComputedStyle(bodyColumn, null).getPropertyValue("font");
@@ -418,7 +418,7 @@ window.qBittorrent.DynamicTable ??= (() => {
 
                 // check required min header width
                 const columnIndex = this.getColumnPos(column.name);
-                const headColumn = document.getElementById(this.dynamicTableFixedHeaderDivId).querySelectorAll("tr>th")[columnIndex];
+                const headColumn = $(this.dynamicTableFixedHeaderDivId).querySelectorAll("tr>th")[columnIndex];
                 const canvas = document.createElement("canvas");
                 const context = canvas.getContext("2d");
                 context.font = window.getComputedStyle(headColumn, null).getPropertyValue("font");
@@ -443,7 +443,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             const menuId = `${this.dynamicTableDivId}_headerMenu`;
 
             // reuse menu if already exists
-            let ul = document.getElementById(menuId);
+            let ul = $(menuId);
             if (ul === null) {
                 ul = document.createElement("ul");
                 ul.id = menuId;
@@ -702,7 +702,7 @@ window.qBittorrent.DynamicTable ??= (() => {
         setupAltRow: function() {
             const useAltRowColors = (LocalPreferences.get("use_alt_row_colors", "true") === "true");
             if (useAltRowColors)
-                document.getElementById(this.dynamicTableDivId).classList.add("altRowColors");
+                $(this.dynamicTableDivId).classList.add("altRowColors");
         },
 
         selectAll: function() {
@@ -1591,7 +1591,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             }
 
             if ((filterTerms !== undefined) && (filterTerms !== null)) {
-                const filterBy = document.getElementById("torrentsFilterSelect").value;
+                const filterBy = $("torrentsFilterSelect").value;
                 const textToSearch = row["full_data"][filterBy].toLowerCase();
                 if (filterTerms instanceof RegExp) {
                     if (!filterTerms.test(textToSearch))
@@ -1618,8 +1618,8 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         getFilteredTorrentsHashes: function(filterName, category, tag, tracker) {
             const rowsHashes = [];
-            const useRegex = document.getElementById("torrentsFilterRegexBox").checked;
-            const filterText = document.getElementById("torrentsFilterInput").value.trim().toLowerCase();
+            const useRegex = $("torrentsFilterRegexBox").checked;
+            const filterText = $("torrentsFilterInput").value.trim().toLowerCase();
             let filterTerms;
             try {
                 filterTerms = (filterText.length > 0)

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -89,7 +89,7 @@ window.qBittorrent.Dialog ??= (() => {
         width: 480,
         onCloseComplete: () => {
             // make sure overlay is properly hidden upon modal closing
-            document.getElementById("modalOverlay").style.display = "none";
+            $("modalOverlay").style.display = "none";
         }
     });
 
@@ -537,7 +537,7 @@ const initializeWindows = () => {
                     },
                     onCloseComplete: () => {
                         // make sure overlay is properly hidden upon modal closing
-                        document.getElementById("modalOverlay").style.display = "none";
+                        $("modalOverlay").style.display = "none";
                     }
                 });
             }

--- a/src/webui/www/private/scripts/pathAutofill.js
+++ b/src/webui/www/private/scripts/pathAutofill.js
@@ -49,7 +49,7 @@ window.qBittorrent.pathAutofill ??= (() => {
             datalist.appendChild(option);
         }
 
-        const oldDatalist = document.getElementById(`${inputElement.id}Suggestions`);
+        const oldDatalist = $(`${inputElement.id}Suggestions`);
         if (oldDatalist !== null) {
             oldDatalist.replaceWith(datalist);
         }

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -43,7 +43,7 @@ window.qBittorrent.PropGeneral ??= (() => {
     $("progress").appendChild(piecesBar);
 
     const clearData = () => {
-        document.getElementById("progressPercentage").textContent = "";
+        $("progressPercentage").textContent = "";
         $("time_elapsed").textContent = "";
         $("eta").textContent = "";
         $("nb_connections").textContent = "";
@@ -110,7 +110,7 @@ window.qBittorrent.PropGeneral ??= (() => {
                 if (data) {
                     // Update Torrent data
 
-                    document.getElementById("progressPercentage").textContent = window.qBittorrent.Misc.friendlyPercentage(data.progress);
+                    $("progressPercentage").textContent = window.qBittorrent.Misc.friendlyPercentage(data.progress);
 
                     const timeElapsed = (data.seeding_time > 0)
                         ? "QBT_TR(%1 (seeded for %2))QBT_TR[CONTEXT=PropertiesWidget]"

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -139,7 +139,7 @@ window.qBittorrent.Search ??= (() => {
             }, window.qBittorrent.Misc.FILTER_INPUT_DELAY);
         });
 
-        document.getElementById("SearchPanel").addEventListener("keydown", (event) => {
+        $("SearchPanel").addEventListener("keydown", (event) => {
             switch (event.key) {
                 case "Enter": {
                     event.preventDefault();
@@ -150,7 +150,7 @@ window.qBittorrent.Search ??= (() => {
                             manageSearchPlugins();
                             break;
                         case "searchPattern":
-                            document.getElementById("startSearchButton").click();
+                            $("startSearchButton").click();
                             break;
                     }
 
@@ -197,7 +197,7 @@ window.qBittorrent.Search ??= (() => {
         listItem.classList.add("selected", "searchTab");
         listItem.addEventListener("click", (e) => {
             setActiveTab(listItem);
-            document.getElementById("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
+            $("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
         });
         listItem.appendChild(tabElem);
         $("searchTabs").appendChild(listItem);
@@ -277,7 +277,7 @@ window.qBittorrent.Search ??= (() => {
         }
         else if (isTabSelected && newTabToSelect) {
             setActiveTab(newTabToSelect);
-            document.getElementById("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
+            $("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
         }
     };
 
@@ -354,7 +354,7 @@ window.qBittorrent.Search ??= (() => {
             const currentSearchPattern = $("searchPattern").value.trim();
             if (state.running && (state.searchPattern === currentSearchPattern)) {
                 // allow search to be stopped
-                document.getElementById("startSearchButton").lastChild.textContent = "QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]";
+                $("startSearchButton").lastChild.textContent = "QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]";
                 searchPatternChanged = false;
             }
 
@@ -411,7 +411,7 @@ window.qBittorrent.Search ??= (() => {
 
                 const responseJSON = await response.json();
 
-                document.getElementById("startSearchButton").lastChild.textContent = "QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]";
+                $("startSearchButton").lastChild.textContent = "QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]";
                 const searchId = responseJSON.id;
                 createSearchTab(searchId, pattern);
 
@@ -545,11 +545,11 @@ window.qBittorrent.Search ??= (() => {
         // start a new search if pattern has changed, otherwise allow the search to be stopped
         if (state && (state.searchPattern === currentSearchPattern)) {
             searchPatternChanged = false;
-            document.getElementById("startSearchButton").lastChild.textContent = "QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]";
+            $("startSearchButton").lastChild.textContent = "QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]";
         }
         else {
             searchPatternChanged = true;
-            document.getElementById("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
+            $("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
         }
     };
 
@@ -585,7 +585,7 @@ window.qBittorrent.Search ??= (() => {
     };
 
     const resetSearchState = (searchId) => {
-        document.getElementById("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
+        $("startSearchButton").lastChild.textContent = "QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]";
         const state = searchState.get(searchId);
         if (state) {
             state.running = false;
@@ -700,7 +700,7 @@ window.qBittorrent.Search ??= (() => {
                     $("searchPattern").disabled = searchPluginsEmpty;
                     $("categorySelect").disabled = searchPluginsEmpty;
                     $("pluginsSelect").disabled = searchPluginsEmpty;
-                    document.getElementById("startSearchButton").disabled = searchPluginsEmpty;
+                    $("startSearchButton").disabled = searchPluginsEmpty;
 
                     if (window.qBittorrent.SearchPlugins !== undefined)
                         window.qBittorrent.SearchPlugins.updateTable();

--- a/src/webui/www/private/views/confirmAutoTMM.html
+++ b/src/webui/www/private/views/confirmAutoTMM.html
@@ -13,9 +13,9 @@
     "use strict";
 
     (() => {
-        const confirmButton = document.getElementById("confirmAutoTmmButton");
-        const cancelButton = document.getElementById("cancelAutoTmmButton");
-        const confirmText = document.getElementById("confirmAutoTmmMessage");
+        const confirmButton = $("confirmAutoTmmButton");
+        const cancelButton = $("cancelAutoTmmButton");
+        const confirmText = $("confirmAutoTmmMessage");
 
         const {
             options: { data: { hashes, enable } },

--- a/src/webui/www/private/views/confirmRecheck.html
+++ b/src/webui/www/private/views/confirmRecheck.html
@@ -13,9 +13,9 @@
     "use strict";
 
     (() => {
-        const confirmButton = document.getElementById("confirmRecheckButton");
-        const cancelButton = document.getElementById("cancelRecheckButton");
-        const confirmText = document.getElementById("confirmRecheckMessage");
+        const confirmButton = $("confirmRecheckButton");
+        const cancelButton = $("cancelRecheckButton");
+        const confirmText = $("confirmRecheckMessage");
 
         const {
             options: { data: { hashes } },
@@ -25,7 +25,7 @@
         confirmText.textContent = "QBT_TR(Are you sure you want to recheck the selected torrent(s)?)QBT_TR[CONTEXT=confirmRecheckDialog]";
 
         cancelButton.addEventListener("click", (e) => {
-            window.qBittorrent.Client.closeWindow(document.getElementById("confirmRecheckDialog"));
+            window.qBittorrent.Client.closeWindow($("confirmRecheckDialog"));
         });
         confirmButton.addEventListener("click", (e) => {
             fetch("api/v2/torrents/recheck", {
@@ -41,7 +41,7 @@
                     }
 
                     updateMainData();
-                    window.qBittorrent.Client.closeWindow(document.getElementById("confirmRecheckDialog"));
+                    window.qBittorrent.Client.closeWindow($("confirmRecheckDialog"));
                 });
         });
 
@@ -54,7 +54,7 @@
                     confirmButton.click();
                     break;
                 case "Escape":
-                    window.qBittorrent.Client.closeWindow(document.getElementById("confirmRecheckDialog"));
+                    window.qBittorrent.Client.closeWindow($("confirmRecheckDialog"));
                     break;
             }
         });

--- a/src/webui/www/private/views/confirmdeletion.html
+++ b/src/webui/www/private/views/confirmdeletion.html
@@ -27,11 +27,11 @@
             rememberButton.classList.toggle("disabled", !enable);
         };
 
-        const confirmButton = document.getElementById("confirmDeletionButton");
-        const cancelButton = document.getElementById("cancelDeletionButton");
-        const rememberButton = document.getElementById("rememberBtn");
-        const deleteCB = document.getElementById("deleteFromDiskCB");
-        const deletionText = document.getElementById("deleteTorrentMessage");
+        const confirmButton = $("confirmDeletionButton");
+        const cancelButton = $("cancelDeletionButton");
+        const rememberButton = $("rememberBtn");
+        const deleteCB = $("deleteFromDiskCB");
+        const deletionText = $("deleteTorrentMessage");
 
         const {
             hashes,
@@ -69,7 +69,7 @@
         });
 
         cancelButton.focus();
-        cancelButton.addEventListener("click", (e) => { window.qBittorrent.Client.closeWindow(document.getElementById("confirmDeletionPage")); });
+        cancelButton.addEventListener("click", (e) => { window.qBittorrent.Client.closeWindow($("confirmDeletionPage")); });
 
         confirmButton.addEventListener("click", (e) => {
             // Some torrents might be removed when waiting for user input, so refetch the torrent list
@@ -93,7 +93,7 @@
                     torrentsTable.deselectAll();
                     updateMainData();
                     updatePropertiesPanel();
-                    window.qBittorrent.Client.closeWindow(document.getElementById("confirmDeletionPage"));
+                    window.qBittorrent.Client.closeWindow($("confirmDeletionPage"));
                 });
         });
     })();

--- a/src/webui/www/private/views/cookies.html
+++ b/src/webui/www/private/views/cookies.html
@@ -138,7 +138,7 @@
                         return;
                     }
 
-                    window.qBittorrent.Client.closeWindow(document.getElementById("cookiesPage"));
+                    window.qBittorrent.Client.closeWindow($("cookiesPage"));
                 });
         };
 
@@ -182,7 +182,7 @@
                 addCookie();
             });
 
-            document.getElementById("saveButton").addEventListener("click", (event) => {
+            $("saveButton").addEventListener("click", (event) => {
                 save();
             });
         };

--- a/src/webui/www/private/views/createtorrent.html
+++ b/src/webui/www/private/views/createtorrent.html
@@ -139,7 +139,7 @@
         };
 
         const init = () => {
-            const pieceSizeSelect = document.getElementById("pieceSize");
+            const pieceSizeSelect = $("pieceSize");
             pieceSizeSelect.appendChild(createSizeOption(0));
             for (let i = 4; i <= 17; ++i)
                 pieceSizeSelect.appendChild(createSizeOption(1024 << i));
@@ -148,17 +148,17 @@
             const libtorrentVersion = window.qBittorrent.Misc.parseVersion(buildInfo.libtorrent);
             if (libtorrentVersion.valid) {
                 if (libtorrentVersion.major >= 2) {
-                    document.getElementById("optimizeAlignmentBox").style.display = "none";
+                    $("optimizeAlignmentBox").style.display = "none";
                 }
                 else {
-                    document.getElementById("torrentFormatBox").style.display = "none";
-                    document.getElementById("optimizeAlignment").addEventListener("change", (e) => {
-                        document.getElementById("paddedFileSizeLimit").disabled = !e.target.checked;
+                    $("torrentFormatBox").style.display = "none";
+                    $("optimizeAlignment").addEventListener("change", (e) => {
+                        $("paddedFileSizeLimit").disabled = !e.target.checked;
                     });
                 }
             }
 
-            document.getElementById("createTorrentForm").addEventListener("submit", (e) => {
+            $("createTorrentForm").addEventListener("submit", (e) => {
                 e.preventDefault();
                 submit();
             });
@@ -168,13 +168,13 @@
         };
 
         const submit = () => {
-            document.getElementById("privateTorrentHidden").value = document.getElementById("privateTorrent").checked ? "true" : "false";
-            document.getElementById("startSeedingHidden").value = document.getElementById("startSeeding").checked ? "true" : "false";
-            document.getElementById("optimizeAlignmentHidden").value = document.getElementById("optimizeAlignment").checked ? "true" : "false";
+            $("privateTorrentHidden").value = $("privateTorrent").checked ? "true" : "false";
+            $("startSeedingHidden").value = $("startSeeding").checked ? "true" : "false";
+            $("optimizeAlignmentHidden").value = $("optimizeAlignment").checked ? "true" : "false";
 
-            document.getElementById("download_spinner").style.display = "block";
+            $("download_spinner").style.display = "block";
 
-            const formData = new FormData(document.getElementById("createTorrentForm"));
+            const formData = new FormData($("createTorrentForm"));
             if (formData.has("trackers"))
                 formData.set("trackers", formatUrls(formData.get("trackers")));
             if (formData.has("urlSeeds"))
@@ -188,41 +188,41 @@
                     alert("QBT_TR(Unable to create torrent.)QBT_TR[CONTEXT=TorrentCreator]");
                     return;
                 }
-                window.qBittorrent.Client.closeWindow(document.getElementById("createTorrentPage"));
+                window.qBittorrent.Client.closeWindow($("createTorrentPage"));
             });
 
         };
 
         const savePreferences = () => {
             const preference = {
-                sourcePath: document.getElementById("sourcePath").value,
-                torrentFormat: document.getElementById("torrentFormat").value,
-                pieceSize: document.getElementById("pieceSize").value,
-                privateTorrent: document.getElementById("privateTorrent").checked,
-                startSeeding: document.getElementById("startSeeding").checked,
-                optimizeAlignment: document.getElementById("optimizeAlignment").checked,
-                paddedFileSizeLimit: document.getElementById("paddedFileSizeLimit").value,
-                trackerURLs: document.getElementById("trackerURLs").value,
-                webSeedURLs: document.getElementById("webSeedURLs").value,
-                comments: document.getElementById("comments").value,
-                source: document.getElementById("source").value,
+                sourcePath: $("sourcePath").value,
+                torrentFormat: $("torrentFormat").value,
+                pieceSize: $("pieceSize").value,
+                privateTorrent: $("privateTorrent").checked,
+                startSeeding: $("startSeeding").checked,
+                optimizeAlignment: $("optimizeAlignment").checked,
+                paddedFileSizeLimit: $("paddedFileSizeLimit").value,
+                trackerURLs: $("trackerURLs").value,
+                webSeedURLs: $("webSeedURLs").value,
+                comments: $("comments").value,
+                source: $("source").value,
             };
             LocalPreferences.set("torrent_creator", JSON.stringify(preference));
         };
 
         const loadPreference = () => {
             const preference = JSON.parse(LocalPreferences.get("torrent_creator") ?? "{}");
-            document.getElementById("sourcePath").value = preference.sourcePath ?? "";
-            document.getElementById("torrentFormat").value = preference.torrentFormat ?? "hybrid";
-            document.getElementById("pieceSize").value = preference.pieceSize ?? 0;
-            document.getElementById("privateTorrent").checked = preference.privateTorrent ?? false;
-            document.getElementById("startSeeding").checked = preference.startSeeding ?? false;
-            document.getElementById("optimizeAlignment").checked = preference.optimizeAlignment ?? false;
-            document.getElementById("paddedFileSizeLimit").value = preference.paddedFileSizeLimit ?? 0;
-            document.getElementById("trackerURLs").value = preference.trackerURLs ?? "";
-            document.getElementById("webSeedURLs").value = preference.webSeedURLs ?? "";
-            document.getElementById("comments").value = preference.comments ?? "";
-            document.getElementById("source").value = preference.source ?? "";
+            $("sourcePath").value = preference.sourcePath ?? "";
+            $("torrentFormat").value = preference.torrentFormat ?? "hybrid";
+            $("pieceSize").value = preference.pieceSize ?? 0;
+            $("privateTorrent").checked = preference.privateTorrent ?? false;
+            $("startSeeding").checked = preference.startSeeding ?? false;
+            $("optimizeAlignment").checked = preference.optimizeAlignment ?? false;
+            $("paddedFileSizeLimit").value = preference.paddedFileSizeLimit ?? 0;
+            $("trackerURLs").value = preference.trackerURLs ?? "";
+            $("webSeedURLs").value = preference.webSeedURLs ?? "";
+            $("comments").value = preference.comments ?? "";
+            $("source").value = preference.source ?? "";
         };
 
         return exports();

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -79,7 +79,7 @@
         };
 
         const toggleCategoryDisplay = (filterItemID) => {
-            const filterItem = document.getElementById(filterItemID);
+            const filterItem = $(filterItemID);
             LocalPreferences.set(`category_${filterItemID}_collapsed`, filterItem.classList.toggle("collapsedCategory").toString());
         };
 
@@ -230,7 +230,7 @@
         if (LocalPreferences.get("filter_tracker_collapsed") === "true")
             toggleFilterDisplay("trackerFilterList");
 
-        document.getElementById("Filters_pad").addEventListener("click", (event) => {
+        $("Filters_pad").addEventListener("click", (event) => {
             const filterItem = event.target.closest("li");
             if (!filterItem || filterItem.classList.contains("selectedFilter"))
                 return;
@@ -256,7 +256,7 @@
             }
         });
 
-        document.getElementById("Filters_pad").addEventListener("click", (event) => {
+        $("Filters_pad").addEventListener("click", (event) => {
             const filterTitle = event.target.closest(".filterTitle");
             if (!filterTitle)
                 return;
@@ -265,7 +265,7 @@
             toggleFilterDisplay(filterList);
         });
 
-        document.getElementById("categoryFilterList").addEventListener("click", (event) => {
+        $("categoryFilterList").addEventListener("click", (event) => {
             if (event.target.className !== "categoryToggle")
                 return;
 
@@ -273,7 +273,7 @@
             toggleCategoryDisplay(event.target.closest("li").id);
         });
 
-        document.getElementById("categoryFilterList").addEventListener("dblclick", function(event) {
+        $("categoryFilterList").addEventListener("dblclick", function(event) {
             const filterItem = event.target.closest("li");
             if (!this.classList.contains("subcategories") || !(filterItem?.querySelector("ul")))
                 return;

--- a/src/webui/www/private/views/installsearchplugin.html
+++ b/src/webui/www/private/views/installsearchplugin.html
@@ -19,7 +19,7 @@
     <div>
         <input type="text" id="newPluginPath" placeholder="QBT_TR(URL or local directory)QBT_TR[CONTEXT=PluginSourceDlg]" autocorrect="off" autocapitalize="none">
         <div style="margin-top: 10px; text-align: center;">
-            <button type="button" id="newPluginCancel" onclick="window.qBittorrent.Client.closeWindow(document.getElementById('installSearchPlugin'));">QBT_TR(Cancel)QBT_TR[CONTEXT=PluginSourceDlg]</button>
+            <button type="button" id="newPluginCancel" onclick="window.qBittorrent.Client.closeWindow($('installSearchPlugin'));">QBT_TR(Cancel)QBT_TR[CONTEXT=PluginSourceDlg]</button>
             <button type="button" id="newPluginOk" onclick="qBittorrent.InstallSearchPlugin.newPluginOk();">QBT_TR(Ok)QBT_TR[CONTEXT=PluginSourceDlg]</button>
         </div>
     </div>
@@ -38,7 +38,7 @@
         };
 
         const setup = () => {
-            const windowEl = document.getElementById("installSearchPlugin");
+            const windowEl = $("installSearchPlugin");
 
             windowEl.addEventListener("keydown", (event) => {
                 switch (event.key) {
@@ -77,7 +77,7 @@
                         if (!response.ok)
                             return;
 
-                        window.qBittorrent.Client.closeWindow(document.getElementById("installSearchPlugin"));
+                        window.qBittorrent.Client.closeWindow($("installSearchPlugin"));
                     });
             }
         };

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -97,7 +97,7 @@
             </select>
 
             <input type="search" id="filterTextInput" oninput="window.qBittorrent.Log.filterTextChanged()" placeholder="QBT_TR(Filter logs)QBT_TR[CONTEXT=ExecutionLogWidget]" aria-label="QBT_TR(Filter logs)QBT_TR[CONTEXT=ExecutionLogWidget]" autocomplete="off" autocorrect="off" autocapitalize="none">
-            <button type="button" title="Clear input" onclick="javascript:document.getElementById('filterTextInput').value='';window.qBittorrent.Log.filterTextChanged();">QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]</button>
+            <button type="button" title="Clear input" onclick="javascript:$('filterTextInput').value='';window.qBittorrent.Log.filterTextChanged();">QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]</button>
         </div>
 
         <div id="logFilterSummary">

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2128,7 +2128,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
         // Advanced Tab
         const updateNetworkInterfaces = (default_iface, default_iface_name) => {
-            [...document.getElementById("networkInterface").children].forEach((el) => { el.destroy(); });
+            [...$("networkInterface").children].forEach((el) => { el.destroy(); });
 
             fetch("api/v2/app/networkInterfaceList", {
                     method: "GET",
@@ -2157,7 +2157,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         const updateInterfaceAddresses = (iface, default_addr) => {
-            [...document.getElementById("optionalIPAddressToBind").children].forEach((el) => { el.destroy(); });
+            [...$("optionalIPAddressToBind").children].forEach((el) => { el.destroy(); });
 
             const url = new URL("api/v2/app/networkInterfaceAddressList", window.location);
             url.search = new URLSearchParams({
@@ -2200,7 +2200,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         const updateColoSchemeSelect = () => {
-            const combobox = document.getElementById("colorSchemeSelect");
+            const combobox = $("colorSchemeSelect");
             const colorScheme = LocalPreferences.get("color_scheme");
 
             if (colorScheme === "light")
@@ -2220,12 +2220,12 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     updateColoSchemeSelect();
                     $("statusBarExternalIP").checked = pref.status_bar_external_ip;
                     $("performanceWarning").checked = pref.performance_warning;
-                    document.getElementById("displayFullURLTrackerColumn").checked = (LocalPreferences.get("full_url_tracker_column", "false") === "true");
-                    document.getElementById("hideZeroFiltersCheckbox").checked = (LocalPreferences.get("hide_zero_status_filters", "false") === "true");
+                    $("displayFullURLTrackerColumn").checked = (LocalPreferences.get("full_url_tracker_column", "false") === "true");
+                    $("hideZeroFiltersCheckbox").checked = (LocalPreferences.get("hide_zero_status_filters", "false") === "true");
                     $("dblclickDownloadSelect").value = LocalPreferences.get("dblclick_download", "1");
                     $("dblclickCompleteSelect").value = LocalPreferences.get("dblclick_complete", "1");
-                    document.getElementById("confirmTorrentDeletion").checked = pref.confirm_torrent_deletion;
-                    document.getElementById("useAltRowColorsInput").checked = (LocalPreferences.get("use_alt_row_colors", "true") === "true");
+                    $("confirmTorrentDeletion").checked = pref.confirm_torrent_deletion;
+                    $("useAltRowColorsInput").checked = (LocalPreferences.get("use_alt_row_colors", "true") === "true");
                     $("filelog_checkbox").checked = pref.file_log_enabled;
                     $("filelog_save_path_input").value = pref.file_log_path;
                     $("filelog_backup_checkbox").checked = pref.file_log_backup_enabled;
@@ -2264,7 +2264,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                             break;
                     }
                     $("stopConditionSelect").getChildren("option")[index].selected = true;
-                    document.getElementById("mergeTrackersInput").checked = pref.merge_trackers;
+                    $("mergeTrackersInput").checked = pref.merge_trackers;
                     $("deletetorrentfileafter_checkbox").checked = pref.auto_delete_mode;
 
                     $("preallocateall_checkbox").checked = pref.preallocate_all;
@@ -2277,7 +2277,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     $("save_path_changed_tmm_combobox").value = pref.save_path_changed_tmm_enabled;
                     $("category_changed_tmm_combobox").value = pref.category_changed_tmm_enabled;
                     $("use_subcategories_checkbox").checked = pref.use_subcategories;
-                    document.getElementById("categoryPathsManualModeCheckbox").checked = pref.use_category_paths_in_manual_mode;
+                    $("categoryPathsManualModeCheckbox").checked = pref.use_category_paths_in_manual_mode;
                     $("savepath_text").value = pref.save_path;
                     $("temppath_checkbox").checked = pref.temp_path_enabled;
                     $("temppath_text").value = pref.temp_path;
@@ -2569,7 +2569,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     $("saveResumeDataInterval").value = pref.save_resume_data_interval;
                     $("saveStatisticsInterval").value = pref.save_statistics_interval;
                     $("torrentFileSizeLimit").value = (pref.torrent_file_size_limit / 1024 / 1024);
-                    document.getElementById("confirmTorrentRecheck").checked = pref.confirm_torrent_recheck;
+                    $("confirmTorrentRecheck").checked = pref.confirm_torrent_recheck;
                     $("recheckTorrentsOnCompletion").checked = pref.recheck_completed_torrents;
                     $("appInstanceName").value = pref.app_instance_name;
                     $("refreshInterval").value = pref.refresh_interval;
@@ -2643,7 +2643,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Behavior tab
             // Language
             settings["locale"] = $("locale_select").value;
-            const colorScheme = Number(document.getElementById("colorSchemeSelect").value);
+            const colorScheme = Number($("colorSchemeSelect").value);
             if (colorScheme === 0)
                 LocalPreferences.remove("color_scheme");
             else if (colorScheme === 1)
@@ -2652,12 +2652,12 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 LocalPreferences.set("color_scheme", "dark");
             settings["status_bar_external_ip"] = $("statusBarExternalIP").checked;
             settings["performance_warning"] = $("performanceWarning").checked;
-            LocalPreferences.set("full_url_tracker_column", document.getElementById("displayFullURLTrackerColumn").checked.toString());
-            LocalPreferences.set("hide_zero_status_filters", document.getElementById("hideZeroFiltersCheckbox").checked.toString());
+            LocalPreferences.set("full_url_tracker_column", $("displayFullURLTrackerColumn").checked.toString());
+            LocalPreferences.set("hide_zero_status_filters", $("hideZeroFiltersCheckbox").checked.toString());
             LocalPreferences.set("dblclick_download", $("dblclickDownloadSelect").value);
             LocalPreferences.set("dblclick_complete", $("dblclickCompleteSelect").value);
-            settings["confirm_torrent_deletion"] = document.getElementById("confirmTorrentDeletion").checked;
-            LocalPreferences.set("use_alt_row_colors", document.getElementById("useAltRowColorsInput").checked.toString());
+            settings["confirm_torrent_deletion"] = $("confirmTorrentDeletion").checked;
+            LocalPreferences.set("use_alt_row_colors", $("useAltRowColorsInput").checked.toString());
             settings["file_log_enabled"] = $("filelog_checkbox").checked;
             settings["file_log_path"] = $("filelog_save_path_input").value;
             settings["file_log_backup_enabled"] = $("filelog_backup_checkbox").checked;
@@ -2672,7 +2672,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["add_to_top_of_queue"] = $("addToTopOfQueueCheckbox").checked;
             settings["add_stopped_enabled"] = $("dontstartdownloads_checkbox").checked;
             settings["torrent_stop_condition"] = $("stopConditionSelect").getSelected()[0].value;
-            settings["merge_trackers"] = document.getElementById("mergeTrackersInput").checked;
+            settings["merge_trackers"] = $("mergeTrackersInput").checked;
             settings["auto_delete_mode"] = Number($("deletetorrentfileafter_checkbox").checked);
 
             settings["preallocate_all"] = $("preallocateall_checkbox").checked;
@@ -2685,7 +2685,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["save_path_changed_tmm_enabled"] = ($("save_path_changed_tmm_combobox").value === "true");
             settings["category_changed_tmm_enabled"] = ($("category_changed_tmm_combobox").value === "true");
             settings["use_subcategories"] = $("use_subcategories_checkbox").checked;
-            settings["use_category_paths_in_manual_mode"] = document.getElementById("categoryPathsManualModeCheckbox").checked;
+            settings["use_category_paths_in_manual_mode"] = $("categoryPathsManualModeCheckbox").checked;
             settings["save_path"] = $("savepath_text").value;
             settings["temp_path_enabled"] = $("temppath_checkbox").checked;
             settings["temp_path"] = $("temppath_text").value;
@@ -3045,7 +3045,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["save_resume_data_interval"] = Number($("saveResumeDataInterval").value);
             settings["save_statistics_interval"] = Number($("saveStatisticsInterval").value);
             settings["torrent_file_size_limit"] = ($("torrentFileSizeLimit").value * 1024 * 1024);
-            settings["confirm_torrent_recheck"] = document.getElementById("confirmTorrentRecheck").checked;
+            settings["confirm_torrent_recheck"] = $("confirmTorrentRecheck").checked;
             settings["recheck_completed_torrents"] = $("recheckTorrentsOnCompletion").checked;
             settings["app_instance_name"] = $("appInstanceName").value;
             settings["refresh_interval"] = Number($("refreshInterval").value);
@@ -3120,12 +3120,12 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 data: settings,
                 onFailure: () => {
                     alert("QBT_TR(Unable to save program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
-                    window.parent.qBittorrent.Client.closeWindow(document.getElementById("preferencesPage"));
+                    window.parent.qBittorrent.Client.closeWindow($("preferencesPage"));
                 },
                 onSuccess: () => {
                     // Close window
                     window.parent.location.reload();
-                    window.parent.qBittorrent.Client.closeWindow(document.getElementById("preferencesPage"));
+                    window.parent.qBittorrent.Client.closeWindow($("preferencesPage"));
                 }
             });
         };

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -3162,7 +3162,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 $("rowMarkOfTheWeb").style.display = "none";
 
             $("networkInterface").addEventListener("change", function() {
-                updateInterfaceAddresses($(this).value, "");
+                updateInterfaceAddresses(this.value, "");
             });
 
             loadPreferences();

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -425,7 +425,7 @@
         };
 
         const clearDetails = () => {
-            [...document.getElementById("rssDetailsView").children].forEach((el) => { el.destroy(); });
+            [...$("rssDetailsView").children].forEach((el) => { el.destroy(); });
         };
 
         const showDetails = (feedUid, articleID) => {
@@ -436,7 +436,7 @@
             if (article === undefined)
                 return;
 
-            const detailsView = document.getElementById("rssDetailsView");
+            const detailsView = $("rssDetailsView");
 
             const articleTitle = article.title;
             if (articleTitle !== undefined) {
@@ -497,7 +497,7 @@
             // Place in iframe with sandbox attribute to prevent js execution
             const torrentDescription = document.createRange().createContextualFragment('<iframe sandbox id="rssDescription"></iframe>');
             $("rssDetailsView").append(torrentDescription);
-            document.getElementById("rssDescription").srcdoc = `<html><head><link rel="stylesheet" type="text/css" href="css/style.css"></head><body>${article.description}</body></html>`;
+            $("rssDescription").srcdoc = `<html><head><link rel="stylesheet" type="text/css" href="css/style.css"></head><body>${article.description}</body></html>`;
         };
 
         const updateRssFeedList = () => {

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -63,7 +63,7 @@
     <div style="width: 100%; margin-top: 10px;">
         <button type="button" style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.installPlugin();">QBT_TR(Install new plugin)QBT_TR[CONTEXT=PluginSelectDlg]</button>
         <button type="button" style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.checkForUpdates();">QBT_TR(Check for updates)QBT_TR[CONTEXT=PluginSelectDlg]</button>
-        <button type="button" style="width: 32%; line-height: 1.4em;" onclick="window.qBittorrent.Client.closeWindow(document.getElementById('searchPlugins'));">QBT_TR(Close)QBT_TR[CONTEXT=PluginSelectDlg]</button>
+        <button type="button" style="width: 32%; line-height: 1.4em;" onclick="window.qBittorrent.Client.closeWindow($('searchPlugins'));">QBT_TR(Close)QBT_TR[CONTEXT=PluginSelectDlg]</button>
     </div>
 </div>
 
@@ -160,8 +160,8 @@
         };
 
         const calculateContextMenuOffsets = () => {
-            prevOffsetLeft = document.getElementById("searchPlugins").getBoundingClientRect().left;
-            prevOffsetTop = document.getElementById("searchPlugins").getBoundingClientRect().top;
+            prevOffsetLeft = $("searchPlugins").getBoundingClientRect().left;
+            prevOffsetTop = $("searchPlugins").getBoundingClientRect().top;
 
             return {
                 x: -prevOffsetLeft,
@@ -171,7 +171,7 @@
 
         const updateSearchPluginsTableContextMenuOffset = () => {
             // only re-calculate if window has moved
-            if ((prevOffsetLeft !== document.getElementById("searchPlugins").getBoundingClientRect().left) || (prevOffsetTop !== document.getElementById("searchPlugins").getBoundingClientRect().top))
+            if ((prevOffsetLeft !== $("searchPlugins").getBoundingClientRect().left) || (prevOffsetTop !== $("searchPlugins").getBoundingClientRect().top))
                 searchPluginsTableContextMenu.options.offsets = calculateContextMenuOffsets();
         };
 

--- a/src/webui/www/private/views/torrentcreator.html
+++ b/src/webui/www/private/views/torrentcreator.html
@@ -134,7 +134,7 @@
                 updateContextMenuOffset();
             }, true);
 
-            document.getElementById("addTaskButton").addEventListener("click", (event) => {
+            $("addTaskButton").addEventListener("click", (event) => {
                 showCreateTorrentPage();
             });
 
@@ -142,8 +142,8 @@
         };
 
         const calculateContextMenuOffsets = () => {
-            prevOffsetLeft = document.getElementById("torrentCreatorPage").getBoundingClientRect().left;
-            prevOffsetTop = document.getElementById("torrentCreatorPage").getBoundingClientRect().top;
+            prevOffsetLeft = $("torrentCreatorPage").getBoundingClientRect().left;
+            prevOffsetTop = $("torrentCreatorPage").getBoundingClientRect().top;
 
             return {
                 x: -prevOffsetLeft,
@@ -153,7 +153,7 @@
 
         const updateContextMenuOffset = () => {
             // only re-calculate if window has moved
-            if ((prevOffsetLeft !== document.getElementById("torrentCreatorPage").getBoundingClientRect().left) || (prevOffsetTop !== document.getElementById("torrentCreatorPage").getBoundingClientRect().top))
+            if ((prevOffsetLeft !== $("torrentCreatorPage").getBoundingClientRect().left) || (prevOffsetTop !== $("torrentCreatorPage").getBoundingClientRect().top))
                 contextMenu.options.offsets = calculateContextMenuOffsets();
         };
 


### PR DESCRIPTION
I added new, simple $ alias for selecting elements by ID to reduce reliance on MooTools and replaced most of the direct document.getElementById calls with it. The code looks a bit cleaner now imo and (almost) everything follows the same style.