### PR TITLE
Remove redundant proxy reload

### DIFF
--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -95,8 +95,6 @@ SearchPluginManager::SearchPluginManager()
 
     connect(Net::ProxyConfigurationManager::instance(), &Net::ProxyConfigurationManager::proxyConfigurationChanged
             , this, &SearchPluginManager::applyProxySettings);
-    connect(Preferences::instance(), &Preferences::changed
-            , this, &SearchPluginManager::applyProxySettings);
     applyProxySettings();
 
     updateNova();


### PR DESCRIPTION
It is already listening to `ProxyConfigurationManager::proxyConfigurationChanged` so there is no need for `Preferences::changed` signal.
