### PR TITLE
WebUI: Delete correct rows after re-sort

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -883,6 +883,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 for (let rowPos = 0; rowPos < rows.length; ++rowPos) {
                     const { rowId } = rows[rowPos];
                     const tr = trMap.get(rowId);
+                    trMap.delete(rowId);
 
                     const isInCorrectLocation = rowId === trs[rowPos]?.rowId;
                     if (!isInCorrectLocation) {
@@ -901,10 +902,8 @@ window.qBittorrent.DynamicTable ??= (() => {
                     prevTr = tr;
                 }
 
-                const rowPos = rows.length;
-
-                while ((rowPos < trs.length) && (trs.length > 0))
-                    trs.pop().remove();
+                for (const tr of trMap.values())
+                    tr.remove();
             }
         }
 


### PR DESCRIPTION
The previous logic assumed that `trs` was properly sorted, which is no longer the case.

Follow up to #22827.