### PR TITLE
WebUI: Allow closing dialogs with Escape key

### DIFF
--- a/src/webui/www/private/confirmfeeddeletion.html
+++ b/src/webui/www/private/confirmfeeddeletion.html
@@ -11,6 +11,14 @@
         "use strict";
 
         window.addEventListener("DOMContentLoaded", (event) => {
+            window.addEventListener("keydown", (event) => {
+                switch (event.key) {
+                    case "Escape":
+                        event.preventDefault();
+                        window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        break;
+                }
+            });
             document.getElementById("cancelBtn").focus();
             document.getElementById("cancelBtn").addEventListener("click", (e) => {
                 e.preventDefault();

--- a/src/webui/www/private/confirmfeeddeletion.html
+++ b/src/webui/www/private/confirmfeeddeletion.html
@@ -19,6 +19,7 @@
                         break;
                 }
             });
+
             document.getElementById("cancelBtn").focus();
             document.getElementById("cancelBtn").addEventListener("click", (e) => {
                 e.preventDefault();

--- a/src/webui/www/private/confirmruleclear.html
+++ b/src/webui/www/private/confirmruleclear.html
@@ -11,6 +11,14 @@
         "use strict";
 
         window.addEventListener("DOMContentLoaded", (event) => {
+            window.addEventListener("keydown", (event) => {
+                switch (event.key) {
+                    case "Escape":
+                        event.preventDefault();
+                        window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        break;
+                }
+            });
             document.getElementById("cancelBtn").focus();
             document.getElementById("cancelBtn").addEventListener("click", (e) => {
                 e.preventDefault();

--- a/src/webui/www/private/confirmruleclear.html
+++ b/src/webui/www/private/confirmruleclear.html
@@ -19,6 +19,7 @@
                         break;
                 }
             });
+
             document.getElementById("cancelBtn").focus();
             document.getElementById("cancelBtn").addEventListener("click", (e) => {
                 e.preventDefault();

--- a/src/webui/www/private/confirmruledeletion.html
+++ b/src/webui/www/private/confirmruledeletion.html
@@ -11,6 +11,14 @@
         "use strict";
 
         window.addEventListener("DOMContentLoaded", (event) => {
+            window.addEventListener("keydown", (event) => {
+                switch (event.key) {
+                    case "Escape":
+                        event.preventDefault();
+                        window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        break;
+                }
+            });
             document.getElementById("cancelBtn").focus();
             document.getElementById("cancelBtn").addEventListener("click", (e) => {
                 e.preventDefault();

--- a/src/webui/www/private/confirmruledeletion.html
+++ b/src/webui/www/private/confirmruledeletion.html
@@ -19,6 +19,7 @@
                         break;
                 }
             });
+
             document.getElementById("cancelBtn").focus();
             document.getElementById("cancelBtn").addEventListener("click", (e) => {
                 e.preventDefault();

--- a/src/webui/www/private/confirmtrackerdeletion.html
+++ b/src/webui/www/private/confirmtrackerdeletion.html
@@ -11,6 +11,14 @@
         "use strict";
 
         window.addEventListener("DOMContentLoaded", (event) => {
+            window.addEventListener("keydown", (event) => {
+                switch (event.key) {
+                    case "Escape":
+                        event.preventDefault();
+                        window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        break;
+                }
+            });
             const searchParams = new URLSearchParams(window.location.search);
             const host = searchParams.get("host");
 

--- a/src/webui/www/private/confirmtrackerdeletion.html
+++ b/src/webui/www/private/confirmtrackerdeletion.html
@@ -19,6 +19,7 @@
                         break;
                 }
             });
+
             const searchParams = new URLSearchParams(window.location.search);
             const host = searchParams.get("host");
 

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -22,6 +22,7 @@
                         break;
                 }
             });
+
             const encodedUrls = new URLSearchParams(window.location.search).get("urls");
             if (encodedUrls !== null) {
                 const urls = encodedUrls.split("|").map(decodeURIComponent);

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -14,6 +14,14 @@
         "use strict";
 
         window.addEventListener("DOMContentLoaded", (event) => {
+            window.addEventListener("keydown", (event) => {
+                switch (event.key) {
+                    case "Escape":
+                        event.preventDefault();
+                        window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        break;
+                }
+            });
             const encodedUrls = new URLSearchParams(window.location.search).get("urls");
             if (encodedUrls !== null) {
                 const urls = encodedUrls.split("|").map(decodeURIComponent);

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1777,17 +1777,18 @@ window.addEventListener("DOMContentLoaded", (event) => {
             case "Escape": {
                 if (event.target.isContentEditable)
                     return;
+
                 event.preventDefault();
                 const modalInstances = Object.values(MochaUI.Windows.instances);
                 if (modalInstances.length <= 0)
                     return;
+
                 // MochaUI.currentModal does not update after a modal is closed
                 const focusedModal = modalInstances.find((modal) => {
                     return modal.windowEl.hasClass("isFocused");
                 });
-                if (!focusedModal)
-                    return;
-                focusedModal.close();
+                if (focusedModal !== undefined)
+                    focusedModal.close();
                 break;
             }
 
@@ -1815,6 +1816,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
                         torrentsFilterElem.focus();
                     }
                 }
+                break;
         }
     });
 

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1774,6 +1774,15 @@ window.addEventListener("DOMContentLoaded", (event) => {
                 deleteSelectedTorrentsFN(event.shiftKey);
                 break;
 
+            case "Escape":
+                if (event.target.isContentEditable)
+                    return;
+                event.preventDefault();
+                Object.values(MochaUI.Windows.instances).forEach((modal) => {
+                    modal.close();
+                });
+                break;
+
             case "f":
             case "F":
                 if (event.ctrlKey || event.metaKey) {
@@ -1798,7 +1807,6 @@ window.addEventListener("DOMContentLoaded", (event) => {
                         torrentsFilterElem.focus();
                     }
                 }
-                break;
         }
     });
 

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1782,11 +1782,12 @@ window.addEventListener("DOMContentLoaded", (event) => {
                 if (modalInstances.length <= 0)
                     return;
                 // MochaUI.currentModal does not update after a modal is closed
-                // use `timestamp` for sequential closing
-                const latestModal = modalInstances.reduce((prev, curr) => {
-                    return (prev.timestamp > curr.timestamp) ? prev : curr;
+                const focusedModal = modalInstances.find((modal) => {
+                    return modal.windowEl.hasClass("isFocused");
                 });
-                latestModal.close();
+                if (!focusedModal)
+                    return;
+                focusedModal.close();
                 break;
             }
 

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1774,14 +1774,21 @@ window.addEventListener("DOMContentLoaded", (event) => {
                 deleteSelectedTorrentsFN(event.shiftKey);
                 break;
 
-            case "Escape":
+            case "Escape": {
                 if (event.target.isContentEditable)
                     return;
                 event.preventDefault();
-                Object.values(MochaUI.Windows.instances).forEach((modal) => {
-                    modal.close();
+                const modalInstances = Object.values(MochaUI.Windows.instances);
+                if (modalInstances.length <= 0)
+                    return;
+                // MochaUI.currentModal does not update after a modal is closed
+                // use `timestamp` for sequential closing
+                const latestModal = modalInstances.reduce((prev, curr) => {
+                    return (prev.timestamp > curr.timestamp) ? prev : curr;
                 });
+                latestModal.close();
                 break;
+            }
 
             case "f":
             case "F":

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -14,6 +14,15 @@
         "use strict";
 
         window.addEventListener("DOMContentLoaded", (event) => {
+            window.addEventListener("keydown", (event) => {
+                switch (event.key) {
+                    case "Escape":
+                        event.preventDefault();
+                        window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        break;
+                }
+            });
+
             let submitted = false;
 
             document.getElementById("uploadForm").addEventListener("submit", (event) => {


### PR DESCRIPTION
Closes [#13891](https://github.com/qbittorrent/qBittorrent/issues/13891)

Tested on the following WebUI Modals:

1. Delete
2. Rename files
3. Settings
4. About
5. Statistics
6. Add torrent

Pressing Escape without an active modal/dialog should not do anything, in my tests it did not, but i might have missed some strange cases. If any such is reported, im gonna can care of it.