### PR TITLE
WebUI: Restore node default collapse state

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -2733,7 +2733,7 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             if (node.isFolder) {
                 if (!this.collapseState.has(node.rowId))
-                    this.collapseState.set(node.rowId, { depth: depth, collapsed: depth > 0 });
+                    this.collapseState.set(node.rowId, { depth: depth, collapsed: false });
                 const data = {
                     rowId: node.rowId,
                     size: node.size,


### PR DESCRIPTION
By default, nodes should be expanded until explicitly collapsed. This restores the default behavior which changed in b4a16f64641873bd067ab5f6c6d54c0b4c12fdcf.

Relevant: https://github.com/qbittorrent/qBittorrent/pull/21645#discussion_r2150695297