### PR TITLE
WebUI: use `defer` when loading scripts

### DIFF
--- a/src/webui/www/private/addpeers.html
+++ b/src/webui/www/private/addpeers.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Add Peers)QBT_TR[CONTEXT=PeersAdditionDialog]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/addtrackers.html
+++ b/src/webui/www/private/addtrackers.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Add trackers)QBT_TR[CONTEXT=TrackersAdditionDialog]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/addwebseeds.html
+++ b/src/webui/www/private/addwebseeds.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Add web seeds)QBT_TR[CONTEXT=HttpServer]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/confirmfeeddeletion.html
+++ b/src/webui/www/private/confirmfeeddeletion.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=RSSWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/confirmruleclear.html
+++ b/src/webui/www/private/confirmruleclear.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Clear downloaded episodes)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/confirmruledeletion.html
+++ b/src/webui/www/private/confirmruledeletion.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Rule deletion confirmation)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/confirmtrackerdeletion.html
+++ b/src/webui/www/private/confirmtrackerdeletion.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Remove tracker)QBT_TR[CONTEXT=confirmDeletionDlg]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -6,10 +6,10 @@
     <title>QBT_TR(Add Torrent Links)QBT_TR[CONTEXT=downloadFromURL]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
     <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/download.js?v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/download.js?v=${CACHEID}"></script>
+    <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
 </head>
 
 <body>
@@ -160,31 +160,33 @@
     <script>
         "use strict";
 
-        const encodedUrls = new URLSearchParams(window.location.search).get("urls");
-        if (encodedUrls !== null) {
-            const urls = encodedUrls.split("|").map(decodeURIComponent);
-            if (urls.length > 0)
-                document.getElementById("urls").value = urls.join("\n");
-        }
+        window.addEventListener("DOMContentLoaded", (event) => {
+            const encodedUrls = new URLSearchParams(window.location.search).get("urls");
+            if (encodedUrls !== null) {
+                const urls = encodedUrls.split("|").map(decodeURIComponent);
+                if (urls.length > 0)
+                    document.getElementById("urls").value = urls.join("\n");
+            }
 
-        let submitted = false;
+            let submitted = false;
 
-        document.getElementById("downloadForm").addEventListener("submit", (event) => {
-            document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
+            document.getElementById("downloadForm").addEventListener("submit", (event) => {
+                document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
 
-            document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
-            document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
+                document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
+                document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
 
-            document.getElementById("download_spinner").style.display = "block";
-            submitted = true;
+                document.getElementById("download_spinner").style.display = "block";
+                submitted = true;
+            });
+
+            document.getElementById("download_frame").addEventListener("load", (event) => {
+                if (submitted)
+                    window.parent.qBittorrent.Client.closeFrameWindow(window);
+            });
+
+            window.qBittorrent.pathAutofill.attachPathAutofill();
         });
-
-        document.getElementById("download_frame").addEventListener("load", (event) => {
-            if (submitted)
-                window.parent.qBittorrent.Client.closeFrameWindow(window);
-        });
-
-        window.qBittorrent.pathAutofill.attachPathAutofill();
     </script>
 </body>
 

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -10,6 +10,37 @@
     <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script defer src="scripts/download.js?v=${CACHEID}"></script>
     <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script>
+        "use strict";
+
+        window.addEventListener("DOMContentLoaded", (event) => {
+            const encodedUrls = new URLSearchParams(window.location.search).get("urls");
+            if (encodedUrls !== null) {
+                const urls = encodedUrls.split("|").map(decodeURIComponent);
+                if (urls.length > 0)
+                    document.getElementById("urls").value = urls.join("\n");
+            }
+
+            let submitted = false;
+
+            document.getElementById("downloadForm").addEventListener("submit", (event) => {
+                document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
+
+                document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
+                document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
+
+                document.getElementById("download_spinner").style.display = "block";
+                submitted = true;
+            });
+
+            document.getElementById("download_frame").addEventListener("load", (event) => {
+                if (submitted)
+                    window.parent.qBittorrent.Client.closeFrameWindow(window);
+            });
+
+            window.qBittorrent.pathAutofill.attachPathAutofill();
+        });
+    </script>
 </head>
 
 <body>
@@ -156,38 +187,6 @@
         </div>
     </form>
     <div id="download_spinner" class="mochaSpinner"></div>
-
-    <script>
-        "use strict";
-
-        window.addEventListener("DOMContentLoaded", (event) => {
-            const encodedUrls = new URLSearchParams(window.location.search).get("urls");
-            if (encodedUrls !== null) {
-                const urls = encodedUrls.split("|").map(decodeURIComponent);
-                if (urls.length > 0)
-                    document.getElementById("urls").value = urls.join("\n");
-            }
-
-            let submitted = false;
-
-            document.getElementById("downloadForm").addEventListener("submit", (event) => {
-                document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
-
-                document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
-                document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
-
-                document.getElementById("download_spinner").style.display = "block";
-                submitted = true;
-            });
-
-            document.getElementById("download_frame").addEventListener("load", (event) => {
-                if (submitted)
-                    window.parent.qBittorrent.Client.closeFrameWindow(window);
-            });
-
-            window.qBittorrent.pathAutofill.attachPathAutofill();
-        });
-    </script>
 </body>
 
 </html>

--- a/src/webui/www/private/editfeedurl.html
+++ b/src/webui/www/private/editfeedurl.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/editwebseed.html
+++ b/src/webui/www/private/editwebseed.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Edit web seed)QBT_TR[CONTEXT=HttpServer]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -5,10 +5,10 @@
     <meta charset="UTF-8">
     <title>QBT_TR(New Category)QBT_TR[CONTEXT=TransferListWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/newfeed.html
+++ b/src/webui/www/private/newfeed.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/newfolder.html
+++ b/src/webui/www/private/newfolder.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Please choose a folder name)QBT_TR[CONTEXT=RSSWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/newrule.html
+++ b/src/webui/www/private/newrule.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/newtag.html
+++ b/src/webui/www/private/newtag.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Add tags)QBT_TR[CONTEXT=TransferListWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Rename)QBT_TR[CONTEXT=TransferListWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/rename_feed.html
+++ b/src/webui/www/private/rename_feed.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Please choose a new name for this RSS feed)QBT_TR[CONTEXT=RSSWidget]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/rename_file.html
+++ b/src/webui/www/private/rename_file.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/filesystem.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/filesystem.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]</title>
-    <script src="scripts/filesystem.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/file-tree.js?v=${CACHEID}"></script>
-    <script src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/rename-files.js?v=${CACHEID}"></script>
+    <script defer src="scripts/filesystem.js?v=${CACHEID}"></script>
+    <script defer src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/file-tree.js?v=${CACHEID}"></script>
+    <script defer src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/rename-files.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/rename_rule.html
+++ b/src/webui/www/private/rename_rule.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Rule renaming)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Set location)QBT_TR[CONTEXT=HttpServer]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/shareratio.html
+++ b/src/webui/www/private/shareratio.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Torrent Upload/Download Ratio Limiting)QBT_TR[CONTEXT=UpDownRatioDialog]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/speedlimit.html
+++ b/src/webui/www/private/speedlimit.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <title>QBT_TR(Speed limit)QBT_TR[CONTEXT=SpeedLimit]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
 </head>
 
 <body>
