### PR TITLE
WebUI: Introduce 'By Shown File Order' priority in WebUI

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -269,6 +269,7 @@
                 <li><a href="#FilePrioNormal"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Normal)QBT_TR[CONTEXT=PropListDelegate]</a></li>
                 <li><a href="#FilePrioHigh"><span style="display: inline-block; width: 16px;"></span> QBT_TR(High)QBT_TR[CONTEXT=PropListDelegate]</a></li>
                 <li><a href="#FilePrioMaximum"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Maximum)QBT_TR[CONTEXT=PropListDelegate]</a></li>
+                <li><a href="#FilePrioByShownOrder"><span style="display: inline-block; width: 16px;"></span> QBT_TR(By shown file order)QBT_TR[CONTEXT=PropListDelegate]</a></li>
             </ul>
         </li>
     </ul>

--- a/src/webui/www/private/scripts/file-tree.js
+++ b/src/webui/www/private/scripts/file-tree.js
@@ -45,7 +45,8 @@ window.qBittorrent.FileTree ??= (() => {
         Normal: 1,
         High: 6,
         Maximum: 7,
-        Mixed: -1
+        Mixed: -1,
+        ByShownOrder: -2
     };
     Object.freeze(FilePriority);
 


### PR DESCRIPTION
Closes #16845 

## Issue summary

There is an open in the context menu of the files panel, that allows assigning priority to the selected files `By Shown File Order`. This option exists in the native/desktop application but is missing from the WebUI interface.

## Summary of changes

Added new priority option and refactored the event that is triggered upon selecting an option.

The "refactored" event is entirely JS code.
The approach I used is supposed to handle both the general case (a single priority for a group of files) and the `By Shown File Order` case (where we determine the priority based on the number of files and their positioning).

We do this by having an object with the value of the `priority` as a key and as value a list of `row_id`/`file_id` pairs. We keep both the `row` & `file` ids because `setFilePriority` wants both of them.

If the change is on one of the "general" priorities (Do Not Download, Normal, High, Maximum) all files/rows go into the same group, otherwise they are distributed by the same logic as in [the desktop application](https://github.com/qbittorrent/qBittorrent/blob/master/src/gui/torrentcontentwidget.cpp#L282)

## How did you test ?

Manually with a torrent containing exactly 10 files. Dont have a larger one at hand atm.