### PR TITLE
build_dist.sh: use git's options for gzip tarball

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -15,5 +15,5 @@ else
 fi
 
 # pack archives
-git archive --format=tar --prefix="qbittorrent-$projectVersion/" HEAD | gzip -9 > "qbittorrent-$projectVersion.tar.gz"
+git archive --prefix="qbittorrent-$projectVersion/" HEAD --output="qbittorrent-$projectVersion.tar.gz" -9
 git archive --format=tar --prefix="qbittorrent-$projectVersion/" HEAD | xz -9 > "qbittorrent-$projectVersion.tar.xz"


### PR DESCRIPTION
see `BACKEND EXTRA OPTIONS` of `man git-archive` for more details.

Tested with git 2.48.1.
Seems to be a bit faster.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
