### PR TITLE
Handle libtorrent alerts in SessionImpl only

### DIFF
--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -580,7 +580,6 @@ namespace BitTorrent
         void exportTorrentFile(const Torrent *torrent, const Path &folderPath);
 
         void handleAlert(const lt::alert *alert);
-        void dispatchTorrentAlert(const lt::torrent_alert *alert);
         void handleAddTorrentAlert(const lt::add_torrent_alert *alert);
         void handleStateUpdateAlert(const lt::state_update_alert *alert);
         void handleMetadataReceivedAlert(const lt::metadata_received_alert *alert);
@@ -607,7 +606,17 @@ namespace BitTorrent
         void handleTrackerAlert(const lt::tracker_alert *alert);
 #ifdef QBT_USES_LIBTORRENT2
         void handleTorrentConflictAlert(const lt::torrent_conflict_alert *alert);
+        void handleFilePrioAlert(const lt::file_prio_alert *alert);
 #endif
+        void handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *alert);
+        void handleFileCompletedAlert(const lt::file_completed_alert *alert);
+        void handleFileRenamedAlert(const lt::file_renamed_alert *alert);
+        void handleFileRenameFailedAlert(const lt::file_rename_failed_alert *alert);
+        void handlePerformanceAlert(const lt::performance_alert *alert) const;
+        void handleSaveResumeDataAlert(const lt::save_resume_data_alert *alert);
+        void handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *alert);
+        void handleTorrentCheckedAlert(const lt::torrent_checked_alert *alert);
+        void handleTorrentFinishedAlert(const lt::torrent_finished_alert *alert);
 
         TorrentImpl *createTorrent(const lt::torrent_handle &nativeHandle, const LoadTorrentParams &params);
         TorrentImpl *getTorrent(const lt::torrent_handle &nativeHandle) const;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -37,7 +37,6 @@
 #endif
 
 #include <libtorrent/address.hpp>
-#include <libtorrent/alert_types.hpp>
 #include <libtorrent/create_torrent.hpp>
 #include <libtorrent/session.hpp>
 #include <libtorrent/storage_defs.hpp>
@@ -2023,7 +2022,7 @@ void TorrentImpl::handleMoveStorageJobFinished(const Path &path, const MoveStora
     }
 }
 
-void TorrentImpl::handleTorrentCheckedAlert([[maybe_unused]] const lt::torrent_checked_alert *p)
+void TorrentImpl::handleTorrentChecked()
 {
     if (!hasMetadata())
     {
@@ -2066,7 +2065,7 @@ void TorrentImpl::handleTorrentCheckedAlert([[maybe_unused]] const lt::torrent_c
     });
 }
 
-void TorrentImpl::handleTorrentFinishedAlert([[maybe_unused]] const lt::torrent_finished_alert *p)
+void TorrentImpl::handleTorrentFinished()
 {
     m_hasMissingFiles = false;
     if (m_hasFinishedStatus)
@@ -2096,17 +2095,9 @@ void TorrentImpl::handleTorrentFinishedAlert([[maybe_unused]] const lt::torrent_
     });
 }
 
-void TorrentImpl::handleTorrentPausedAlert([[maybe_unused]] const lt::torrent_paused_alert *p)
+void TorrentImpl::handleSaveResumeData(lt::add_torrent_params params)
 {
-}
-
-void TorrentImpl::handleTorrentResumedAlert([[maybe_unused]] const lt::torrent_resumed_alert *p)
-{
-}
-
-void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
-{
-    if (m_ltAddTorrentParams.url_seeds != p->params.url_seeds)
+    if (m_ltAddTorrentParams.url_seeds != params.url_seeds)
     {
         // URL seed list have been changed by libtorrent for some reason, so we need to update cached one.
         // Unfortunately, URL seed list containing in "resume data" is generated according to different rules
@@ -2114,12 +2105,12 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
         fetchURLSeeds().then(this, [this](const QList<QUrl> &urlSeeds) { m_urlSeeds = urlSeeds; });
     }
 
-    if ((m_maintenanceJob == MaintenanceJob::HandleMetadata) && p->params.ti)
+    if ((m_maintenanceJob == MaintenanceJob::HandleMetadata) && params.ti)
     {
         Q_ASSERT(m_indexMap.isEmpty());
 
         const auto isSeedMode = static_cast<bool>(m_ltAddTorrentParams.flags & lt::torrent_flags::seed_mode);
-        m_ltAddTorrentParams = p->params;
+        m_ltAddTorrentParams = std::move(params);
         if (isSeedMode)
             m_ltAddTorrentParams.flags |= lt::torrent_flags::seed_mode;
 
@@ -2167,11 +2158,11 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
     }
     else
     {
-        prepareResumeData(p->params);
+        prepareResumeData(std::move(params));
     }
 }
 
