### PR TITLE
Prevent saveState() from being called during shutdown

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -386,7 +386,9 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
 
 AddNewTorrentDialog::~AddNewTorrentDialog()
 {
-    saveState();
+    if (!QCoreApplication::closingDown())
+        saveState();
+
     delete m_ui;
 }
 


### PR DESCRIPTION
Calling saveState() during the shutdown process may lead to unexpected behavior or errors, as some subsystems might already be partially destroyed.