### PR TITLE
Add Size (Bytes) column to Content tab

### DIFF
--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -166,7 +166,7 @@ namespace
 
 TorrentContentModel::TorrentContentModel(QObject *parent)
     : QAbstractItemModel(parent)
-    , m_rootItem(new TorrentContentModelFolder(QList<QString>({ tr("Name"), tr("Total Size"), tr("Progress"), tr("Download Priority"), tr("Remaining"), tr("Availability") })))
+    , m_rootItem(new TorrentContentModelFolder(QList<QString>({ tr("Name"), tr("Total Size"), tr("Size (Bytes)"), tr("Progress"), tr("Download Priority"), tr("Remaining"), tr("Availability") })))
 #if defined(Q_OS_WIN)
     , m_fileIconProvider {new QFileIconProvider}
 #elif defined(Q_OS_MACOS)
@@ -409,7 +409,8 @@ QVariant TorrentContentModel::data(const QModelIndex &index, const int role) con
 
     case Qt::TextAlignmentRole:
         if ((index.column() == TorrentContentModelItem::COL_SIZE)
-            || (index.column() == TorrentContentModelItem::COL_REMAINING))
+            || (index.column() == TorrentContentModelItem::COL_SIZE_BYTES)
+			|| (index.column() == TorrentContentModelItem::COL_REMAINING))
         {
             return QVariant {Qt::AlignRight | Qt::AlignVCenter};
         }
@@ -456,6 +457,7 @@ QVariant TorrentContentModel::headerData(int section, Qt::Orientation orientatio
 
     case Qt::TextAlignmentRole:
         if ((section == TorrentContentModelItem::COL_SIZE)
+			|| (section == TorrentContentModelItem::COL_SIZE_BYTES)
             || (section == TorrentContentModelItem::COL_REMAINING))
         {
             return QVariant {Qt::AlignRight | Qt::AlignVCenter};
@@ -649,7 +651,8 @@ void TorrentContentModel::refresh()
             {TorrentContentModelItem::COL_NAME, TorrentContentModelItem::COL_NAME},
             {TorrentContentModelItem::COL_PROGRESS, TorrentContentModelItem::COL_PROGRESS},
             {TorrentContentModelItem::COL_PRIO, TorrentContentModelItem::COL_PRIO},
-            {TorrentContentModelItem::COL_AVAILABILITY, TorrentContentModelItem::COL_AVAILABILITY}
+            {TorrentContentModelItem::COL_AVAILABILITY, TorrentContentModelItem::COL_AVAILABILITY},
+			{TorrentContentModelItem::COL_SIZE_BYTES , TorrentContentModelItem::COL_SIZE_BYTES}
         };
         notifySubtreeUpdated(index(0, 0), columns);
     }

--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -28,6 +28,7 @@
 
 #include "torrentcontentmodelitem.h"
 
+#include <QLocale> 
 #include <QVariant>
 
 #include "base/unicodestrings.h"
@@ -139,6 +140,8 @@ QString TorrentContentModelItem::displayData(const int column) const
                                   : Utils::String::fromDouble((avail * 100), 1);
             return (value + u'%');
         }
+	case COL_SIZE_BYTES:
+        return QLocale().toString(m_size);
     default:
         Q_UNREACHABLE();
         break;
@@ -166,6 +169,9 @@ QVariant TorrentContentModelItem::underlyingData(const int column) const
         return remaining();
     case COL_AVAILABILITY:
         return availability();
+	case COL_SIZE_BYTES:
+		return m_size;
+
     default:
         Q_UNREACHABLE();
         break;

--- a/src/gui/torrentcontentmodelitem.h
+++ b/src/gui/torrentcontentmodelitem.h
@@ -46,6 +46,7 @@ public:
     {
         COL_NAME,
         COL_SIZE,
+		COL_SIZE_BYTES,
         COL_PROGRESS,
         COL_PRIO,
         COL_REMAINING,


### PR DESCRIPTION
## Description
Adds a new "Size (Bytes)" column to the Content tab displaying exact file sizes with locale-appropriate formatting.

## Motivation
Users modify torrent files with external tools (e.g., mkvMerge) causing small size differences. The human-readable size column cannot show these differences, making cross-seeding detection difficult.

## Changes
- Added COL_SIZE_BYTES enum to TreeItemColumns
- Implemented QLocale().toString() formatting for exact byte display  
- Added right-alignment for consistency with other size columns
- Updated refresh logic to include new column

## Testing
-  Builds successfully on Windows with MSVC 2022
-  Tested with multi-file torrents
-  Verified proper thousands separator formatting
-  Confirmed right-alignment matches other columns

## Screenshot
<img width="959" alt="working_displayed_bytes" src="https://github.com/user-attachments/assets/5b0d2663-78f1-4f02-b1c8-0eedf4fb7a0a" />

Closes #22690.
