### PR TITLE
Change default permissions on log to 640

### DIFF
--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -176,7 +176,7 @@ void FileLogger::flushLog()
 void FileLogger::openLogFile()
 {
     if (!m_logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)
-        || !m_logFile.setPermissions(QFile::ReadOwner | QFile::WriteOwner))
+        || !m_logFile.setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ReadGroup))
     {
         m_logFile.close();
         LogMsg(tr("An error occurred while trying to open the log file. Logging to file is disabled."), Log::CRITICAL);


### PR DESCRIPTION
This will allow other users in the same group as the user running qBittorrent to read the log file. Useful if running a setup with a systemd service and an unprivileged qbt user for example.