### PR TITLE
WebUI: Make footer scrollable on mobile

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -276,9 +276,9 @@
         <li><a href="#ToggleSelection"><img src="images/edit-rename.svg" alt="QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
     </ul>
     <div id="desktopFooterWrapper">
-        <div id="desktopFooter">
+        <div id="desktopFooter" style="overflow-x: auto;">
             <span id="error_div"></span>
-            <table style="position: absolute; right: 5px;">
+            <table style="margin-right: 5px; width: max-content;">
                 <tbody>
                     <tr>
                         <td id="freeSpaceOnDisk"></td>


### PR DESCRIPTION
The window footer can now be scrolled.

![Screenshot 2025-06-24 at 21 45 12](https://github.com/user-attachments/assets/2c8fe62d-69ab-496d-ba95-517ed888c9dc)

Closes #21541