### PR TITLE
GHA CI: enforce sorted import in Python scripts

### DIFF
--- a/.github/workflows/ci_python.yaml
+++ b/.github/workflows/ci_python.yaml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3'  # use default version
 
       - name: Install tools (auxiliary scripts)
-        run: pip install bandit pycodestyle pyflakes
+        run: pip install bandit isort pycodestyle pyflakes
 
       - name: Gather files (auxiliary scripts)
         run: |
@@ -44,6 +44,10 @@ jobs:
             --max-line-length=1000 \
             --statistics \
             $PY_FILES
+          isort \
+             --check \
+             --diff \
+             $PY_FILES
 
       - name: Build code (auxiliary scripts)
         run: |
@@ -55,7 +59,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install tools (search engine)
-        run: pip install bandit mypy pycodestyle pyflakes pyright
+        run: pip install bandit isort mypy pycodestyle pyflakes pyright
 
       - name: Gather files (search engine)
         run: |
@@ -85,6 +89,10 @@ jobs:
             --max-line-length=1000 \
             --statistics \
             $PY_FILES
+          isort \
+             --check \
+             --diff \
+             $PY_FILES
 
       - name: Build code (search engine)
         run: |

--- a/.github/workflows/helper/pre-commit/check_grid_items_order.py
+++ b/.github/workflows/helper/pre-commit/check_grid_items_order.py
@@ -26,12 +26,12 @@
 # but you are not obligated to do so. If you do not wish to do so, delete this
 # exception statement from your version.
 
-from collections.abc import Callable, Sequence
-from typing import Optional
 import argparse
 import re
-import xml.etree.ElementTree as ElementTree
 import sys
+import xml.etree.ElementTree as ElementTree
+from collections.abc import Callable, Sequence
+from typing import Optional
 
 
 def traversePostOrder(root: ElementTree.Element, visitFunc: Callable[[ElementTree.Element], None]) -> None:

--- a/.github/workflows/helper/pre-commit/check_translation_tag.py
+++ b/.github/workflows/helper/pre-commit/check_translation_tag.py
@@ -26,11 +26,11 @@
 # but you are not obligated to do so. If you do not wish to do so, delete this
 # exception statement from your version.
 
-from collections.abc import Sequence
-from typing import Optional
 import argparse
 import re
 import sys
+from collections.abc import Sequence
+from typing import Optional
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -1,4 +1,4 @@
-# VERSION: 1.53
+# VERSION: 1.54
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)
@@ -33,7 +33,6 @@ import html
 import io
 import os
 import socket
-import socks
 import ssl
 import sys
 import tempfile
@@ -42,6 +41,8 @@ import urllib.parse
 import urllib.request
 from collections.abc import Mapping
 from typing import Any, Optional
+
+import socks
 
 
 def _getBrowserUserAgent() -> str:


### PR DESCRIPTION
This main point is to normalize the sorting of imports in Python scripts.
Currently the default setting from isort is used: https://pycqa.github.io/isort/docs/configuration/custom_sections_and_ordering.html