### PR TITLE
Update help message for Windows systems

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -490,6 +490,12 @@ QString wrapText(const QString &text, const int initialIndentation = USAGE_TEXT_
 QString makeUsage(const QString &prgName)
 {
     const QString indentation {USAGE_INDENTATION, u' '};
+    
+#if defined(Q_OS_WIN)
+    const QString noSplashCommand = u"set QBT_NO_SPLASH=1 && " + prgName;
+#else
+    const QString noSplashCommand = u"QBT_NO_SPLASH=1 " + prgName;
+#endif
 
     const QString text = QCoreApplication::translate("CMD Options", "Usage:") + u'\n'
         + indentation + prgName + u' ' + QCoreApplication::translate("CMD Options", "[options] [(<filename> | <url>)...]") + u'\n'
@@ -542,11 +548,7 @@ QString makeUsage(const QString &prgName)
                                 "'parameter-name', environment variable name is 'QBT_PARAMETER_NAME' (in upper "
                                 "case, '-' replaced with '_'). To pass flag values, set the variable to '1' or "
                                 "'TRUE'. For example, to disable the splash screen: "), 0) + u'\n'
-#if defined(Q_OS_WIN)
-        + u"set QBT_NO_SPLASH=1\n" + prgName + u'\n'
-#else
-        + u"QBT_NO_SPLASH=1 " + prgName + u'\n'
-#endif
+        + noSplashCommand + u'\n'
         + wrapText(QCoreApplication::translate("CMD Options", "Command line parameters take precedence over environment variables"), 0) + u'\n';
 
     return text;

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -490,7 +490,7 @@ QString wrapText(const QString &text, const int initialIndentation = USAGE_TEXT_
 QString makeUsage(const QString &prgName)
 {
     const QString indentation {USAGE_INDENTATION, u' '};
-    
+
 #if defined(Q_OS_WIN)
     const QString noSplashCommand = u"set QBT_NO_SPLASH=1 && " + prgName;
 #else

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -542,7 +542,11 @@ QString makeUsage(const QString &prgName)
                                 "'parameter-name', environment variable name is 'QBT_PARAMETER_NAME' (in upper "
                                 "case, '-' replaced with '_'). To pass flag values, set the variable to '1' or "
                                 "'TRUE'. For example, to disable the splash screen: "), 0) + u'\n'
+#if defined(Q_OS_WIN)
+        + u"set QBT_NO_SPLASH=1\n" + prgName + u'\n'
+#else
         + u"QBT_NO_SPLASH=1 " + prgName + u'\n'
+#endif
         + wrapText(QCoreApplication::translate("CMD Options", "Command line parameters take precedence over environment variables"), 0) + u'\n';
 
     return text;


### PR DESCRIPTION
Fixes #22662.

For windows environment the `--help` output will show :
```
set QBT_NO_SPLASH=1
C:\Program Files\qBittorrent\qbittorrent.exe
```

instead of 
```
QBT_NO_SPLASH=1 C:\Program Files\qBittorrent\qbittorrent.exe
```

Changes:
- Adds a OS based if condition to `makeUsage` function to switch between the lines 
