### PR TITLE
Don't limit the size of read "resume data"

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -147,7 +147,7 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::load(cons
     const Path torrentFilePath = path() / Path(idString + u".torrent");
     const qint64 torrentSizeLimit = Preferences::instance()->getTorrentFileSizeLimit();
 
-    const auto resumeDataReadResult = Utils::IO::readFile(fastresumePath, torrentSizeLimit);
+    const auto resumeDataReadResult = Utils::IO::readFile(fastresumePath, -1);
     if (!resumeDataReadResult)
         return nonstd::make_unexpected(resumeDataReadResult.error().message);
 


### PR DESCRIPTION
IMO, it's not a good idea to limit the size of the data created by qBittorrent itself.
So far, such limiting has only brought problems to users. And considering that there have never been any problems due to the lack of such a limit, I just decided to remove it.

P.S. Technically, it is possible to roughly calculate the estimated maximum "resume data" size based on torrent metadata, but I certainly do not intend to do this.