### PR TITLE
Move saveState() call to closeEvent to avoid crash on app exit

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -386,7 +386,6 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
 
 AddNewTorrentDialog::~AddNewTorrentDialog()
 {
-    saveState();
     delete m_ui;
 }
 
@@ -426,6 +425,12 @@ void AddNewTorrentDialog::showEvent(QShowEvent *event)
 
     activateWindow();
     raise();
+}
+
+void AddNewTorrentDialog::closeEvent(QCloseEvent *e)
+{
+    saveState();
+    QDialog::closeEvent(e);
 }
 
 void AddNewTorrentDialog::setCurrentContext(const std::shared_ptr<Context> context)

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -85,6 +85,7 @@ private:
     struct Context;
 
     void showEvent(QShowEvent *event) override;
+    void closeEvent(QCloseEvent *) override;
 
     void setCurrentContext(std::shared_ptr<Context> context);
     void updateCurrentContext();


### PR DESCRIPTION
closes #19933. 

This is due to SettingsStorage being already destroyed or in the process of destruction when the dialog is being deleted.By relocating saveState() to closeEvent(), ensuring that dialog state is saved while all dependencies, including SettingsStorage, are still valid.