### PR TITLE
Revise labels for 'duplicate torrent' actions

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1031,7 +1031,7 @@
                <item>
                 <widget class="QGroupBox" name="duplicateTorrentGroup">
                  <property name="title">
-                  <string>When duplicate torrent is being added</string>
+                  <string>When adding a duplicate torrent</string>
                  </property>
                  <layout class="QVBoxLayout" name="duplicateTorrentBoxLayout">
                   <item>
@@ -1047,7 +1047,7 @@
                   <item>
                    <widget class="QCheckBox" name="checkConfirmMergeTrackers">
                     <property name="text">
-                     <string>Ask for merging trackers when torrent is being added manually</string>
+                     <string>Ask to merge trackers for manually added torrent</string>
                     </property>
                     <property name="checked">
                      <bool>true</bool>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -141,7 +141,7 @@
             </select>
         </div>
         <fieldset class="settings">
-            <legend>QBT_TR(When duplicate torrent is being added)QBT_TR[CONTEXT=OptionsDialog]</legend>
+            <legend>QBT_TR(When adding a duplicate torrent)QBT_TR[CONTEXT=OptionsDialog]</legend>
             <div class="formRow">
                 <input type="checkbox" id="mergeTrackersInput">
                 <label for="mergeTrackersInput">QBT_TR(Merge trackers to existing torrent)QBT_TR[CONTEXT=OptionsDialog]</label>


### PR DESCRIPTION
Screenshot:
![screenshot](https://github.com/user-attachments/assets/d360203e-f0a6-4d7f-bdc2-2b5dff2b6231)
