### PR TITLE
WebUI: Allow `Rename files` on multiple selected torrents

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,5 +1,10 @@
 # WebAPI Changelog
 
+## 2.11.9
+
+* [#???](https://github.com/qbittorrent/qBittorrent/pull/)
+  * Introduce `torrents/bulkFiles`, accepts a list of `hash`es separated with `|` (pipe), returns list of files for all selected torrents
+
 ## 2.11.8
 
 * [#21349](https://github.com/qbittorrent/qBittorrent/pull/21349)

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -48,6 +48,7 @@ private slots:
     void editWebSeedAction();
     void removeWebSeedsAction();
     void filesAction();
+    void bulkFilesAction();
     void pieceHashesAction();
     void pieceStatesAction();
     void startAction();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -53,7 +53,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 11, 8};
+inline const Utils::Version<3, 2> API_VERSION {2, 11, 9};
 
 class APIController;
 class AuthController;

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -298,7 +298,8 @@
                         path: file.name,
                         original: window.qBittorrent.Filesystem.fileName(file.name),
                         renamed: "",
-                        size: file.size
+                        size: file.size,
+                        torrentHash: file.torrent_hash
                     };
 
                     return row;
@@ -375,7 +376,7 @@
             };
 
             const setupTable = (selectedRows) => {
-                const url = new URL("api/v2/torrents/files", window.location);
+                const url = new URL("api/v2/torrents/bulkFiles", window.location);
                 url.search = new URLSearchParams({
                     hash: data.hash
                 });

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -397,7 +397,6 @@ window.qBittorrent.ContextMenu ??= (() => {
                     : this.hideItem("renameFiles");
             }
             else {
-                this.hideItem("renameFiles");
                 this.hideItem("rename");
             }
 

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -740,28 +740,31 @@ const initializeWindows = () => {
 
     renameFilesFN = () => {
         const hashes = torrentsTable.selectedRowsIds();
-        if (hashes.length === 1) {
-            const hash = hashes[0];
+        const hashList = hashes.join("|");
+        const rows = [];
+        hashes.forEach((hash) => {
             const row = torrentsTable.getRow(hash);
-            if (row) {
-                new MochaUI.Window({
-                    id: "multiRenamePage",
-                    icon: "images/qbittorrent-tray.svg",
-                    title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TransferListWidget]",
-                    data: { hash: hash, selectedRows: [] },
-                    loadMethod: "xhr",
-                    contentURL: "rename_files.html",
-                    scrollbars: false,
-                    resizable: true,
-                    maximizable: false,
-                    paddingVertical: 0,
-                    paddingHorizontal: 0,
-                    width: 800,
-                    height: 420,
-                    resizeLimit: { x: [800], y: [420] }
-                });
-            }
-        }
+            if (row)
+                rows.push(row);
+        });
+        if (rows.length === 0)
+            return;
+        new MochaUI.Window({
+            id: "multiRenamePage",
+            icon: "images/qbittorrent-tray.svg",
+            title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TransferListWidget]",
+            data: { hash: hashList, selectedRows: rows },
+            loadMethod: "xhr",
+            contentURL: "rename_files.html",
+            scrollbars: false,
+            resizable: true,
+            maximizable: false,
+            paddingVertical: 0,
+            paddingHorizontal: 0,
+            width: 800,
+            height: 420,
+            resizeLimit: { x: [800], y: [420] }
+        });
     };
 
     startVisibleTorrentsFN = () => {

--- a/src/webui/www/private/scripts/rename-files.js
+++ b/src/webui/www/private/scripts/rename-files.js
@@ -244,7 +244,7 @@ window.qBittorrent.MultiRename ??= (() => {
                     await fetch((isFolder ? "api/v2/torrents/renameFolder" : "api/v2/torrents/renameFile"), {
                         method: "POST",
                         body: new URLSearchParams({
-                            hash: this.hash,
+                            hash: match.data.torrentHash,
                             oldPath: oldPath,
                             newPath: newPath
                         })


### PR DESCRIPTION
Closes #22852 

## Feature summary

The goal is to be able to select multiple torrents and apply/execute `Rename files`  on all of their files at the same time.

## Why API bump ?

I tried to find a way to do it with the currently existing endpoints/API, but my main blocker there was that `torrents/files` has (besides the `hash` argument) an `indexes` argument, which I cannot imagine working in any friendly manner with multiple torrents.

(And I definitely dont want to send a request for every selected torrent when i could send only one request)

## Changes summary

Added `torrents/bulkFiles` which accepts a list of torrent hashes in the `hash` argument (only argument) and returns a list of files with the additional property/attribute `torrent_hash` set on them.

The `torrent_hash` later seen as `torrentHash` in the `js` is used in order to keep track of the torrent to which the file belongs, so we use the same rename API (`renameFile`/`renameFolder`) as before without changing it.

## Will this break existing API integrations ?

Nope, old API functions as before, only adding brand new functionality.

## How did you test ?

Manually.