### PR TITLE
WebAPI: allow filter torrents by tracker_errored

### DIFF
--- a/src/base/torrentfilter.h
+++ b/src/base/torrentfilter.h
@@ -62,6 +62,7 @@ public:
         Checking,
         Moving,
         Errored,
+        TrackerErrored,
 
         _Count
     };
@@ -84,6 +85,7 @@ public:
     static const TorrentFilter CheckingTorrent;
     static const TorrentFilter MovingTorrent;
     static const TorrentFilter ErroredTorrent;
+    static const TorrentFilter TrackerErroredTorrent;
 
     TorrentFilter() = default;
     // category & tags: pass empty string for uncategorized / untagged torrents.


### PR DESCRIPTION
Closes #22194 

Adds the option to filter the `/api/v2/torrents/info` endpoint by trackers which have errored.
i.e. `/api/v2/torrents/info?filter=tracker_errored&category=sample%20category&sort=ratio`


Notes:

1. I couldn't find where the rest of the torrentfilter.cpp code is tested. If you could point me in the right direction, I can try writing some tests. 

2. If this change looks good, I will update the documentation in the wiki (https://github.com/qbittorrent/wiki/blob/master/WebUI-API-(qBittorrent-5.0).md)