### PR TITLE
WebUI: Add option to display tracker icons

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -425,6 +425,18 @@ void Preferences::setPreventFromSuspendWhenSeeding(const bool b)
     setValue(u"Preferences/General/PreventFromSuspendWhenSeeding"_s, b);
 }
 
+bool Preferences::isDownloadTrackerFavicon() const
+{
+    return value(u"Preferences/General/DownloadTrackerFavicon"_s, true);
+}
+
+void Preferences::setDownloadTrackerFavicon(const bool value)
+{
+    if (value == isDownloadTrackerFavicon())
+        return;
+    setValue(u"Preferences/General/DownloadTrackerFavicon"_s, value);
+}
+
 #ifdef Q_OS_WIN
 bool Preferences::WinStartup() const
 {

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -274,6 +274,8 @@ public:
     void setAutoRunOnTorrentFinishedEnabled(bool enabled);
     QString getAutoRunOnTorrentFinishedProgram() const;
     void setAutoRunOnTorrentFinishedProgram(const QString &program);
+    bool isDownloadTrackerFavicon() const;
+    void setDownloadTrackerFavicon(bool enabled);
 #if defined(Q_OS_WIN)
     bool isAutoRunConsoleEnabled() const;
     void setAutoRunConsoleEnabled(bool enabled);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -328,7 +328,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     // Reannounce to all trackers when ip/port changed
     session->setReannounceWhenAddressChangedEnabled(m_checkBoxReannounceWhenAddressChanged.isChecked());
     // Misc GUI properties
-    app()->mainWindow()->setDownloadTrackerFavicon(m_checkBoxTrackerFavicon.isChecked());
+    pref->setDownloadTrackerFavicon(m_checkBoxTrackerFavicon.isChecked());
     pref->setAddNewTorrentDialogSavePathHistoryLength(m_spinBoxSavePathHistoryLength.value());
     pref->setSpeedWidgetEnabled(m_checkBoxSpeedWidgetEnabled.isChecked());
 #ifndef Q_OS_MACOS
@@ -854,7 +854,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_checkBoxReannounceWhenAddressChanged.setChecked(session->isReannounceWhenAddressChangedEnabled());
     addRow(REANNOUNCE_WHEN_ADDRESS_CHANGED, tr("Reannounce to all trackers when IP or port changed"), &m_checkBoxReannounceWhenAddressChanged);
     // Download tracker's favicon
-    m_checkBoxTrackerFavicon.setChecked(app()->mainWindow()->isDownloadTrackerFavicon());
+    m_checkBoxTrackerFavicon.setChecked(pref->isDownloadTrackerFavicon());
     addRow(DOWNLOAD_TRACKER_FAVICON, tr("Download tracker's favicon"), &m_checkBoxTrackerFavicon);
     // Save path history length
     m_spinBoxSavePathHistoryLength.setRange(0, 99);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -196,7 +196,7 @@ private:
     void displaySearchTab(bool enable);
     void createTorrentTriggered(const Path &path);
     void showStatusBar(bool show);
-    void showFiltersSidebar(bool show);
+    void showFiltersSidebar(bool show, bool showTrackerFavicon);
     void applyTransferListFilter();
     void refreshWindowTitle();
     void refreshTrayIconTooltip();
@@ -250,7 +250,6 @@ private:
     QMenu *m_toolbarMenu = nullptr;
 
     SettingValue<bool> m_storeExecutionLogEnabled;
-    SettingValue<bool> m_storeDownloadTrackerFavicon;
     CachedSettingValue<Log::MsgTypes> m_storeExecutionLogTypes;
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -410,6 +410,8 @@ void AppController::preferencesAction()
     data[u"ignore_ssl_errors"_s] = pref->isIgnoreSSLErrors();
     // Python executable path
     data[u"python_executable_path"_s] = pref->getPythonExecutablePath().toString();
+    // Should we show Tracker's Favicon
+    data[u"show_tracker_favicon"_s] = pref->isDownloadTrackerFavicon();
 
     // libtorrent preferences
     // Bdecode depth limit
@@ -1023,6 +1025,8 @@ void AppController::setPreferencesAction()
     // Reannounce to all trackers when ip/port changed
     if (hasKey(u"reannounce_when_address_changed"_s))
         session->setReannounceWhenAddressChangedEnabled(it.value().toBool());
+    if (hasKey(u"show_tracker_favicon"_s))
+        pref->setDownloadTrackerFavicon(it.value().toBool());
     // Embedded tracker
     if (hasKey(u"embedded_tracker_port"_s))
         pref->setTrackerPort(it.value().toInt());

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -487,7 +487,7 @@ void WebApplication::configure()
     const QString contentSecurityPolicy =
         (m_isAltUIUsed
             ? QString()
-            : u"default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self'; frame-src 'self' blob:;"_s)
+            : u"default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self'; frame-src 'self' blob:;"_s)
         + (isClickjackingProtectionEnabled ? u" frame-ancestors 'self';"_s : QString())
         + (m_isHttpsEnabled ? u" upgrade-insecure-requests;"_s : QString());
     if (!contentSecurityPolicy.isEmpty())

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -702,6 +702,18 @@ window.addEventListener("DOMContentLoaded", (event) => {
                 case TRACKERS_WARNING:
                     span.lastElementChild.src = "images/tracker-warning.svg";
                     break;
+                default: {
+                    if (LocalPreferences.get("show_tracker_favicon", "false") === "false")
+                        break;
+                    const link = host.split(".").slice(1).join(".");
+                    const img = trackerFilterItem.getElementsByTagName("img")[0];
+
+                    img.src = `https://${link}/favicon.ico`;
+                    img.onerror = () => {
+                        img.src = "images/trackers.svg";
+                    };
+                    break;
+                }
             }
 
             return trackerFilterItem;

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -60,7 +60,7 @@
 <template id="trackerFilterItem">
     <li class="trackersFilterContextMenuTarget">
         <span class="link">
-            <img src="images/trackers.svg" alt="">
+            <img src="images/trackers.svg" alt="" referrerpolicy="no-referrer">
         </span>
     </li>
 </template>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1264,6 +1264,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 </tr>
                 <tr>
                     <td>
+                        <label for="showTrackerFavicon">QBT_TR(Show tracker favicon in torrent list:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="showTrackerFavicon">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <label for="enableEmbeddedTracker">QBT_TR(Enable embedded tracker:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
@@ -2597,6 +2605,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("markOfTheWeb").checked = pref.mark_of_the_web;
                     document.getElementById("ignoreSSLErrors").checked = pref.ignore_ssl_errors;
                     document.getElementById("pythonExecutablePath").value = pref.python_executable_path;
+                    document.getElementById("showTrackerFavicon").checked = pref.show_tracker_favicon;
                     // libtorrent section
                     document.getElementById("bdecodeDepthLimit").value = pref.bdecode_depth_limit;
                     document.getElementById("bdecodeTokenLimit").value = pref.bdecode_token_limit;
@@ -3069,6 +3078,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["refresh_interval"] = Number(document.getElementById("refreshInterval").value);
             settings["resolve_peer_countries"] = document.getElementById("resolvePeerCountries").checked;
             settings["reannounce_when_address_changed"] = document.getElementById("reannounceWhenAddressChanged").checked;
+            settings["show_tracker_favicon"] = document.getElementById("showTrackerFavicon").checked;
+            LocalPreferences.set("show_tracker_favicon", settings["show_tracker_favicon"].toString());
             settings["enable_embedded_tracker"] = document.getElementById("enableEmbeddedTracker").checked;
             settings["embedded_tracker_port"] = Number(document.getElementById("embeddedTrackerPort").value);
             settings["embedded_tracker_port_forwarding"] = document.getElementById("embeddedTrackerPortForwarding").checked;


### PR DESCRIPTION
Closes #18982.

## Summary of issue

QT app has a setting (turned *ON* by default) which downloads (into `/tmp`) the favicons of the trackers. This feature is missing from the WebUI where every trackes uses the same default `svg`.

## Summary of Changes

Previously the setting was loaded only for `MainWindow`, unlike other preferences that are saved/loaded from the `preference.*` files. I've created the required methods in `preference.*` and removed the other ones used before.

This in turn allows us to expose this preference to the WebUI.

After that we apply a similar logic to the C++ retrieval, as we remove the "subdomain" (`tracker.`) and create an `img` element with the supposed favicon address. To the `img` we attach a `onerror` handler in order to be able to add the default `svg` if the fetch fails.

## Can this be made only for WebUI and not change server code ?

Sure, im lost as to which preferences we expose from server and which we have only in WebUI. So if you think it should not alter the server code it can be done.

## Notes
### Change in CSP
`img: https:` was added to the CSP, in case you think it might expose some/any security issues. Hopefully the `nosniff` will not allow the icon to be interpreted as anything other than an image.

### Images might take a second to load
I notice a lag on the first opening of WebUI, the page is responsive and all but the lag is that the trackers need a few seconds in order to populate with either their favicons or the default svg.
(`picture` element from HTML5 had support for multiple sources :thinking: )

### My vision of best approach
It crossed my mind that all the info about the trackers could be passed back to the WebUI with the same request that loads the trackers, but after seeing that the downloaded image file [gets assigned to a QT object](https://github.com/qbittorrent/qBittorrent/blob/master/src/gui/transferlistfilters/trackersfilterwidget.cpp#L579) I got kinda discouraged. Not sure how to map icon to tracker in this implementation. In any case, if you think changing some of the core logic in order to allow the `tracker` to have its own icon (not bound to a `QListWidgetItem`) im willing to look into it.