### PR TITLE
Modify `CategoryOptions` serialization to JSON

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,5 +1,10 @@
 # WebAPI Changelog
 
+## 2.11.10
+
+* [#22932](https://github.com/qbittorrent/qBittorrent/pull/22932)
+  * `torrents/categories` and `sync/maindata` now serialize categories' `downloadPath` to `null`, rather than `undefined`
+
 ## 2.11.9
 
 * [#21015](https://github.com/qbittorrent/qBittorrent/pull/21015)

--- a/src/base/bittorrent/categoryoptions.cpp
+++ b/src/base/bittorrent/categoryoptions.cpp
@@ -52,7 +52,7 @@ BitTorrent::CategoryOptions BitTorrent::CategoryOptions::fromJSON(const QJsonObj
 
 QJsonObject BitTorrent::CategoryOptions::toJSON() const
 {
-    QJsonValue downloadPathValue = QJsonValue::Undefined;
+    QJsonValue downloadPathValue = QJsonValue::Null;
     if (downloadPath)
     {
         if (downloadPath->enabled)

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -53,7 +53,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 11, 9};
+inline const Utils::Version<3, 2> API_VERSION {2, 11, 10};
 
 class APIController;
 class AuthController;


### PR DESCRIPTION
When a category's download path option is set to "Default", its `downloadPath` is serialized into JSON as `undefined`. This results in the `downloadPath` field being omitted from `torrents/categories` and `torrents/maindata` payloads (as is expected with an `undefined` value).

The use of `undefined` here causes an issue in the WebUI. Specifically, when the category previously contained a value for this field (i.e. download path option set to either "Yes" or "No"), the `processMap` logic in `SyncController` does not detect the removal this field. This results in the category's new `downloadPath` not being properly sent to the client. By switching from `undefined` to `null`, we ensure that the `downloadPath` value is always included in the category's payload. This allows `processMap` to properly detect whenever the value changes.

This change is backwards compatible with existing categories.json files. Older qBittorrent versions should also be able to parse new categories.json files containing `null`.

More context: https://github.com/qbittorrent/qBittorrent/pull/22938/commits/cd3fbfbf9b63a42f1d4d9d48d0c2d20a5c1a4b28#r2173148696