### PR TITLE
Reannounce DHT when reannouncing all trackers

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -649,7 +649,10 @@ void TransferListWidget::recheckSelectedTorrents()
 void TransferListWidget::reannounceSelectedTorrents()
 {
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
+    {
         torrent->forceReannounce();
+        torrent->forceDHTAnnounce();
+    }
 }
 
 int TransferListWidget::visibleColumnsCount() const

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1171,9 +1171,7 @@ void TorrentsController::editTrackerAction()
         throw APIError(APIErrorType::Conflict, u"Tracker not found"_s);
 
     torrent->replaceTrackers(entries);
-
-    if (!torrent->isStopped())
-        torrent->forceReannounce();
+    torrent->forceReannounce();
 
     setResult(QString());
 }

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1620,7 +1620,11 @@ void TorrentsController::reannounceAction()
     requireParams({u"hashes"_s});
 
     const QStringList hashes {params()[u"hashes"_s].split(u'|')};
-    applyToTorrents(hashes, [](BitTorrent::Torrent *const torrent) { torrent->forceReannounce(); });
+    applyToTorrents(hashes, [](BitTorrent::Torrent *const torrent)
+    {
+        torrent->forceReannounce();
+        torrent->forceDHTAnnounce();
+    });
 
     setResult(QString());
 }


### PR DESCRIPTION
This matches the behavior exhibited by `TrackerListWidget` when reannouncing to a torrent's complete tracker list.

I noticed this discrepancy when investing adding individual tracker reannounce support to the WebUI/WebAPI.