### PR TITLE
Change default permissions on log to 640

### DIFF
--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -183,7 +183,7 @@ void FileLogger::openLogFile()
     }
 
     // best effort, don't report error
-    m_logFile.setPermissions(QFile::ReadOwner | QFile::WriteOwner);
+    m_logFile.setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ReadGroup);
 }
 
 void FileLogger::closeLogFile()


### PR DESCRIPTION
This will allow other users in the same group as the user running qBittorrent to read the log file. Useful if running a setup with a systemd service and an unprivileged qbt user for example.