### PR TITLE
Use proper capitalization for MSVC linker flags

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -121,7 +121,7 @@ jobs:
             ${{ env.libtorrent_path }}
           cd ${{ env.libtorrent_path }}
           $env:CXXFLAGS+=" /guard:cf"
-          $env:LDFLAGS+=" /guard:cf"
+          $env:LDFLAGS+=" /GUARD:CF"
           cmake `
             -B build `
             -G "Ninja" `

--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -89,7 +89,7 @@ if (MSVC)
         /Zc:__cplusplus
     )
     target_link_options(qbt_common_cfg INTERFACE
-        /guard:cf
+        /GUARD:CF
         $<$<NOT:$<CONFIG:Debug>>:/OPT:REF /OPT:ICF>
         # suppress linking warning due to /INCREMENTAL and /OPT:ICF being both ON
         $<$<CONFIG:RelWithDebInfo>:/INCREMENTAL:NO>


### PR DESCRIPTION
The linker flags are case insensitive [1] but it would be better to use the proper capitalization [2].

[1] https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#command-line
[2] https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-guard-checks?view=msvc-170
