### PR TITLE
Add support for setting the NAT-PMP gateway

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -379,6 +379,8 @@ namespace BitTorrent
         virtual void setUploadRateForSlowTorrents(int rateInKibiBytes) = 0;
         virtual int slowTorrentsInactivityTimer() const = 0;
         virtual void setSlowTorrentsInactivityTimer(int timeInSeconds) = 0;
+        virtual QString NATPMPGateway() const = 0;
+        virtual void setNATPMPGateway(const QString& gateway) = 0;
         virtual int outgoingPortsMin() const = 0;
         virtual void setOutgoingPortsMin(int min) = 0;
         virtual int outgoingPortsMax() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -490,6 +490,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_slowTorrentsInactivityTimer(BITTORRENT_SESSION_KEY(u"SlowTorrentsInactivityTimer"_s), 60)
     , m_outgoingPortsMin(BITTORRENT_SESSION_KEY(u"OutgoingPortsMin"_s), 0)
     , m_outgoingPortsMax(BITTORRENT_SESSION_KEY(u"OutgoingPortsMax"_s), 0)
+    , m_NATPMPGateway(BITTORRENT_SESSION_KEY(u"NATPMPGateway"_s))
     , m_UPnPLeaseDuration(BITTORRENT_SESSION_KEY(u"UPnPLeaseDuration"_s), 0)
     , m_peerDSCP(BITTORRENT_SESSION_KEY(u"PeerToS"_s), 0x01)
     , m_ignoreLimitsOnLAN(BITTORRENT_SESSION_KEY(u"IgnoreLimitsOnLAN"_s), false)
@@ -2064,6 +2065,8 @@ lt::settings_pack SessionImpl::loadLTSettings() const
     // Outgoing ports
     settingsPack.set_int(lt::settings_pack::outgoing_port, outgoingPortsMin());
     settingsPack.set_int(lt::settings_pack::num_outgoing_ports, (outgoingPortsMax() - outgoingPortsMin()));
+    // NAT-PMP gateway
+    settingsPack.set_str(lt::settings_pack::natpmp_gateway, NATPMPGateway().toStdString());
     // UPnP lease duration
     settingsPack.set_int(lt::settings_pack::upnp_lease_duration, UPnPLeaseDuration());
 #if LIBTORRENT_VERSION_NUM >= 20013
@@ -4912,6 +4915,18 @@ void SessionImpl::setOutgoingPortsMax(const int max)
     if (max != m_outgoingPortsMax)
     {
         m_outgoingPortsMax = max;
+        configureDeferred();
+    }
+}
+
+QString SessionImpl::NATPMPGateway() const {
+    return m_NATPMPGateway;
+}
+
+void SessionImpl::setNATPMPGateway(const QString& gateway) {
+    if (gateway != m_NATPMPGateway)
+    {
+        m_NATPMPGateway = gateway;
         configureDeferred();
     }
 }

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -358,6 +358,8 @@ namespace BitTorrent
         void setOutgoingPortsMin(int min) override;
         int outgoingPortsMax() const override;
         void setOutgoingPortsMax(int max) override;
+        QString NATPMPGateway() const override;
+        void setNATPMPGateway(const QString &gateway) override;
         int UPnPLeaseDuration() const override;
         void setUPnPLeaseDuration(int duration) override;
         int peerDSCP() const override;
@@ -688,6 +690,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_slowTorrentsInactivityTimer;
         CachedSettingValue<int> m_outgoingPortsMin;
         CachedSettingValue<int> m_outgoingPortsMax;
+        CachedSettingValue<QString> m_NATPMPGateway;
         CachedSettingValue<int> m_UPnPLeaseDuration;
         CachedSettingValue<int> m_peerDSCP;
         CachedSettingValue<bool> m_ignoreLimitsOnLAN;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -151,6 +151,7 @@ namespace
         SOCKET_BACKLOG_SIZE,
         OUTGOING_PORT_MIN,
         OUTGOING_PORT_MAX,
+        NATPMP_GATEWAY,
         UPNP_LEASE_DURATION,
         PEER_DSCP,
         UTP_MIX_MODE,
@@ -278,6 +279,8 @@ void AdvancedSettings::saveAdvancedSettings() const
     // Outgoing ports
     session->setOutgoingPortsMin(m_spinBoxOutgoingPortsMin.value());
     session->setOutgoingPortsMax(m_spinBoxOutgoingPortsMax.value());
+    // NAT-PMP gateway
+    session->setNATPMPGateway(m_lineEditNATPMPGateway.text());
     // UPnP lease duration
     session->setUPnPLeaseDuration(m_spinBoxUPnPLeaseDuration.value());
     // Type of service
