### PR TITLE
Make modifying log file perms best effort

### DIFF
--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -175,12 +175,14 @@ void FileLogger::flushLog()
 
 void FileLogger::openLogFile()
 {
-    if (!m_logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)
-        || !m_logFile.setPermissions(QFile::ReadOwner | QFile::WriteOwner))
+    if (!m_logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text))
     {
-        m_logFile.close();
         LogMsg(tr("An error occurred while trying to open the log file. Logging to file is disabled."), Log::CRITICAL);
+        return;
     }
+
+    // best effort, don't report error
+    m_logFile.setPermissions(QFile::ReadOwner | QFile::WriteOwner);
 }
 
 void FileLogger::closeLogFile()

--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -177,7 +177,8 @@ void FileLogger::openLogFile()
 {
     if (!m_logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text))
     {
-        LogMsg(tr("An error occurred while trying to open the log file. Logging to file is disabled."), Log::CRITICAL);
+        LogMsg(tr("An error occurred while trying to open the log file. Logging to file is disabled. File: \"%1\". Error: \"%2\".")
+            .arg(m_logFile.fileName(), m_logFile.errorString()), Log::CRITICAL);
         return;
     }
 


### PR DESCRIPTION
qBittorrent is able to write to the log file, so it's ok if the permission change fails. The downside will be that the file remains readable to the world.