### PR TITLE
Make qBittorrent quit on MacOS with main window closed

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1163,7 +1163,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
     if (!m_forceExit)
     {
         hide();
-        e->accept();
+        e->ignore();
         return;
     }
 #else


### PR DESCRIPTION
Fixes the reported bug that you couldn't quit qBittorrent when the main window was closed on MacOS.
Closes https://github.com/qbittorrent/qBittorrent/issues/22849.
