### PR TITLE
Enforce SOCKS proxy setting in search engine plugins

### DIFF
--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -1,4 +1,4 @@
-#VERSION: 1.48
+# VERSION: 1.49
 
 # Author:
 #  Fabien Devaux <fab AT gnux DOT info>
@@ -45,6 +45,16 @@ from glob import glob
 from multiprocessing import Pool, cpu_count
 from os import path
 from typing import Optional
+
+# qbt tend to run this script in 'isolate mode' so append the current path manually
+current_path = str(pathlib.Path(__file__).parent.resolve())
+if current_path not in sys.path:
+    sys.path.append(current_path)
+
+import helpers
+
+# enable SOCKS proxy for all plugins by default
+helpers.enable_socks_proxy(True)
 
 THREADED: bool = True
 try:
@@ -182,11 +192,6 @@ def run_search(search_params: tuple[type[Engine], str, Category]) -> bool:
 
 if __name__ == "__main__":
     def main() -> int:
-        # qbt tend to run this script in 'isolate mode' so append the current path manually
-        current_path = str(pathlib.Path(__file__).parent.resolve())
-        if current_path not in sys.path:
-            sys.path.append(current_path)
-
         # https://docs.python.org/3/library/sys.html#sys.exit
         class ExitCode(Enum):
             OK = 0

--- a/src/searchengine/nova3/nova2dl.py
+++ b/src/searchengine/nova3/nova2dl.py
@@ -1,4 +1,4 @@
-#VERSION: 1.24
+# VERSION: 1.25
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)
@@ -38,7 +38,10 @@ current_path = str(pathlib.Path(__file__).parent.resolve())
 if current_path not in sys.path:
     sys.path.append(current_path)
 
-from helpers import download_file
+import helpers
+
+# enable SOCKS proxy for all plugins by default
+helpers.enable_socks_proxy(True)
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:
@@ -58,6 +61,6 @@ if __name__ == '__main__':
     if hasattr(engine, 'download_torrent'):
         engine.download_torrent(download_param)
     else:
-        print(download_file(download_param))
+        print(helpers.download_file(download_param))
 
     sys.exit(0)


### PR DESCRIPTION
Previously it require each plugin to import helpers.py to setup SOCKS proxy.
Now it is enforced by default for all plugins when qbt invokes them.
Also added a function for plugins to ignore/restore the socket to default state.