### PR TITLE
Add Backspace as alternative to Delete

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -231,6 +231,9 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
     connect(editHotkey, &QShortcut::activated, this, &TransferListWidget::renameSelectedTorrent);
     const auto *deleteHotkey = new QShortcut(Utils::KeySequence::deleteItem(), this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(deleteHotkey, &QShortcut::activated, this, &TransferListWidget::softDeleteSelectedTorrents);
+    // Declare Backspace as alternative for compact keyboards
+    const auto *deleteHotkeyAlt = new QShortcut(Qt::Key_Backspace, this, nullptr, nullptr, Qt::WidgetShortcut);
+    connect(deleteHotkeyAlt, &QShortcut::activated, this, &TransferListWidget::softDeleteSelectedTorrents);
     const auto *permDeleteHotkey = new QShortcut((Qt::SHIFT | Qt::Key_Delete), this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(permDeleteHotkey, &QShortcut::activated, this, &TransferListWidget::permDeleteSelectedTorrents);
     const auto *doubleClickHotkeyReturn = new QShortcut(Qt::Key_Return, this, nullptr, nullptr, Qt::WidgetShortcut);

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1773,6 +1773,23 @@ window.addEventListener("DOMContentLoaded", (event) => {
                 event.preventDefault();
                 deleteSelectedTorrentsFN(event.shiftKey);
                 break;
+
+            case "Backspace":
+                if ((event.target.nodeName === "INPUT") || (event.target.nodeName === "TEXTAREA"))
+                    return;
+                if (event.target.isContentEditable)
+                    return;
+                event.preventDefault();
+                deleteSelectedTorrentsFN(event.shiftKey);
+                break;
+
+            case "Escape":
+                if (event.target.isContentEditable)
+                    return;
+                event.preventDefault();
+                if (typeof MochaUI.Windows.instances["confirmDeletionPage"] !== "undefined")
+                    MochaUI.Windows.instances["confirmDeletionPage"].close();
+                break;
         }
     });
 


### PR DESCRIPTION
Closes #22861.

If you google `60% keyboard` you will see the type of layout OP is talking about, or if you own a Mac i guess.

* Add backspace as alternative to delete in app/desktop
* Add the same support to WebUI

And this here is an addition that slightly annoyed me before. The desktop behaves as expected, Escape closes the modal without deleting the item. But the WebUI does not respond in anyway to pressing escape after the modal opens.

If you think this part needs its own PR/Issue, just say so, im gonna edit it out of this one.

* Add support for closing delete modal with Escape in WebUI