-void TorrentImpl::prepareResumeData(const lt::add_torrent_params &params)
+void TorrentImpl::prepareResumeData(lt::add_torrent_params params)
 {
     {
         decltype(params.have_pieces) havePieces;
@@ -2195,7 +2186,7 @@ void TorrentImpl::prepareResumeData(const lt::add_torrent_params &params)
         }
 
         // Update recent resume data
-        m_ltAddTorrentParams = params;
+        m_ltAddTorrentParams = std::move(params);
 
         if (needPreserveProgress)
         {
@@ -2237,29 +2228,16 @@ void TorrentImpl::prepareResumeData(const lt::add_torrent_params &params)
     m_session->handleTorrentResumeDataReady(this, resumeData);
 }
 
-void TorrentImpl::handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *p)
-{
-    if (p->error != lt::errors::resume_data_not_modified)
-    {
-        LogMsg(tr("Generate resume data failed. Torrent: \"%1\". Reason: \"%2\"")
-            .arg(name(), Utils::String::fromLocal8Bit(p->error.message())), Log::CRITICAL);
-    }
-}
-
-void TorrentImpl::handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p)
+void TorrentImpl::handleFastResumeRejected()
 {
     // Files were probably moved or storage isn't accessible
     m_hasMissingFiles = true;
-    LogMsg(tr("Failed to restore torrent. Files were probably moved or storage isn't accessible. Torrent: \"%1\". Reason: \"%2\"")
-        .arg(name(), QString::fromStdString(p->message())), Log::WARNING);
 }
 
