### PR TITLE
WebAPI: Add more properties to 'torrents/info' result

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1438,7 +1438,7 @@ int TorrentImpl::totalLeechersCount() const
 
 int TorrentImpl::downloadLimit() const
 {
-    return m_downloadLimit;;
+    return m_downloadLimit;
 }
 
 int TorrentImpl::uploadLimit() const

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018-2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018-2025  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -107,14 +107,27 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
             : (QDateTime::currentSecsSinceEpoch() - timeSinceActivity);
     };
 
+    const bool hasMetadata = torrent.hasMetadata();
+
     return {
         {KEY_TORRENT_ID, torrent.id().toString()},
         {KEY_TORRENT_INFOHASHV1, torrent.infoHash().v1().toString()},
         {KEY_TORRENT_INFOHASHV2, torrent.infoHash().v2().toString()},
         {KEY_TORRENT_NAME, torrent.name()},
+
+        {KEY_TORRENT_HAS_METADATA, hasMetadata},
+        {KEY_TORRENT_CREATED_BY, torrent.creator()},
+        {KEY_TORRENT_CREATION_DATE, Utils::DateTime::toSecsSinceEpoch(torrent.creationDate())},
+        {KEY_TORRENT_PRIVATE, (hasMetadata ? torrent.isPrivate() : QVariant())},
+        {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()},
+        {KEY_TORRENT_PIECES_NUM, torrent.piecesCount()},
+        {KEY_TORRENT_PIECE_SIZE, torrent.pieceLength()},
+
         {KEY_TORRENT_MAGNET_URI, torrent.createMagnetURI()},
         {KEY_TORRENT_SIZE, torrent.wantedSize()},
         {KEY_TORRENT_PROGRESS, torrent.progress()},
+        {KEY_TORRENT_TOTAL_WASTED, torrent.wastedSize()},
+        {KEY_TORRENT_PIECES_HAVE, torrent.piecesHave()},
         {KEY_TORRENT_DLSPEED, torrent.downloadPayloadRate()},
         {KEY_TORRENT_UPSPEED, torrent.uploadPayloadRate()},
         {KEY_TORRENT_QUEUE_POSITION, adjustQueuePosition(torrent.queuePosition())},
@@ -148,6 +161,8 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_AMOUNT_UPLOADED_SESSION, torrent.totalPayloadUpload()},
         {KEY_TORRENT_AMOUNT_LEFT, torrent.remainingSize()},
         {KEY_TORRENT_AMOUNT_COMPLETED, torrent.completedSize()},
+        {KEY_TORRENT_CONNECTIONS_COUNT, torrent.connectionsCount()},
+        {KEY_TORRENT_CONNECTIONS_LIMIT, torrent.connectionsLimit()},
         {KEY_TORRENT_MAX_RATIO, torrent.maxRatio()},
         {KEY_TORRENT_MAX_SEEDING_TIME, torrent.maxSeedingTime()},
         {KEY_TORRENT_MAX_INACTIVE_SEEDING_TIME, torrent.maxInactiveSeedingTime()},
@@ -163,9 +178,6 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
-        {KEY_TORRENT_COMMENT, torrent.comment()},
-        {KEY_TORRENT_PRIVATE, (torrent.hasMetadata() ? torrent.isPrivate() : QVariant())},
-        {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()},
-        {KEY_TORRENT_HAS_METADATA, torrent.hasMetadata()}
+        {KEY_TORRENT_COMMENT, torrent.comment()}
     };
 }

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018-2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018-2025  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -96,5 +96,13 @@ inline const QString KEY_TORRENT_REANNOUNCE = u"reannounce"_s;
 inline const QString KEY_TORRENT_COMMENT = u"comment"_s;
 inline const QString KEY_TORRENT_PRIVATE = u"private"_s;
 inline const QString KEY_TORRENT_HAS_METADATA = u"has_metadata"_s;
+inline const QString KEY_TORRENT_CONNECTIONS_COUNT = u"connections_count"_s;
+inline const QString KEY_TORRENT_CONNECTIONS_LIMIT = u"connections_limit"_s;
+inline const QString KEY_TORRENT_TOTAL_WASTED = u"total_wasted"_s;
+inline const QString KEY_TORRENT_PIECES_NUM = u"pieces_num"_s;
+inline const QString KEY_TORRENT_PIECE_SIZE = u"piece_size"_s;
+inline const QString KEY_TORRENT_PIECES_HAVE = u"pieces_have"_s;
+inline const QString KEY_TORRENT_CREATED_BY = u"created_by"_s;
+inline const QString KEY_TORRENT_CREATION_DATE = u"creation_date"_s;
 
 QVariantMap serialize(const BitTorrent::Torrent &torrent);


### PR DESCRIPTION
We have already added some properties to serialized form of torrent used in `torrents/info` and `sync/maindata`. There are only a few properties left that are only accessible through `torrents/properties`, and users want them to be still accessible through `torrents/info`. I see no reason not to do this.
This will also allow we to completely deprecate `torrents/properties`, and use in WebUI only the data from the synchronized snapshot.