### PR TITLE
feat: Add Per-Status group sort persistence.

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -265,10 +265,30 @@ window.addEventListener("DOMContentLoaded", (event) => {
         }
     };
 
+    const getFilterSortColumn = (filterName) => {
+        return LocalPreferences.get(`selected_filter_sort_${filterName}`);
+    };
+
+    const saveFilterSort = (filterName, sort, isReverse) => {
+        LocalPreferences.set(`selected_filter_sort_${filterName}`, sort);
+        LocalPreferences.set(`selected_filter_sort_reverse_${filterName}`, isReverse);
+    };
+
     setStatusFilter = (name) => {
         const currentHash = torrentsTable.getCurrentTorrentID();
 
+        // Save current sorting for this filter.
+        if (torrentsTable.getSortedColumn())
+            saveFilterSort(selectedStatus, torrentsTable.getSortedColumn(), torrentsTable.reverseSort ?? "0");
         LocalPreferences.set("selected_filter", name);
+        // If there is a saved sorting column, load it.
+        const sortColumn = getFilterSortColumn(name);
+        if (sortColumn) {
+            torrentsTable.setSortedColumn(
+                sortColumn,
+                LocalPreferences.get(`selected_filter_sort_reverse_${name}`, "0")
+            );
+        }
         selectedStatus = name;
         highlightSelectedStatus();
         updateMainData();

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -681,7 +681,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const oldColumn = this.sortedColumn;
                 this.sortedColumn = column;
                 this.reverseSort = reverse ?? "0";
-                this.setSortedColumnIcon(column, oldColumn, false);
+                this.setSortedColumnIcon(column, oldColumn, reverse === "1");
             }
             else {
                 // Toggle sort order


### PR DESCRIPTION
Closes #22422 

## Short Request Summary

The request is for a feature that would allow the user to have one sorting set for each different `Status Group`.
That would allow to sort `Downloading` by `Progress` and `Seeding` by `Ratio` for example, and be able to switch between them without having to apply the wanted sort manually.

## How I did it

Save data to `localStorage` in the format `selected_filter_sort_${status group}` and `selected_filter_sort_reverse_${status group}`.

When opening/switching to a given status-group we check if sorting was applied to the current table, if it was applied we save the above mentioned data for future use.
If there is saved data for the new/just opened Status Group, we send it to the `setSortedColumn` function of the torrents table.