### PR TITLE
WebUI: Select multiple files to rename with Shift

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -2355,6 +2355,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     checkbox.type = "checkbox";
                     checkbox.className = "RenamingCB";
                     checkbox.addEventListener("click", (e) => {
+                        e.stopPropagation();
                         const targetId = e.target.dataset.id;
                         const ids = [];
                         // when holding shift, set all files between the previously selected one and the clicked one
@@ -2388,7 +2389,6 @@ window.qBittorrent.DynamicTable ??= (() => {
                         }
                         that.updateGlobalCheckbox();
                         that.onRowSelectionChange(that.getNode(targetId));
-                        e.stopPropagation();
                         that.prevCheckboxNum = targetId;
                     });
                     checkbox.indeterminate = false;


### PR DESCRIPTION
Convenience feature in the "Rename Files" menu in the Web UI. 
If you click one file's checkbox, and then click another with Shift held, all the checkboxes between those two will be selected/unselected based on the state of the first checkbox.
It's based on what the Windows file explorer does when holding Ctrl and Shift

Closes #22455