### PR TITLE
WebUI: Reset filter selection when double clicking filter

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -490,7 +490,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
         updateFilter("moving", "QBT_TR(Moving (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
         updateFilter("errored", "QBT_TR(Errored (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
         if (useAutoHideZeroStatusFilters && document.getElementById(`${selectedStatus}_filter`).classList.contains("invisible"))
-            setStatusFilter("all");
+            window.qBittorrent.Filters.clearStatusFilter();
     };
 
     const highlightSelectedStatus = () => {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -967,7 +967,7 @@ const initializeWindows = () => {
                 if (!response.ok)
                     return;
 
-                setCategoryFilter(CATEGORIES_ALL);
+                window.qBittorrent.Filters.clearCategoryFilter();
                 updateMainData();
             });
     };
@@ -988,7 +988,7 @@ const initializeWindows = () => {
                 if (!response.ok)
                     return;
 
-                setCategoryFilter(CATEGORIES_ALL);
+                window.qBittorrent.Filters.clearCategoryFilter();
                 updateMainData();
             });
     };
@@ -1074,7 +1074,7 @@ const initializeWindows = () => {
                 tags: tag
             })
         });
-        setTagFilter(TAGS_ALL);
+        window.qBittorrent.Filters.clearTagFilter();
     };
 
     deleteUnusedTagsFN = () => {
@@ -1089,7 +1089,7 @@ const initializeWindows = () => {
                 tags: tags.join(",")
             })
         });
-        setTagFilter(TAGS_ALL);
+        window.qBittorrent.Filters.clearTagFilter();
     };
 
     deleteTrackerFN = (trackerHost) => {
@@ -1118,7 +1118,7 @@ const initializeWindows = () => {
             height: 100,
             onCloseComplete: () => {
                 updateMainData();
-                setTrackerFilter(TRACKERS_ALL);
+                window.qBittorrent.Filters.clearTrackerFilter();
             }
         });
     };

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -256,6 +256,39 @@
             }
         });
 
+        document.getElementById("Filters_pad").addEventListener("dblclick", (event) => {
+            const filterItem = event.target.closest("li");
+            if (!filterItem)
+                return;
+
+            const { id: filterListID } = filterItem.closest("ul[id]");
+            switch (filterListID) {
+                case "statusFilterList":
+                    clearCategoryFilter();
+                    clearTagFilter();
+                    clearTrackerFilter();
+                    break;
+                case "categoryFilterList":
+                    clearStatusFilter();
+                    clearTagFilter();
+                    clearTrackerFilter();
+                    break;
+                case "tagFilterList":
+                    clearStatusFilter();
+                    clearCategoryFilter();
+                    clearTrackerFilter();
+                    break;
+                case "trackerFilterList":
+                    clearStatusFilter();
+                    clearCategoryFilter();
+                    clearTagFilter();
+                    break;
+                default:
+                    console.error(`Unexpected filterListID: ${filterListID}`);
+                    break;
+            }
+        });
+
         document.getElementById("Filters_pad").addEventListener("click", (event) => {
             const filterTitle = event.target.closest(".filterTitle");
             if (!filterTitle)
@@ -280,6 +313,11 @@
 
             toggleCategoryDisplay(filterItem.id);
         });
+
+        const clearStatusFilter = () => { setStatusFilter("all"); };
+        const clearCategoryFilter = () => { setCategoryFilter(CATEGORIES_ALL); };
+        const clearTagFilter = () => { setTagFilter(TAGS_ALL); };
+        const clearTrackerFilter = () => { setTrackerFilter(TRACKERS_ALL); };
 
         return exports();
     })();

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -74,7 +74,11 @@
             return {
                 categoriesFilterContextMenu: categoriesFilterContextMenu,
                 tagsFilterContextMenu: tagsFilterContextMenu,
-                trackersFilterContextMenu: trackersFilterContextMenu
+                trackersFilterContextMenu: trackersFilterContextMenu,
+                clearStatusFilter: clearStatusFilter,
+                clearCategoryFilter: clearCategoryFilter,
+                clearTagFilter: clearTagFilter,
+                clearTrackerFilter: clearTrackerFilter
             };
         };
 
@@ -257,8 +261,11 @@
         });
 
         document.getElementById("Filters_pad").addEventListener("dblclick", (event) => {
+            if (LocalPreferences.get("dblclick_filter", "1") !== "1")
+                return;
+
             const filterItem = event.target.closest("li");
-            if (!filterItem)
+            if (filterItem === null)
                 return;
 
             const { id: filterListID } = filterItem.closest("ul[id]");

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -49,6 +49,15 @@
                             </select>
                         </td>
                     </tr>
+                    <tr>
+                        <td><label for="dblclickFiltersSelect">QBT_TR(Filters:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                        <td>
+                            <select id="dblclickFiltersSelect">
+                                <option value="1" selected>QBT_TR(Reset filter selection)QBT_TR[CONTEXT=OptionsDialog]</option>
+                                <option value="0">QBT_TR(No action)QBT_TR[CONTEXT=OptionsDialog]</option>
+                            </select>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </fieldset>
@@ -2230,6 +2239,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("hideZeroFiltersCheckbox").checked = (LocalPreferences.get("hide_zero_status_filters", "false") === "true");
                     document.getElementById("dblclickDownloadSelect").value = LocalPreferences.get("dblclick_download", "1");
                     document.getElementById("dblclickCompleteSelect").value = LocalPreferences.get("dblclick_complete", "1");
+                    document.getElementById("dblclickFiltersSelect").value = LocalPreferences.get("dblclick_filter", "1");
                     document.getElementById("confirmTorrentDeletion").checked = pref.confirm_torrent_deletion;
                     document.getElementById("useAltRowColorsInput").checked = (LocalPreferences.get("use_alt_row_colors", "true") === "true");
                     document.getElementById("filelog_checkbox").checked = pref.file_log_enabled;
@@ -2663,6 +2673,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             LocalPreferences.set("hide_zero_status_filters", document.getElementById("hideZeroFiltersCheckbox").checked.toString());
             LocalPreferences.set("dblclick_download", document.getElementById("dblclickDownloadSelect").value);
             LocalPreferences.set("dblclick_complete", document.getElementById("dblclickCompleteSelect").value);
+            LocalPreferences.set("dblclick_filter", document.getElementById("dblclickFiltersSelect").value);
             settings["confirm_torrent_deletion"] = document.getElementById("confirmTorrentDeletion").checked;
             LocalPreferences.set("use_alt_row_colors", document.getElementById("useAltRowColorsInput").checked.toString());
             settings["file_log_enabled"] = document.getElementById("filelog_checkbox").checked;


### PR DESCRIPTION
When double clicking on a filter, all other filters will be reset. For example, double clicking on a status filter will reset the categories, tags, and trackers filters to "All". This behavior can be disabled in WebUI options.

Closes #22449