### PR TITLE
Add fallback to update mechanism

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1662,11 +1662,11 @@ void MainWindow::handleUpdateCheckFinished(ProgramUpdater *updater, const bool i
         updater->deleteLater();
     };
 
-    const QString newVersion = updater->getNewVersion();
-    if (!newVersion.isEmpty())
+    const auto newVersion = updater->getNewVersion();
+    if (newVersion.isValid())
     {
         const QString msg {tr("A new version is available.") + u"<br/>"
-            + tr("Do you want to download %1?").arg(newVersion) + u"<br/><br/>"
+            + tr("Do you want to download %1?").arg(newVersion.toString()) + u"<br/><br/>"
             + u"<a href=\"https://www.qbittorrent.org/news\">%1</a>"_s.arg(tr("Open changelog..."))};
         auto *msgBox = new QMessageBox {QMessageBox::Question, tr("qBittorrent Update Available"), msg
             , (QMessageBox::Yes | QMessageBox::No), this};

--- a/src/gui/programupdater.h
+++ b/src/gui/programupdater.h
@@ -30,8 +30,9 @@
 #pragma once
 
 #include <QObject>
-#include <QString>
 #include <QUrl>
+
+#include "base/utils/version.h"
 
 namespace Net
 {
@@ -45,9 +46,10 @@ class ProgramUpdater final : public QObject
 
 public:
     using QObject::QObject;
+    using Version = Utils::Version<4, 3>;
 
     void checkForUpdates() const;
-    QString getNewVersion() const;
+    Version getNewVersion() const;
     bool updateProgram() const;
 
 signals:
@@ -62,7 +64,7 @@ private:
     bool shouldUseFallback() const;
 
     mutable bool m_hasCompletedOneReq = false;
-    QString m_remoteVersion;
-    QString m_fallbackRemoteVersion;
+    Version m_remoteVersion;
+    Version m_fallbackRemoteVersion;
     QUrl m_updateURL;
 };

--- a/src/gui/programupdater.h
+++ b/src/gui/programupdater.h
@@ -55,8 +55,14 @@ signals:
 
 private slots:
     void rssDownloadFinished(const Net::DownloadResult &result);
+    void fallbackDownloadFinished(const Net::DownloadResult &result);
 
 private:
-    QString m_newVersion;
+    void handleFinishedRequest();
+    bool shouldUseFallback() const;
+
+    mutable bool m_hasCompletedOneReq = false;
+    QString m_remoteVersion;
+    QString m_fallbackRemoteVersion;
     QUrl m_updateURL;
 };


### PR DESCRIPTION
This brings a fallback version check to the update mechanism, which should be as stable as it can be.
It will allow migrating to another primary mechanism without having to have updated the older primary mechanism too.

In case that the primary and fallback mechanism become out of sync, the fallback mechanism wins. In this case when the user chooses to download the new update, qbt will launch our download page in their browser.

It seems that login to fosshub is not possible at this moment. So I opt to introduce this mechanism as soon as possible in order to minimize the number of users that aren't going to get informed about new version going forward.
At some later point, I'll change the primary mechanism too.
