### PR TITLE
WebUI: Default select & Remember files for rename

### DIFF
--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -256,9 +256,7 @@
                 document.getElementById("renameOptions").disabled = false;
 
                 // Recreate table
-                let selectedRows = bulkRenameFilesTable.getSelectedRows().map(row => row.rowId.toString());
-                for (const renamedRow of rows)
-                    selectedRows = selectedRows.filter(selectedRow => selectedRow !== renamedRow.rowId.toString());
+                const selectedRows = bulkRenameFilesTable.getSelectedRows().map(row => row.rowId.toString());
                 bulkRenameFilesTable.clear();
 
                 // Adjust file enumeration count by 1 when replacing single files to prevent naming conflicts
@@ -379,7 +377,7 @@
                 url.search = new URLSearchParams({
                     hash: data.hash
                 });
-                fetch(url, {
+                return fetch(url, {
                         method: "GET",
                         cache: "no-store"
                     })
@@ -394,7 +392,11 @@
                             handleTorrentFiles(files, selectedRows);
                     });
             };
-            setupTable(data.selectedRows);
+            setupTable(data.selectedRows).then(() => {
+                document.getElementById("rootMultiRename_cb").click();
+            }).catch((error) => {
+                console.error("Error setting up the table:", error);
+            });
         })();
     </script>
 </head>


### PR DESCRIPTION
Closes #22851 

## Changes summary

This PR is meant to introduce 2 behavioral changes in the WebUI.

1. Upon opening `Rename files` dialog, all files will be selected by default.
2. After a rename, selection will remain as is.

## Use cases

1. Opening the `Rename files` usually entails the rename of multiple files, as stated by OP in the issue. So it makes more sense to have all files selected by default, and allow the user to deselect some of  them.
2. Another common use case (for the second change) is for replacement of multiple different terms in filenames that follow some schema (adding the video format in the name of each file for example). So in that use case it makes sense to keep the selection after renaming the files.

## Issues

1. There was an explicit removal of renamed files from selection. There might have been some other discussion or intent behind this removal that im unaware of.
2. I personally dont like the invocation of the `.click()` function, don't have a better idea at the moment tho. Also [the state of the checkbox is determined by the state of the files, not vice verca](https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/www/private/scripts/dynamicTable.js#L2293C9-L2313) which confused me enough to settle for a simulated click. If you think its good idea to change that logic, and make it so its an `event` (file select) that affects the global checkbox, rather than looping through all nodes in the tree, im willing to give it a try.