### PR TITLE
Add AppStream metadata for qbt-nox

### DIFF
--- a/dist/unix/CMakeLists.txt
+++ b/dist/unix/CMakeLists.txt
@@ -34,12 +34,12 @@ endforeach()
 
 if (GUI)
     install(FILES org.qbittorrent.qBittorrent.desktop
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
         COMPONENT data
     )
 
     install(FILES org.qbittorrent.qBittorrent.metainfo.xml
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo/
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
         COMPONENT data
     )
 
@@ -53,6 +53,11 @@ if (GUI)
         ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-dark.svg
         ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-light.svg
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status
+        COMPONENT data
+    )
+else()
+    install(FILES org.qbittorrent.qBittorrent-nox.metainfo.xml
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
         COMPONENT data
     )
 endif()

--- a/dist/unix/org.qbittorrent.qBittorrent-nox.metainfo.xml
+++ b/dist/unix/org.qbittorrent.qBittorrent-nox.metainfo.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 sledgehammer999 <sledgehammer999@qbittorrent.org> -->
+<component type="console-application">
+  <id>org.qbittorrent.qBittorrent-nox</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later and OpenSSL</project_license>
+  <name>qBittorrent-nox</name>
+  <summary>An open-source Bittorrent client (nox version)</summary>
+  <description>
+    <p>
+      The qBittorrent project aims to provide an open-source software alternative to µTorrent.
+      Additionally, qBittorrent runs and provides the same features on all major platforms (FreeBSD, Linux, macOS, OS/2, Windows).
+      qBittorrent is based on the Qt toolkit and libtorrent-rasterbar library.
+    </p>
+    <ul>
+      <li>Polished µTorrent-like User Interface</li>
+      <li>Well-integrated and extensible Search Engine</li>
+      <li>RSS feed support with advanced download filters (incl. regex)</li>
+      <li>Many Bittorrent extensions supported</li>
+      <li>Remote control through Web user interface, written with AJAX</li>
+      <li>Sequential downloading (Download in order)</li>
+      <li>Advanced control over torrents, trackers and peers</li>
+      <li>Bandwidth scheduler</li>
+      <li>Torrent creation tool</li>
+      <li>IP Filtering (eMule &amp; PeerGuardian format compatible)</li>
+      <li>IPv6 compliant</li>
+      <li>UPnP / NAT-PMP port forwarding support</li>
+      <li>Available on all platforms: Windows, Linux, macOS, FreeBSD, OS/2</li>
+      <li>Available in ~70 languages</li>
+    </ul>
+  </description>
+  <provides>
+    <binary>qbittorrent-nox</binary>
+  </provides>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Running headless (nox) version</caption>
+      <image>https://raw.githubusercontent.com/qbittorrent/qBittorrent-website/43fcf4550f567c38fb879b984922b659e90982cc/src/img/screenshots/linux/5.webp</image>
+    </screenshot>
+  </screenshots>
+  <update_contact>sledgehammer999@qbittorrent.org</update_contact>
+  <developer id="org.qbittorrent">
+    <name>The qBittorrent Project</name>
+  </developer>
+  <url type="homepage">https://www.qbittorrent.org/</url>
+  <url type="bugtracker">https://bugs.qbittorrent.org/</url>
+  <url type="faq">https://wiki.qbittorrent.org/Frequently-Asked-Questions</url>
+  <url type="help">https://forum.qbittorrent.org/</url>
+  <url type="donation">https://www.qbittorrent.org/donate</url>
+  <url type="translate">https://wiki.qbittorrent.org/How-to-translate-qBittorrent</url>
+  <url type="vcs-browser">https://github.com/qbittorrent/qBittorrent</url>
+  <url type="contribute">https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md</url>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="5.2.0~alpha1" date="2025-02-11"/>
+  </releases>
+</component>


### PR DESCRIPTION
Also trim redundant trailing path separators.

Ref: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-ConsoleApplication.html
