### PR TITLE
GHA CI: Bump spellcheck related hooks revs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         - ts
 
   - repo: https://github.com/codespell-project/codespell.git
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
     - id: codespell
       name: Check spelling (codespell)
@@ -88,7 +88,7 @@ repos:
         - ts
 
   - repo: https://github.com/crate-ci/typos.git
-    rev: v1.29.4
+    rev: v1.32.0
     hooks:
     - id: typos
       name: Check spelling (typos)


### PR DESCRIPTION
* Bumped `codespell` -> `2.4.1`
* Bumped `typos` -> `1.32.0`