### PR TITLE
WebUI: Fix memory leak

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -26,6 +26,7 @@
     <script defer src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script defer src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
     <script defer src="scripts/lib/mocha.min.js"></script>
+    <script defer src="scripts/monkeypatch.js?v=${CACHEID}"></script>
     <script defer src="scripts/cache.js?v=${CACHEID}"></script>
     <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
     <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -175,12 +175,15 @@ let setStatusFilter = () => {};
 let toggleFilterDisplay = () => {};
 
 window.addEventListener("DOMContentLoaded", (event) => {
+    // Override MooTools' `document.id` (used for `$(id)`), which prevents it
+    // from allocating a `uniqueNumber` for elements that don't need it.
+    // This is also more efficient than the original.
     document.id = el => {
         switch (typeOf(el)) {
-        case "string":
-            return document.getElementById(el);
-        case "element":
-            return el;
+            case "string":
+                return document.getElementById(el);
+            case "element":
+                return el;
         }
     };
 

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -175,6 +175,15 @@ let setStatusFilter = () => {};
 let toggleFilterDisplay = () => {};
 
 window.addEventListener("DOMContentLoaded", (event) => {
+    document.id = el => {
+        switch (typeOf(el)) {
+        case "string":
+            return document.getElementById(el);
+        case "element":
+            return el;
+        }
+    };
+
     window.qBittorrent.LocalPreferences.upgrade();
 
     let isSearchPanelLoaded = false;
@@ -499,7 +508,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
         if (!categoryList)
             return;
 
-        [...categoryList.children].forEach((el) => { el.destroy(); });
+        [...categoryList.children].forEach((el) => { el.remove(); });
 
         const categoryItemTemplate = document.getElementById("categoryFilterItem");
 
@@ -620,7 +629,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
         if (tagFilterList === null)
             return;
 
-        [...tagFilterList.children].forEach((el) => { el.destroy(); });
+        [...tagFilterList.children].forEach((el) => { el.remove(); });
 
         const tagItemTemplate = document.getElementById("tagFilterItem");
 
@@ -673,7 +682,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
         if (trackerFilterList === null)
             return;
 
-        [...trackerFilterList.children].forEach((el) => { el.destroy(); });
+        [...trackerFilterList.children].forEach((el) => { el.remove(); });
 
         const trackerItemTemplate = document.getElementById("trackerFilterItem");
 

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -175,18 +175,6 @@ let setStatusFilter = () => {};
 let toggleFilterDisplay = () => {};
 
 window.addEventListener("DOMContentLoaded", (event) => {
-    // Override MooTools' `document.id` (used for `$(id)`), which prevents it
-    // from allocating a `uniqueNumber` for elements that don't need it.
-    // This is also more efficient than the original.
-    document.id = el => {
-        switch (typeOf(el)) {
-            case "string":
-                return document.getElementById(el);
-            case "element":
-                return el;
-        }
-    };
-
     window.qBittorrent.LocalPreferences.upgrade();
 
     let isSearchPanelLoaded = false;

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -478,7 +478,7 @@ window.qBittorrent.ContextMenu ??= (() => {
 
         updateCategoriesSubMenu(categories) {
             const contextCategoryList = document.getElementById("contextCategoryList");
-            [...contextCategoryList.children].forEach((el) => { el.destroy(); });
+            [...contextCategoryList.children].forEach((el) => { el.remove(); });
 
             const createMenuItem = (text, imgURL, clickFn) => {
                 const anchor = document.createElement("a");

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -900,7 +900,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const rowPos = rows.length;
 
                 while ((rowPos < trs.length) && (trs.length > 0))
-                    trs.pop().destroy();
+                    trs.pop().remove();
             }
         }
 
@@ -1022,7 +1022,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             }
             else {
                 const tr = this.getTrByRowId(rowId);
-                tr?.destroy();
+                tr?.remove();
             }
         }
 
@@ -1034,7 +1034,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             }
             else {
                 for (const tr of this.getTrs())
-                    tr.destroy();
+                    tr.remove();
             }
         }
 

--- a/src/webui/www/private/scripts/monkeypatch.js
+++ b/src/webui/www/private/scripts/monkeypatch.js
@@ -44,14 +44,23 @@ window.qBittorrent.MonkeyPatch ??= (() => {
     const patchMootoolsDocumentId = () => {
         // Override MooTools' `document.id` (used for `$(id)`), which prevents it
         // from allocating a `uniqueNumber` for elements that don't need it.
-        // This is also more efficient than the original.
-        document.id = el => {
-            switch (typeOf(el)) {
+        // MooTools and MochaUI use it internally.
+
+        if (document.id === undefined)
+            return;
+
+        document.id = (el) => {
+            if ((el === null) || (el === undefined))
+                return null;
+
+            switch (typeof el) {
+                case "object":
+                    return el;
                 case "string":
                     return document.getElementById(el);
-                case "element":
-                    return el;
             }
+
+            return null;
         };
     };
 

--- a/src/webui/www/private/scripts/monkeypatch.js
+++ b/src/webui/www/private/scripts/monkeypatch.js
@@ -1,0 +1,63 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2025  bolshoytoster <toasterbig@gmail.com>
+ * Copyright (C) 2025  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+"use strict";
+
+window.qBittorrent ??= {};
+window.qBittorrent.MonkeyPatch ??= (() => {
+    const exports = () => {
+        return {
+            patch: patch
+        };
+    };
+
+    const patch = () => {
+        patchMootoolsDocumentId();
+    };
+
+    const patchMootoolsDocumentId = () => {
+        // Override MooTools' `document.id` (used for `$(id)`), which prevents it
+        // from allocating a `uniqueNumber` for elements that don't need it.
+        // This is also more efficient than the original.
+        document.id = el => {
+            switch (typeOf(el)) {
+                case "string":
+                    return document.getElementById(el);
+                case "element":
+                    return el;
+            }
+        };
+    };
+
+    return exports();
+})();
+Object.freeze(window.qBittorrent.MonkeyPatch);
+
+// execute now
+window.qBittorrent.MonkeyPatch.patch();

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -248,7 +248,7 @@ window.qBittorrent.Search ??= (() => {
         if (state && state.running)
             stopSearch(searchId);
 
-        tab.destroy();
+        tab.remove();
 
         fetch("api/v2/search/delete", {
             method: "POST",

--- a/src/webui/www/private/views/cookies.html
+++ b/src/webui/www/private/views/cookies.html
@@ -104,7 +104,7 @@
         };
 
         const deleteCookie = (element) => {
-            element.closest("tr").destroy();
+            element.closest("tr").remove();
         };
 
         const save = () => {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2132,7 +2132,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
         // Advanced Tab
         const updateNetworkInterfaces = (default_iface, default_iface_name) => {
-            [...document.getElementById("networkInterface").children].forEach((el) => { el.destroy(); });
+            [...document.getElementById("networkInterface").children].forEach((el) => { el.remove(); });
 
             fetch("api/v2/app/networkInterfaceList", {
                     method: "GET",
@@ -2161,7 +2161,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         const updateInterfaceAddresses = (iface, default_addr) => {
-            [...document.getElementById("optionalIPAddressToBind").children].forEach((el) => { el.destroy(); });
+            [...document.getElementById("optionalIPAddressToBind").children].forEach((el) => { el.remove(); });
 
             const url = new URL("api/v2/app/networkInterfaceAddressList", window.location);
             url.search = new URLSearchParams({

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -425,7 +425,7 @@
         };
 
         const clearDetails = () => {
-            [...document.getElementById("rssDetailsView").children].forEach((el) => { el.destroy(); });
+            [...document.getElementById("rssDetailsView").children].forEach((el) => { el.remove(); });
         };
 
         const showDetails = (feedUid, articleID) => {

--- a/src/webui/www/webui.qrc
+++ b/src/webui/www/webui.qrc
@@ -408,6 +408,7 @@
         <file>private/scripts/localpreferences.js</file>
         <file>private/scripts/misc.js</file>
         <file>private/scripts/mocha-init.js</file>
+        <file>private/scripts/monkeypatch.js</file>
         <file>private/scripts/pathAutofill.js</file>
         <file>private/scripts/piecesbar.js</file>
         <file>private/scripts/progressbar.js</file>


### PR DESCRIPTION
See #22734, there is a memory leak in the MooTools `.destroy()`, this replaces all uses of that with the browser native `.remove()`.

This also overrides the MooTools `Document.id` function, which is used by `$(id)`. The original function always allocates an ID to elements it selects, the override doesn't, and is also a little more efficient.