### PR TITLE
Interpret tracker "updating" status as a separate property

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -152,35 +152,40 @@ namespace
 
                 if (ltAnnounceInfo.updating)
                 {
-                    trackerEndpointStatus.state = TrackerEndpointState::Updating;
+                    trackerEndpointStatus.isUpdating = true;
                     ++numUpdating;
-                }
-                else if (ltAnnounceInfo.fails > 0)
-                {
-                    if (ltAnnounceInfo.last_error == lt::errors::tracker_failure)
-                    {
-                        trackerEndpointStatus.state = TrackerEndpointState::TrackerError;
-                        ++numTrackerError;
-                    }
-                    else if (ltAnnounceInfo.last_error == lt::errors::announce_skipped)
-                    {
-                        trackerEndpointStatus.state = TrackerEndpointState::Unreachable;
-                        ++numUnreachable;
-                    }
-                    else
-                    {
-                        trackerEndpointStatus.state = TrackerEndpointState::NotWorking;
-                        ++numNotWorking;
-                    }
-                }
-                else if (nativeEntry.verified)
-                {
-                    trackerEndpointStatus.state = TrackerEndpointState::Working;
-                    ++numWorking;
                 }
                 else
                 {
-                    trackerEndpointStatus.state = TrackerEndpointState::NotContacted;
+                    trackerEndpointStatus.isUpdating = false;
+
+                    if (ltAnnounceInfo.fails > 0)
+                    {
+                        if (ltAnnounceInfo.last_error == lt::errors::tracker_failure)
+                        {
+                            trackerEndpointStatus.state = TrackerEndpointState::TrackerError;
+                            ++numTrackerError;
+                        }
+                        else if (ltAnnounceInfo.last_error == lt::errors::announce_skipped)
+                        {
+                            trackerEndpointStatus.state = TrackerEndpointState::Unreachable;
+                            ++numUnreachable;
+                        }
+                        else
+                        {
+                            trackerEndpointStatus.state = TrackerEndpointState::NotWorking;
+                            ++numNotWorking;
+                        }
+                    }
+                    else if (nativeEntry.verified)
+                    {
+                        trackerEndpointStatus.state = TrackerEndpointState::Working;
+                        ++numWorking;
+                    }
+                    else
+                    {
+                        trackerEndpointStatus.state = TrackerEndpointState::NotContacted;
+                    }
                 }
 
                 if (!ltAnnounceInfo.message.empty())
@@ -215,23 +220,28 @@ namespace
         {
             if (numUpdating > 0)
             {
-                trackerEntryStatus.state = TrackerEndpointState::Updating;
+                trackerEntryStatus.isUpdating = true;
             }
-            else if (numWorking > 0)
+            else
             {
-                trackerEntryStatus.state = TrackerEndpointState::Working;
-            }
-            else if (numTrackerError > 0)
-            {
-                trackerEntryStatus.state = TrackerEndpointState::TrackerError;
-            }
-            else if (numUnreachable == numEndpoints)
-            {
-                trackerEntryStatus.state = TrackerEndpointState::Unreachable;
-            }
-            else if ((numUnreachable + numNotWorking) == numEndpoints)
-            {
-                trackerEntryStatus.state = TrackerEndpointState::NotWorking;
+                trackerEntryStatus.isUpdating = false;
+
+                if (numWorking > 0)
+                {
+                    trackerEntryStatus.state = TrackerEndpointState::Working;
+                }
+                else if (numTrackerError > 0)
+                {
+                    trackerEntryStatus.state = TrackerEndpointState::TrackerError;
+                }
+                else if (numUnreachable == numEndpoints)
+                {
+                    trackerEntryStatus.state = TrackerEndpointState::Unreachable;
+                }
+                else if ((numUnreachable + numNotWorking) == numEndpoints)
+                {
+                    trackerEntryStatus.state = TrackerEndpointState::NotWorking;
+                }
             }
         }
 

