### PR TITLE
Fix system language autodetection on MacOS

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -94,7 +94,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         string(REPLACE ".ts" ".lproj" LPROJ_FOLDER "${LPROJ_FOLDER}")
         # @ is not valid as a language code for a lproj folder on MacOS
         string(REPLACE "@" "-" LPROJ_FOLDER "${LPROJ_FOLDER}")
-        add_custom_command( TARGET qbt_app POST_BUILD
+        add_custom_command(TARGET qbt_app POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E make_directory
             "$<TARGET_FILE_DIR:qbt_app>/../Resources/${LPROJ_FOLDER}"
         )


### PR DESCRIPTION
Due to a change in MacOS Qlocale returns always english, when there are no language lproj folders in the app bundle. So the program would always start in english no matter what your system language is. This pr adds this folders so Qlocale returns the correct system language. Because of this change the program can detect the system language and, when a translation is available, the program starts in the correct language. The lproj folders are added to the Ressources folder in the app bundle. If new translations are added the corresponding lproj folders should be added for the new languages so that autodetection works for the new translations too. Bugreports in qt about this issue:

https://bugreports.qt.io/browse/QTBUG-72491
https://bugreports.qt.io/browse/QTBUG-63324

legalnotice in different languages on the first start so autodetection works now

German:
<img width="298" alt="German legalnotice" src="https://github.com/user-attachments/assets/424dd64d-cfee-47a3-81c2-68ac2bca3c0d" />

Japanese:
<img width="259" alt="Japanese legalnotice" src="https://github.com/user-attachments/assets/9f4a8124-a231-45e5-b5ac-2ad7d4fa091d" />

English:
<img width="258" alt="English legalnotice" src="https://github.com/user-attachments/assets/e9954bd9-2719-4c32-8518-7a2b558a6e4b" />