@@ -726,6 +729,11 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(OUTGOING_PORT_MAX, (tr("Outgoing ports (Max) [0: disabled]")
         + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#outgoing_port", u"(?)"))
         , &m_spinBoxOutgoingPortsMax);
+    // NAT-PMP gateway
+    m_lineEditNATPMPGateway.setText(session->NATPMPGateway());
+    addRow(NATPMP_GATEWAY, (tr("Optional NAT-PMP gateway")
+        + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#natpmp-gateway", u"(?)"))
+        , &m_lineEditNATPMPGateway);
     // UPnP lease duration
     m_spinBoxUPnPLeaseDuration.setMinimum(0);
     m_spinBoxUPnPLeaseDuration.setMaximum(std::numeric_limits<int>::max());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -83,7 +83,7 @@ private:
               m_checkBoxConfirmRemoveTrackerFromAllTorrents, m_checkBoxStartSessionPaused;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxDiskIOReadMode, m_comboBoxDiskIOWriteMode, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage, m_comboBoxTorrentContentRemoveOption;
-    QLineEdit m_lineEditAppInstanceName, m_pythonExecutablePath, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes;
+    QLineEdit m_lineEditAppInstanceName, m_pythonExecutablePath, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes, m_lineEditNATPMPGateway;
 
 #ifndef QBT_USES_LIBTORRENT2
     QSpinBox m_spinBoxCache, m_spinBoxCacheTTL;

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -474,6 +474,8 @@ void AppController::preferencesAction()
     // Outgoing ports
     data[u"outgoing_ports_min"_s] = session->outgoingPortsMin();
     data[u"outgoing_ports_max"_s] = session->outgoingPortsMax();
+    // NAT-PMP gateway
+    data[u"natpmp_gateway"_s] = session->NATPMPGateway();
     // UPnP lease duration
     data[u"upnp_lease_duration"_s] = session->UPnPLeaseDuration();
     // Type of service
@@ -1147,6 +1149,12 @@ void AppController::setPreferencesAction()
         session->setOutgoingPortsMin(it.value().toInt());
     if (hasKey(u"outgoing_ports_max"_s))
         session->setOutgoingPortsMax(it.value().toInt());
+    // NAT-PMP gateway
+    if (hasKey(u"natpmp_gateway"_s))
+    {
+        const QHostAddress gatewayAddr {it.value().toString().trimmed()};
+        session->setNATPMPGateway(gatewayAddr.isNull() ? QString() : gatewayAddr.toString());
+    }
     // UPnP lease duration
     if (hasKey(u"upnp_lease_duration"_s))
         session->setUPnPLeaseDuration(it.value().toInt());

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1624,6 +1624,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 </tr>
                 <tr>
                     <td>
+                        <label for="NATPMPGateway">QBT_TR(Optional NAT-PMP gateway:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#natmp-gateway" target="_blank">(?)</a></label>
+                    </td>
+                    <td>
+                        <input type="text" id="NATPMPGateway" style="width: 15em;">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <label for="UPnPLeaseDuration">QBT_TR(UPnP lease duration [0: permanent lease]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration" target="_blank">(?)</a></label>
                     </td>
                     <td>
@@ -2760,6 +2768,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("socketBacklogSize").value = pref.socket_backlog_size;
                     document.getElementById("outgoingPortsMin").value = pref.outgoing_ports_min;
                     document.getElementById("outgoingPortsMax").value = pref.outgoing_ports_max;
+                    document.getElementById("NATPMPGateway").value = pref.natpmp_gateway;
                     document.getElementById("UPnPLeaseDuration").value = pref.upnp_lease_duration;
                     document.getElementById("peerDSCP").value = pref.peer_tos;
                     document.getElementById("utpTCPMixedModeAlgorithm").value = pref.utp_tcp_mixed_mode;
@@ -3257,6 +3266,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["socket_backlog_size"] = Number(document.getElementById("socketBacklogSize").value);
             settings["outgoing_ports_min"] = Number(document.getElementById("outgoingPortsMin").value);
             settings["outgoing_ports_max"] = Number(document.getElementById("outgoingPortsMax").value);
+            settings["natpmp_gateway"] = document.getElementById("NATPMPGateway").value;
             settings["upnp_lease_duration"] = Number(document.getElementById("UPnPLeaseDuration").value);
 
             const peerDSCP = Number(document.getElementById("peerDSCP").value);


### PR DESCRIPTION
This pull request adds support for changing the NAT-PMP gateway. This is needed for e.g. correctly doing a port forward when behind ProtonVPN. NAT-PMP only starts to work with ProtonVPN if we set the gateway to `10.2.0.1`.

~~The feature in libtorrent is currently [awaiting approval](https://github.com/arvidn/libtorrent/pull/7890). I'm hoping this feature will be in libtorrent 2.0.12, the next version.~~

Checklist:

 - [x] Feature merged in libtorrent
 - [x] Web interface adjustments
 - [x] Native GUI adjustments
 - [x] Fixing bug in libtorrent or this patch (see below)
 - [x] More testing
 - [x] ~~Documentation~~ Should happen in libtorrent