--- a/src/base/bittorrent/trackerentrystatus.h
+++ b/src/base/bittorrent/trackerentrystatus.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015-2024  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2025  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -41,7 +41,6 @@ namespace BitTorrent
     {
         NotContacted = 1,
         Working = 2,
-        Updating = 3,
         NotWorking = 4,
         TrackerError = 5,
         Unreachable = 6
@@ -52,6 +51,7 @@ namespace BitTorrent
         QString name {};
         int btVersion = 1;
 
+        bool isUpdating = false;
         TrackerEndpointState state = TrackerEndpointState::NotContacted;
         QString message {};
 
@@ -69,6 +69,7 @@ namespace BitTorrent
         QString url {};
         int tier = 0;
 
+        bool isUpdating = false;
         TrackerEndpointState state = TrackerEndpointState::NotContacted;
         QString message {};
 

--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -463,9 +463,6 @@ void TrackersFilterWidget::handleTrackerStatusesUpdated(const BitTorrent::Torren
                     trackerErrorHashesIt->remove(trackerEntryStatus.url);
             }
             break;
-
-        case BitTorrent::TrackerEndpointState::Updating:
-            break;
         };
     }
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -64,6 +64,7 @@
 
 // Tracker keys
 const QString KEY_TRACKER_URL = u"url"_s;
+const QString KEY_TRACKER_UPDATING = u"updating"_s;
 const QString KEY_TRACKER_STATUS = u"status"_s;
 const QString KEY_TRACKER_TIER = u"tier"_s;
 const QString KEY_TRACKER_MSG = u"msg"_s;
@@ -265,6 +266,7 @@ namespace
             {
                 {KEY_TRACKER_URL, tracker.url},
                 {KEY_TRACKER_TIER, tracker.tier},
+                {KEY_TRACKER_UPDATING, tracker.isUpdating},
                 {KEY_TRACKER_STATUS, static_cast<int>((isNotWorking ? BitTorrent::TrackerEndpointState::NotWorking : tracker.state))},
                 {KEY_TRACKER_MSG, tracker.message},
                 {KEY_TRACKER_PEERS_COUNT, tracker.numPeers},

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -53,7 +53,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 11, 6};
+inline const Utils::Version<3, 2> API_VERSION {2, 11, 7};
 
 class APIController;
 class AuthController;

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -80,22 +80,25 @@ window.qBittorrent.PropTrackers ??= (() => {
                 if (trackers) {
                     trackers.each((tracker) => {
                         let status;
-                        switch (tracker.status) {
-                            case 0:
-                                status = "QBT_TR(Disabled)QBT_TR[CONTEXT=TrackerListWidget]";
-                                break;
-                            case 1:
-                                status = "QBT_TR(Not contacted yet)QBT_TR[CONTEXT=TrackerListWidget]";
-                                break;
-                            case 2:
-                                status = "QBT_TR(Working)QBT_TR[CONTEXT=TrackerListWidget]";
-                                break;
-                            case 3:
-                                status = "QBT_TR(Updating...)QBT_TR[CONTEXT=TrackerListWidget]";
-                                break;
-                            case 4:
-                                status = "QBT_TR(Not working)QBT_TR[CONTEXT=TrackerListWidget]";
-                                break;
+
+                        if (tracker.updating) {
+                            status = "QBT_TR(Updating...)QBT_TR[CONTEXT=TrackerListWidget]";
+                        }
+                        else {
+                            switch (tracker.status) {
+                                case 0:
+                                    status = "QBT_TR(Disabled)QBT_TR[CONTEXT=TrackerListWidget]";
+                                    break;
+                                case 1:
+                                    status = "QBT_TR(Not contacted yet)QBT_TR[CONTEXT=TrackerListWidget]";
+                                    break;
+                                case 2:
+                                    status = "QBT_TR(Working)QBT_TR[CONTEXT=TrackerListWidget]";
+                                    break;
+                                case 4:
+                                    status = "QBT_TR(Not working)QBT_TR[CONTEXT=TrackerListWidget]";
+                                    break;
+                            }
                         }
 
                         const row = {


### PR DESCRIPTION
So far, "Updating" has been one of the tracker (announce) entry states, but it is inherently different from all the other values that indicate the **result** of the last announce. Although it makes sense to combine them into a single system in some use cases (like it is done in Trackers list), at a core level they still should be provided as different properties.
Ref.: https://github.com/qbittorrent/qBittorrent/pull/22166#issuecomment-2912282003.