### PR TITLE
WebUI: Fix path autofill in set location and new category

### DIFF
--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -145,9 +145,9 @@
                         break;
                 }
             });
-        });
 
-        window.qBittorrent.pathAutofill.attachPathAutofill();
+            window.qBittorrent.pathAutofill.attachPathAutofill();
+        });
     </script>
 </head>
 

--- a/src/webui/www/private/newfolder.html
+++ b/src/webui/www/private/newfolder.html
@@ -7,7 +7,6 @@
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
     <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
     <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -59,15 +58,13 @@
                     });
             });
         });
-
-        window.qBittorrent.pathAutofill.attachPathAutofill();
     </script>
 </head>
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <label for="folderName" style="font-weight: bold;">QBT_TR(Folder name:)QBT_TR[CONTEXT=RSSWidget]</label>
-        <input type="text" id="folderName" class="pathDirectory" style="width: 320px;">
+        <input type="text" id="folderName" style="width: 320px;">
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(OK)QBT_TR[CONTEXT=HttpServer]" id="submitButton">
         </div>

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
     <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
     <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -59,6 +60,8 @@
                         window.parent.qBittorrent.Client.closeFrameWindow(window);
                     });
             });
+
+            window.qBittorrent.pathAutofill.attachPathAutofill();
         });
     </script>
 </head>
@@ -66,7 +69,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <label for="setLocation" style="font-weight: bold;">QBT_TR(Location:)QBT_TR[CONTEXT=TransferListWidget]</label>
-        <input type="text" id="setLocation" autocorrect="off" autocapitalize="none" style="width: 99%;">
+        <input type="text" id="setLocation" class="pathDirectory" autocorrect="off" autocapitalize="none" style="width: 99%;">
         <div style="float: none; width: 99%;" id="error_div">&nbsp;</div>
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="setLocationButton">


### PR DESCRIPTION
attachPathAutofill after DOMContentLoaded.
Also removed pathAutofill.js in newfolder.html since it's meant for new RSS folder name.