### PR TITLE
Use modern API to export torrent

### DIFF
--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -373,7 +373,7 @@ namespace BitTorrent
 
         bool m_unchecked = false;
 
-        lt::add_torrent_params m_ltAddTorrentParams;
+        mutable lt::add_torrent_params m_ltAddTorrentParams;
 
         int m_downloadLimit = 0;
         int m_uploadLimit = 0;


### PR DESCRIPTION
Avoid a blocking call to `lt::torrent_handle::torrent_file_with_hashes()`.