### PR TITLE
WebUI: Prevent mobile keyboards from capitalizing username input

### DIFF
--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -32,7 +32,7 @@
             <form id="loginform">
                 <div class="row">
                     <label for="username">QBT_TR(Username)QBT_TR[CONTEXT=Login]</label><br>
-                    <input type="text" id="username" name="username" autocomplete="username" autofocus required autocapitalize="none">
+                    <input type="text" id="username" name="username" autocomplete="username" autocapitalize="none" autofocus required>
                 </div>
                 <div class="row">
                     <label for="password">QBT_TR(Password)QBT_TR[CONTEXT=Login]</label><br>

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -32,7 +32,7 @@
             <form id="loginform">
                 <div class="row">
                     <label for="username">QBT_TR(Username)QBT_TR[CONTEXT=Login]</label><br>
-                    <input type="text" id="username" name="username" autocomplete="username" autofocus required>
+                    <input type="text" id="username" name="username" autocomplete="username" autofocus required autocapitalize="none">
                 </div>
                 <div class="row">
                     <label for="password">QBT_TR(Password)QBT_TR[CONTEXT=Login]</label><br>


### PR DESCRIPTION
### Description

This PR improves the user experience on mobile devices by ensuring the username field in the login form does not automatically capitalize the first letter when the keyboard opens.

### Changes:
- Added `autocapitalize="none"` to the username input field (`login.html`).

### Reason:
Mobile browsers tend to automatically capitalize the first letter of text inputs, which can lead to login failures if the username is case-sensitive. By explicitly disabling autocapitalization, the WebUI ensures a more predictable and user-friendly experience on mobile devices.

---

**Tested on:**
- iOS (Safari)