### PR TITLE
Fix preview not opening on Wayland

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -256,10 +256,7 @@ TransferListModel *TransferListWidget::getSourceModel() const
 
 void TransferListWidget::previewFile(const Path &filePath)
 {
-    QTimer::singleShot(0, this, [=]()
-    {
-        Utils::Gui::openPath(filePath);
-    });
+    Utils::Gui::openPath(filePath);
 }
 
 QModelIndex TransferListWidget::mapToSource(const QModelIndex &index) const
@@ -317,7 +314,7 @@ void TransferListWidget::torrentDoubleClicked()
         {
             auto *dialog = new PreviewSelectDialog(this, torrent);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
-            connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile);
+            connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile, Qt::QueuedConnection);
             dialog->show();
         }
         else

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -312,10 +312,7 @@ void TransferListWidget::torrentDoubleClicked()
     case PREVIEW_FILE:
         if (torrentContainsPreviewableFiles(torrent))
         {
-            auto *dialog = new PreviewSelectDialog(this, torrent);
-            dialog->setAttribute(Qt::WA_DeleteOnClose);
-            connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile, Qt::QueuedConnection);
-            dialog->show();
+            openPreviewSelectDialog(torrent);
         }
         else
         {
@@ -617,10 +614,7 @@ void TransferListWidget::previewSelectedTorrents()
     {
         if (torrentContainsPreviewableFiles(torrent))
         {
-            auto *dialog = new PreviewSelectDialog(this, torrent);
-            dialog->setAttribute(Qt::WA_DeleteOnClose);
-            connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile);
-            dialog->show();
+            openPreviewSelectDialog(torrent);
         }
         else
         {
@@ -1448,4 +1442,11 @@ void TransferListWidget::wheelEvent(QWheelEvent *event)
     }
 
     QTreeView::wheelEvent(event);  // event delegated to base class
+}
+
+void TransferListWidget::openPreviewSelectDialog(const BitTorrent::Torrent *torrent) {
+    auto *dialog = new PreviewSelectDialog(this, torrent);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile, Qt::QueuedConnection);
+    dialog->show();
 }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -256,7 +256,10 @@ TransferListModel *TransferListWidget::getSourceModel() const
 
 void TransferListWidget::previewFile(const Path &filePath)
 {
-    Utils::Gui::openPath(filePath);
+    QTimer::singleShot(0, this, [=]()
+    {
+        Utils::Gui::openPath(filePath);
+    });
 }
 
 QModelIndex TransferListWidget::mapToSource(const QModelIndex &index) const

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1448,6 +1448,8 @@ void TransferListWidget::openPreviewSelectDialog(const BitTorrent::Torrent *torr
 {
     auto *dialog = new PreviewSelectDialog(this, torrent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
+    // Qt::QueuedConnection is required to prevent a bug on wayland compositors where the preview won't open.
+    // It occurs when the window focus shifts immediately after TransferListWidget::previewFile has been called.
     connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile, Qt::QueuedConnection);
     dialog->show();
 }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1444,7 +1444,8 @@ void TransferListWidget::wheelEvent(QWheelEvent *event)
     QTreeView::wheelEvent(event);  // event delegated to base class
 }
 
-void TransferListWidget::openPreviewSelectDialog(const BitTorrent::Torrent *torrent) {
+void TransferListWidget::openPreviewSelectDialog(const BitTorrent::Torrent *torrent)
+{
     auto *dialog = new PreviewSelectDialog(this, torrent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile, Qt::QueuedConnection);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -119,11 +119,11 @@ private slots:
     void saveSettings();
 
 private:
-    void openPreviewSelectDialog(const BitTorrent::Torrent *torrent);
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void openPreviewSelectDialog(const BitTorrent::Torrent *torrent);
     QModelIndex mapToSource(const QModelIndex &index) const;
     QModelIndexList mapToSource(const QModelIndexList &indexes) const;
     QModelIndex mapFromSource(const QModelIndex &index) const;

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -119,6 +119,7 @@ private slots:
     void saveSettings();
 
 private:
+    void openPreviewSelectDialog(const BitTorrent::Torrent *torrent);
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;


### PR DESCRIPTION
Deferring the opening of the preview slightly gives the preview select dialog time to close and for focus to shift back to the main window.

Closes #22607.