-void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
+void TorrentImpl::handleFileRenamed(const lt::file_index_t nativeFileIndex, const Path &newActualFilePath, const Path &oldActualFilePath)
 {
-    const int fileIndex = m_indexMap.value(p->index, -1);
+    const int fileIndex = fileIndexFromNative(nativeFileIndex);
     Q_ASSERT(fileIndex >= 0);
-
-    const Path newActualFilePath {QString::fromUtf8(p->new_name())};
 
     const Path oldFilePath = m_filePaths.at(fileIndex);
     const Path newFilePath = makeUserPath(newActualFilePath);
@@ -2270,11 +2248,6 @@ void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
     if (oldFilePath.data() == newFilePath.data())
     {
         // Remove empty ".unwanted" folders
-#ifdef QBT_USES_LIBTORRENT2
-        const Path oldActualFilePath {QString::fromUtf8(p->old_name())};
-#else
-        const Path oldActualFilePath;
-#endif
         const Path oldActualParentPath = oldActualFilePath.parentPath();
         const Path newActualParentPath = newActualFilePath.parentPath();
         if (newActualParentPath.filename() == UNWANTED_FOLDER_NAME)
@@ -2324,13 +2297,10 @@ void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
     deferredRequestResumeData();
 }
 
-void TorrentImpl::handleFileRenameFailedAlert(const lt::file_rename_failed_alert *p)
+void TorrentImpl::handleFileRenameFailed(const lt::file_index_t nativeFileIndex)
 {
-    const int fileIndex = m_indexMap.value(p->index, -1);
+    const int fileIndex = fileIndexFromNative(nativeFileIndex);
     Q_ASSERT(fileIndex >= 0);
-
-    LogMsg(tr("File rename failed. Torrent: \"%1\", file: \"%2\", reason: \"%3\"")
-        .arg(name(), filePath(fileIndex).toString(), Utils::String::fromLocal8Bit(p->error.message())), Log::WARNING);
 
     --m_renameCount;
     while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
@@ -2339,12 +2309,12 @@ void TorrentImpl::handleFileRenameFailedAlert(const lt::file_rename_failed_alert
     deferredRequestResumeData();
 }
 
-void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
+void TorrentImpl::handleFileCompleted(const lt::file_index_t nativeFileIndex)
 {
     if (m_maintenanceJob == MaintenanceJob::HandleMetadata)
         return;
 
-    const int fileIndex = m_indexMap.value(p->index, -1);
+    const int fileIndex = fileIndexFromNative(nativeFileIndex);
     Q_ASSERT(fileIndex >= 0);
 
     m_completedFiles.setBit(fileIndex);
@@ -2372,22 +2342,13 @@ void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
     }
 }
 
-void TorrentImpl::handleFileErrorAlert(const lt::file_error_alert *p)
+void TorrentImpl::handleFileError(FileErrorInfo fileError)
 {
-    m_lastFileError = {p->error, p->op};
+    m_lastFileError = std::move(fileError);
 }
 
-#ifdef QBT_USES_LIBTORRENT2
-void TorrentImpl::handleFilePrioAlert(const lt::file_prio_alert *)
+void TorrentImpl::handleMetadataReceived()
 {
-    deferredRequestResumeData();
-}
-#endif
-
-void TorrentImpl::handleMetadataReceivedAlert([[maybe_unused]] const lt::metadata_received_alert *p)
-{
-    qDebug("Metadata received for torrent %s.", qUtf8Printable(name()));
-
 #ifdef QBT_USES_LIBTORRENT2
     const InfoHash prevInfoHash = infoHash();
     m_infoHash = InfoHash(m_nativeHandle.info_hashes());
@@ -2397,12 +2358,6 @@ void TorrentImpl::handleMetadataReceivedAlert([[maybe_unused]] const lt::metadat
 
     m_maintenanceJob = MaintenanceJob::HandleMetadata;
     deferredRequestResumeData();
-}
-
-void TorrentImpl::handlePerformanceAlert(const lt::performance_alert *p) const
-{
-    LogMsg((tr("Performance alert: %1. More info: %2").arg(QString::fromStdString(p->message()), u"https://libtorrent.org/reference-Alerts.html#enum-performance-warning-t"_s))
-           , Log::INFO);
 }
 
 void TorrentImpl::handleCategoryOptionsChanged()
@@ -2425,57 +2380,6 @@ void TorrentImpl::handleUnwantedFolderToggled()
         return;
 
     manageActualFilePaths();
-}
-
-void TorrentImpl::handleAlert(const lt::alert *a)
-{
-    switch (a->type())
-    {
-#ifdef QBT_USES_LIBTORRENT2
-    case lt::file_prio_alert::alert_type:
-        handleFilePrioAlert(static_cast<const lt::file_prio_alert*>(a));
-        break;
-#endif
-    case lt::file_renamed_alert::alert_type:
-        handleFileRenamedAlert(static_cast<const lt::file_renamed_alert*>(a));
-        break;
-    case lt::file_rename_failed_alert::alert_type:
-        handleFileRenameFailedAlert(static_cast<const lt::file_rename_failed_alert*>(a));
-        break;
-    case lt::file_completed_alert::alert_type:
-        handleFileCompletedAlert(static_cast<const lt::file_completed_alert*>(a));
-        break;
-    case lt::file_error_alert::alert_type:
-        handleFileErrorAlert(static_cast<const lt::file_error_alert*>(a));
-        break;
-    case lt::torrent_finished_alert::alert_type:
-        handleTorrentFinishedAlert(static_cast<const lt::torrent_finished_alert*>(a));
-        break;
-    case lt::save_resume_data_alert::alert_type:
-        handleSaveResumeDataAlert(static_cast<const lt::save_resume_data_alert*>(a));
-        break;
-    case lt::save_resume_data_failed_alert::alert_type:
-        handleSaveResumeDataFailedAlert(static_cast<const lt::save_resume_data_failed_alert*>(a));
-        break;
-    case lt::torrent_paused_alert::alert_type:
-        handleTorrentPausedAlert(static_cast<const lt::torrent_paused_alert*>(a));
-        break;
-    case lt::torrent_resumed_alert::alert_type:
-        handleTorrentResumedAlert(static_cast<const lt::torrent_resumed_alert*>(a));
-        break;
-    case lt::metadata_received_alert::alert_type:
-        handleMetadataReceivedAlert(static_cast<const lt::metadata_received_alert*>(a));
-        break;
-    case lt::fastresume_rejected_alert::alert_type:
-        handleFastResumeRejectedAlert(static_cast<const lt::fastresume_rejected_alert*>(a));
-        break;
-    case lt::torrent_checked_alert::alert_type:
-        handleTorrentCheckedAlert(static_cast<const lt::torrent_checked_alert*>(a));
-        break;
-    case lt::performance_alert::alert_type:
-        handlePerformanceAlert(static_cast<const lt::performance_alert*>(a));
-        break;
-    }
 }
 
 void TorrentImpl::manageActualFilePaths()
@@ -2523,6 +2427,11 @@ void TorrentImpl::doRenameFile(const int index, const Path &path)
 lt::torrent_handle TorrentImpl::nativeHandle() const
 {
     return m_nativeHandle;
+}
+
+int TorrentImpl::fileIndexFromNative(const lt::file_index_t nativeFileIndex) const
+{
+    return m_indexMap.value(nativeFileIndex, -1);
 }
 
 void TorrentImpl::setMetadata(const TorrentInfo &torrentInfo)
@@ -3016,7 +2925,7 @@ void TorrentImpl::prioritizeFiles(const QList<DownloadPriority> &priorities)
     Q_ASSERT(priorities.size() == filesCount());
 
     // Reset 'm_hasSeedStatus' if needed in order to react again to
-    // 'torrent_finished_alert' and eg show tray notifications
+    // "torrent finished" event and e.g. show tray notifications
     const QList<DownloadPriority> oldPriorities = filePriorities();
     for (int i = 0; i < oldPriorities.size(); ++i)
     {

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -264,8 +264,18 @@ namespace BitTorrent
         // Session interface
         lt::torrent_handle nativeHandle() const;
 
-        void handleAlert(const lt::alert *a);
+        int fileIndexFromNative(lt::file_index_t nativeFileIndex) const;
+
         void handleStateUpdate(const lt::torrent_status &nativeStatus);
+        void handleFastResumeRejected();
+        void handleFileCompleted(lt::file_index_t nativeFileIndex);
+        void handleFileError(FileErrorInfo fileError);
+        void handleFileRenamed(lt::file_index_t nativeFileIndex, const Path &newActualFilePath, const Path &oldActualFilePath);
+        void handleFileRenameFailed(lt::file_index_t nativeFileIndex);
+        void handleMetadataReceived();
+        void handleSaveResumeData(lt::add_torrent_params params);
+        void handleTorrentChecked();
+        void handleTorrentFinished();
         void handleQueueingModeChanged();
         void handleCategoryOptionsChanged();
         void handleAppendExtensionToggled();
@@ -285,23 +295,6 @@ namespace BitTorrent
         void updateProgress();
         void updateState();
 
-        void handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p);
-        void handleFileCompletedAlert(const lt::file_completed_alert *p);
-        void handleFileErrorAlert(const lt::file_error_alert *p);
-#ifdef QBT_USES_LIBTORRENT2
-        void handleFilePrioAlert(const lt::file_prio_alert *p);
-#endif
-        void handleFileRenamedAlert(const lt::file_renamed_alert *p);
-        void handleFileRenameFailedAlert(const lt::file_rename_failed_alert *p);
-        void handleMetadataReceivedAlert(const lt::metadata_received_alert *p);
-        void handlePerformanceAlert(const lt::performance_alert *p) const;
-        void handleSaveResumeDataAlert(const lt::save_resume_data_alert *p);
-        void handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *p);
-        void handleTorrentCheckedAlert(const lt::torrent_checked_alert *p);
-        void handleTorrentFinishedAlert(const lt::torrent_finished_alert *p);
-        void handleTorrentPausedAlert(const lt::torrent_paused_alert *p);
-        void handleTorrentResumedAlert(const lt::torrent_resumed_alert *p);
-
         bool isMoveInProgress() const;
 
         void setAutoManaged(bool enable);
@@ -314,7 +307,7 @@ namespace BitTorrent
         void manageActualFilePaths();
         void applyFirstLastPiecePriority(bool enabled);
 
-        void prepareResumeData(const lt::add_torrent_params &params);
+        void prepareResumeData(lt::add_torrent_params resumeData);
         void endReceivedMetadataHandling(const Path &savePath, const PathList &fileNames);
         void reload();
 


### PR DESCRIPTION
Turn `SessionImpl` to handle torrent alerts and call `TorrentImpl` instance only when needed.
This reduces cross-dependencies between classes as well as dependencies from `libtorrent`.