### PR TITLE
WebUI: Improve search page experience on mobile

### DIFF
--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -1,6 +1,6 @@
 <style>
     #searchPattern {
-        width: 300px;
+        width: 180px;
         background-image: url("images/edit-find.svg");
         background-repeat: no-repeat;
         background-size: 1.5em;
@@ -70,6 +70,25 @@
         margin: 0 5px -3px 0;
     }
 
+    #searchResultsHeader {
+        height: 60px;
+        overflow: hidden;
+    }
+
+    #searchResultsHeaderContainer {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px;
+        margin-top: 4px;
+        height: 24px;
+    }
+
+    @media (min-width: 760px) {
+        #searchPattern {
+            width: 300px;
+        }
+    }
+
     @media (min-width: 1060px) {
         #searchResultsGranularFilters {
             display: inline-block;
@@ -82,13 +101,17 @@
         #searchPattern {
             width: 500px;
         }
+
+        #searchResultsHeaderContainer {
+            margin: 20px 0 10px 0;
+        }
     }
 
 </style>
 
 <div id="searchResults">
-    <div style="overflow: hidden; height: 60px;">
-        <div style="display: flex; flex-wrap: wrap; gap: 5px; margin: 20px 0 10px 0; height: 24px;">
+    <div id="searchResultsHeader">
+        <div id="searchResultsHeaderContainer">
             <input type="search" id="searchPattern" class="searchInputField" placeholder="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" aria-label="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocomplete="off" autocapitalize="none" oninput="qBittorrent.Search.onSearchPatternChanged()">
             <select id="categorySelect" class="searchInputField" aria-label="QBT_TR(Select category)QBT_TR[CONTEXT=SearchEngineWidget]" onchange="qBittorrent.Search.categorySelected()"></select>
             <select id="pluginsSelect" class="searchInputField" aria-label="QBT_TR(Select plugins)QBT_TR[CONTEXT=SearchEngineWidget]" onchange="qBittorrent.Search.pluginSelected()"></select>


### PR DESCRIPTION
This change better handles resizing of elements on the search page to ensure no controls are hidden at typical mobile screen sizes.

Improvements seen below:
- "Search" button is now accessible
- Content no longer overflows w/ "Search plugins..." button pushed offscreen
- Tabs overflow horizontally and are scrollable, rather than pushing down the search results table

After: (including the changes from #22914 and #22915)
![IMG_9561](https://github.com/user-attachments/assets/9cd89465-1a2d-471c-8b70-e0ecb352c299)


Before:
![IMG_9558](https://github.com/user-attachments/assets/479a269b-471e-4b3d-9857-404c7be24c72)
