### PR TITLE
WebUI: avoid saving invalid size

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1515,7 +1515,9 @@ window.addEventListener("DOMContentLoaded", () => {
         },
         column: "mainColumn",
         onResize: window.qBittorrent.Misc.createDebounceHandler(500, (e) => {
-            saveColumnSizes();
+            const isHidden = (parseInt(document.getElementById("propertiesPanel").style.height, 10) === 0);
+            if (!isHidden)
+                saveColumnSizes();
         }),
         height: null
     });


### PR DESCRIPTION
Don't save the wrong size when the tab is collapsed.
Reported in: https://github.com/qbittorrent/qBittorrent/pull/21215/files#r1966052959