### PR TITLE
fix: Repair small error in french translation

### DIFF
--- a/src/lang/qbittorrent_fr.ts
+++ b/src/lang/qbittorrent_fr.ts
@@ -9321,7 +9321,7 @@ Ces derniers ont été désactivés.</translation>
     <message>
         <location filename="../gui/search/searchjobwidget.cpp" line="107"/>
         <source>Published On</source>
-        <translation>Publié sur</translation>
+        <translation>Publié le</translation>
     </message>
     <message>
         <location filename="../gui/search/searchjobwidget.cpp" line="548"/>


### PR DESCRIPTION
This PR fixes a very small translation error in French.

`Published On` → ~~Publié sur~~ → Publié **le**

Could also be translated with "Date de publication"

Source: I am a native French speaker.