@@ -19,140 +19,144 @@
             </div>
             <input type="range" id="limitSliderInput" min="0" value="0" style="width: 100%;" aria-label="QBT_TR(Speed limit)QBT_TR[CONTEXT=SpeedLimit]">
         </div>
-        <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]" onclick="saveLimit()">
+        <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]">
     </div>
 
     <script>
         "use strict";
 
-        window.addEventListener("keydown", (event) => {
-            switch (event.key) {
-                case "Enter":
-                    event.preventDefault();
-                    document.getElementById("applyButton").click();
-                    break;
-                case "Escape":
-                    event.preventDefault();
-                    window.parent.qBittorrent.Client.closeFrameWindow(window);
-                    break;
-            }
-        });
+        window.addEventListener("DOMContentLoaded", (event) => {
+            const applyButton = document.getElementById("applyButton");
 
-        const params = new URLSearchParams(window.location.search);
-        const type = params.get("type");
-        const hashes = params.get("hashes").split("|");
-
-        const isGlobal = (hashes[0] === "global");
-        // Otherwise it's download limit
-        const isUpload = (type === "upload");
-
-        const getLimitMethod = isUpload ? "uploadLimit" : "downloadLimit";
-        const setLimitMethod = isUpload ? "setUploadLimit" : "setDownloadLimit";
-
-        const limitUpdateValue = document.getElementById("limitUpdateValue");
-        const limitUnit = document.getElementById("limitUnit");
-
-        const setLimitUpdateValue = (value) => {
-            if (value === 0) {
-                limitUpdateValue.value = "∞";
-                limitUnit.style.visibility = "hidden";
-            }
-            else {
-                limitUpdateValue.value = value;
-                limitUnit.style.visibility = "visible";
-            }
-        };
-
-        const setupSlider = (limit, maximum) => {
-            const input = document.getElementById("limitSliderInput");
-            input.max = maximum;
-            input.value = limit;
-            input.addEventListener("input", (event) => {
-                setLimitUpdateValue(Number(event.target.value));
+            window.addEventListener("keydown", (event) => {
+                switch (event.key) {
+                    case "Enter":
+                        event.preventDefault();
+                        applyButton.click();
+                        break;
+                    case "Escape":
+                        event.preventDefault();
+                        window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        break;
+                }
             });
-            // Set default value
-            setLimitUpdateValue(limit);
-        };
 
-        const saveLimit = () => {
-            const limit = Number(limitUpdateValue.value) * 1024;
-            if (isGlobal) {
-                fetch(`api/v2/transfer/${setLimitMethod}`, {
-                        method: "POST",
-                        body: new URLSearchParams({
-                            limit: limit
-                        })
-                    })
-                    .then((response) => {
-                        if (!response.ok)
-                            return;
+            const params = new URLSearchParams(window.location.search);
+            const type = params.get("type");
+            const hashes = params.get("hashes").split("|");
 
-                        window.parent.updateMainData();
-                        window.parent.qBittorrent.Client.closeFrameWindow(window);
-                    });
-            }
-            else {
-                fetch(`api/v2/torrents/${setLimitMethod}`, {
-                        method: "POST",
-                        body: new URLSearchParams({
-                            hashes: hashes.join("|"),
-                            limit: limit
-                        })
-                    })
-                    .then((response) => {
-                        if (!response.ok)
-                            return;
+            const isGlobal = (hashes[0] === "global");
+            // Otherwise it's download limit
+            const isUpload = (type === "upload");
 
-                        window.parent.qBittorrent.Client.closeFrameWindow(window);
-                    });
-            }
-        };
+            const getLimitMethod = isUpload ? "uploadLimit" : "downloadLimit";
+            const setLimitMethod = isUpload ? "setUploadLimit" : "setDownloadLimit";
 
-        document.getElementById("limitUpdateLabel").textContent =
-            isUpload
-            ? `QBT_TR(Upload limit:)QBT_TR[CONTEXT=SpeedLimit]`
-            : `QBT_TR(Download limit:)QBT_TR[CONTEXT=SpeedLimit]`;
+            const limitUpdateValue = document.getElementById("limitUpdateValue");
+            const limitUnit = document.getElementById("limitUnit");
 
-        fetch(`api/v2/transfer/${getLimitMethod}`, {
-                method: "GET",
-                cache: "no-store"
-            })
-            .then(async (response) => {
-                if (!response.ok)
-                    return;
-
-                const data = await response.text();
-
-                const globalLimit = Math.max((Number(data) / 1024), 0);
-
-                // Get torrents download limit
-                // And create slider
-                if (isGlobal) {
-                    setupSlider(globalLimit, 10000);
+            const setLimitUpdateValue = (value) => {
+                if (value === 0) {
+                    limitUpdateValue.value = "∞";
+                    limitUnit.style.visibility = "hidden";
                 }
                 else {
-                    fetch(`api/v2/torrents/${getLimitMethod}`, {
+                    limitUpdateValue.value = value;
+                    limitUnit.style.visibility = "visible";
+                }
+            };
+
+            const setupSlider = (limit, maximum) => {
+                const input = document.getElementById("limitSliderInput");
+                input.max = maximum;
+                input.value = limit;
+                input.addEventListener("input", (event) => {
+                    setLimitUpdateValue(Number(event.target.value));
+                });
+                // Set default value
+                setLimitUpdateValue(limit);
+            };
+
+            applyButton.addEventListener("click", (event) => {
+                const limit = Number(limitUpdateValue.value) * 1024;
+                if (isGlobal) {
+                    fetch(`api/v2/transfer/${setLimitMethod}`, {
                             method: "POST",
                             body: new URLSearchParams({
-                                hashes: hashes.join("|")
+                                limit: limit
                             })
                         })
-                        .then(async (response) => {
+                        .then((response) => {
                             if (!response.ok)
                                 return;
 
-                            const data = await response.json();
+                            window.parent.updateMainData();
+                            window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        });
+                }
+                else {
+                    fetch(`api/v2/torrents/${setLimitMethod}`, {
+                            method: "POST",
+                            body: new URLSearchParams({
+                                hashes: hashes.join("|"),
+                                limit: limit
+                            })
+                        })
+                        .then((response) => {
+                            if (!response.ok)
+                                return;
 
-                            const firstLimit = Math.max(data[hashes[0]], 0);
-                            const isAllFirstLimit = Object.values(data).every(value => value === firstLimit);
-                            const limit = isAllFirstLimit ? Math.round(firstLimit / 1024) : 0;
-
-                            setupSlider(limit, ((globalLimit > 0) ? globalLimit : 1000));
+                            window.parent.qBittorrent.Client.closeFrameWindow(window);
                         });
                 }
             });
 
-        limitUpdateValue.focus();
+            document.getElementById("limitUpdateLabel").textContent =
+                isUpload
+                ? `QBT_TR(Upload limit:)QBT_TR[CONTEXT=SpeedLimit]`
+                : `QBT_TR(Download limit:)QBT_TR[CONTEXT=SpeedLimit]`;
+
+            fetch(`api/v2/transfer/${getLimitMethod}`, {
+                    method: "GET",
+                    cache: "no-store"
+                })
+                .then(async (response) => {
+                    if (!response.ok)
+                        return;
+
+                    const data = await response.text();
+
+                    const globalLimit = Math.max((Number(data) / 1024), 0);
+
+                    // Get torrents download limit
+                    // And create slider
+                    if (isGlobal) {
+                        setupSlider(globalLimit, 10000);
+                    }
+                    else {
+                        fetch(`api/v2/torrents/${getLimitMethod}`, {
+                                method: "POST",
+                                body: new URLSearchParams({
+                                    hashes: hashes.join("|")
+                                })
+                            })
+                            .then(async (response) => {
+                                if (!response.ok)
+                                    return;
+
+                                const data = await response.json();
+
+                                const firstLimit = Math.max(data[hashes[0]], 0);
+                                const isAllFirstLimit = Object.values(data).every(value => value === firstLimit);
+                                const limit = isAllFirstLimit ? Math.round(firstLimit / 1024) : 0;
+
+                                setupSlider(limit, ((globalLimit > 0) ? globalLimit : 1000));
+                            });
+                    }
+                });
+
+            limitUpdateValue.focus();
+        });
     </script>
 </body>
 

--- a/src/webui/www/private/speedlimit.html
+++ b/src/webui/www/private/speedlimit.html
@@ -7,21 +7,6 @@
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
     <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
     <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
-</head>
-
-<body>
-    <div style="padding-top: 10px; width: 100%; text-align: center; margin: 0 auto; overflow: hidden">
-        <div class="slider">
-            <div class="update">
-                <label id="limitUpdateLabel" for="limitUpdateValue">QBT_TR(Limit:)QBT_TR[CONTEXT=SpeedLimit]</label>
-                <input type="text" id="limitUpdateValue" size="6" placeholder="∞" style="text-align: center;">
-                <span id="limitUnit">QBT_TR(KiB/s)QBT_TR[CONTEXT=SpeedLimit]</span>
-            </div>
-            <input type="range" id="limitSliderInput" min="0" value="0" style="width: 100%;" aria-label="QBT_TR(Speed limit)QBT_TR[CONTEXT=SpeedLimit]">
-        </div>
-        <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]">
-    </div>
-
     <script>
         "use strict";
 
@@ -158,6 +143,20 @@
             limitUpdateValue.focus();
         });
     </script>
+</head>
+
+<body>
+    <div style="padding-top: 10px; width: 100%; text-align: center; margin: 0 auto; overflow: hidden">
+        <div class="slider">
+            <div class="update">
+                <label id="limitUpdateLabel" for="limitUpdateValue">QBT_TR(Limit:)QBT_TR[CONTEXT=SpeedLimit]</label>
+                <input type="text" id="limitUpdateValue" size="6" placeholder="∞" style="text-align: center;">
+                <span id="limitUnit">QBT_TR(KiB/s)QBT_TR[CONTEXT=SpeedLimit]</span>
+            </div>
+            <input type="range" id="limitSliderInput" min="0" value="0" style="width: 100%;" aria-label="QBT_TR(Speed limit)QBT_TR[CONTEXT=SpeedLimit]">
+        </div>
+        <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]">
+    </div>
 </body>
 
 </html>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -10,6 +10,34 @@
     <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
     <script defer src="scripts/download.js?v=${CACHEID}"></script>
     <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script>
+        "use strict";
+
+        window.addEventListener("DOMContentLoaded", (event) => {
+            let submitted = false;
+
+            document.getElementById("uploadForm").addEventListener("submit", (event) => {
+                document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
+
+                document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
+                document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
+
+                document.getElementById("upload_spinner").style.display = "block";
+                submitted = true;
+            });
+
+            document.getElementById("upload_frame").addEventListener("load", (event) => {
+                if (submitted)
+                    window.parent.qBittorrent.Client.closeFrameWindow(window);
+            });
+
+            const userAgent = (navigator.userAgentData?.platform ?? navigator.platform).toLowerCase();
+            if (userAgent.includes("ipad") || userAgent.includes("iphone") || (userAgent.includes("mac") && (navigator.maxTouchPoints > 1)))
+                document.getElementById("fileselect").accept = ".torrent";
+
+            window.qBittorrent.pathAutofill.attachPathAutofill();
+        });
+    </script>
 </head>
 
 <body>
@@ -153,35 +181,6 @@
         </fieldset>
     </form>
     <div id="upload_spinner" class="mochaSpinner"></div>
-
-    <script>
-        "use strict";
-
-        window.addEventListener("DOMContentLoaded", (event) => {
-            let submitted = false;
-
-            document.getElementById("uploadForm").addEventListener("submit", (event) => {
-                document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
-
-                document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
-                document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
-
-                document.getElementById("upload_spinner").style.display = "block";
-                submitted = true;
-            });
-
-            document.getElementById("upload_frame").addEventListener("load", (event) => {
-                if (submitted)
-                    window.parent.qBittorrent.Client.closeFrameWindow(window);
-            });
-
-            const userAgent = (navigator.userAgentData?.platform ?? navigator.platform).toLowerCase();
-            if (userAgent.includes("ipad") || userAgent.includes("iphone") || (userAgent.includes("mac") && (navigator.maxTouchPoints > 1)))
-                document.getElementById("fileselect").accept = ".torrent";
-
-            window.qBittorrent.pathAutofill.attachPathAutofill();
-        });
-    </script>
 </body>
 
 </html>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -6,10 +6,10 @@
     <title>QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
     <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/download.js?v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="scripts/download.js?v=${CACHEID}"></script>
+    <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
 </head>
 
 <body>
@@ -157,28 +157,30 @@
     <script>
         "use strict";
 
-        let submitted = false;
+        window.addEventListener("DOMContentLoaded", (event) => {
+            let submitted = false;
 
-        document.getElementById("uploadForm").addEventListener("submit", (event) => {
-            document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
+            document.getElementById("uploadForm").addEventListener("submit", (event) => {
+                document.getElementById("startTorrentHidden").value = document.getElementById("startTorrent").checked ? "false" : "true";
 
-            document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
-            document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
+                document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
+                document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
 
-            document.getElementById("upload_spinner").style.display = "block";
-            submitted = true;
+                document.getElementById("upload_spinner").style.display = "block";
+                submitted = true;
+            });
+
+            document.getElementById("upload_frame").addEventListener("load", (event) => {
+                if (submitted)
+                    window.parent.qBittorrent.Client.closeFrameWindow(window);
+            });
+
+            const userAgent = (navigator.userAgentData?.platform ?? navigator.platform).toLowerCase();
+            if (userAgent.includes("ipad") || userAgent.includes("iphone") || (userAgent.includes("mac") && (navigator.maxTouchPoints > 1)))
+                document.getElementById("fileselect").accept = ".torrent";
+
+            window.qBittorrent.pathAutofill.attachPathAutofill();
         });
-
-        document.getElementById("upload_frame").addEventListener("load", (event) => {
-            if (submitted)
-                window.parent.qBittorrent.Client.closeFrameWindow(window);
-        });
-
-        const userAgent = (navigator.userAgentData?.platform ?? navigator.platform).toLowerCase();
-        if (userAgent.includes("ipad") || userAgent.includes("iphone") || (userAgent.includes("mac") && (navigator.maxTouchPoints > 1)))
-            document.getElementById("fileselect").accept = ".torrent";
-
-        window.qBittorrent.pathAutofill.attachPathAutofill();
     </script>
 </body>
 


### PR DESCRIPTION
So that the HTML layout can be rendered earlier.
A few inline scripts are moved into `<head>` for consistency.
Also, those scripts needs to wait for `DOMContentLoaded` event.
