### PR TITLE
WebUI: Support editing tracker tier

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -6,6 +6,10 @@
     * `endpoints` is an array of tracker endpoints, each with `name`, `updating`, `status`, `msg`, `bt_version`, `num_peers`, `num_peers`, `num_leeches`, `num_downloaded`, `next_announce` and `min_announce` fields
   *  `torrents/trackers` now returns `5` and `6` in `status` field as possible values
     * `5` for `Tracker error` and `6` for `Unreachable`
+* [#22963](https://github.com/qbittorrent/qBittorrent/pull/22963)
+  * `torrents/editTracker` endpoint now supports setting a tracker's tier via `tier` parameter
+  * `torrents/editTracker` endpoint always responds with a 204 when successful
+  * `torrents/editTracker` endpoint `origUrl` parameter renamed to `url`
 
 ## 2.12.1
 * [#23031](https://github.com/qbittorrent/qBittorrent/pull/23031)

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1273,7 +1273,7 @@ void TorrentsController::addPeersAction()
     }
 
     if (peerList.isEmpty())
-        throw APIError(APIErrorType::BadParams, u"No valid peers were specified"_s);
+        throw APIError(APIErrorType::BadParams, tr("No valid peers were specified"));
 
     QJsonObject results;
 

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -26,9 +26,11 @@
 
             const searchParams = new URLSearchParams(window.location.search);
             const currentUrl = searchParams.get("url");
-            if (currentUrl === null)
+            const currentTier = searchParams.get("tier");
+            if ((currentUrl === null) || (currentTier === null))
                 return;
 
+            document.getElementById("trackerTier").value = currentTier;
             document.getElementById("trackerUrl").value = currentUrl;
             document.getElementById("trackerUrl").focus();
 
@@ -41,7 +43,8 @@
                         body: new URLSearchParams({
                             hash: searchParams.get("hash"),
                             url: currentUrl,
-                            newUrl: document.getElementById("trackerUrl").value
+                            newUrl: document.getElementById("trackerUrl").value,
+                            tier: document.getElementById("trackerTier").value
                         })
                     })
                     .then((response) => {
@@ -61,6 +64,11 @@
         <label for="trackerUrl">QBT_TR(Tracker URL:)QBT_TR[CONTEXT=TrackerListWidget]</label>
         <div style="text-align: center; padding-top: 10px;">
             <input type="text" id="trackerUrl" style="width: 90%;">
+        </div>
+        <br>
+        <label for="trackerTier">QBT_TR(Tier:)QBT_TR[CONTEXT=TrackerListWidget]</label>
+        <div style="text-align: center; padding-top: 10px;">
+            <input type="number" id="trackerTier" style="width: 90%; max-width: 100px;" min="0" max="255">
         </div>
         <br>
         <input type="button" value="QBT_TR(Edit)QBT_TR[CONTEXT=HttpServer]" id="editTrackerButton">

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -40,7 +40,7 @@
                         method: "POST",
                         body: new URLSearchParams({
                             hash: searchParams.get("hash"),
-                            origUrl: currentUrl,
+                            url: currentUrl,
                             newUrl: document.getElementById("trackerUrl").value
                         })
                     })

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -255,13 +255,21 @@ window.qBittorrent.PropTrackers ??= (() => {
         if (current_hash.length === 0)
             return;
 
-        const trackerUrl = encodeURIComponent(torrentTrackersTable.selectedRowsIds()[0]);
+        const tracker = torrentTrackersTable.getRow(torrentTrackersTable.getSelectedRowId());
+        const contentURL = new URL("edittracker.html", window.location);
+        contentURL.search = new URLSearchParams({
+            v: "${CACHEID}",
+            hash: current_hash,
+            url: tracker.full_data.url,
+            tier: tracker.full_data.tier
+        });
+
         new MochaUI.Window({
             id: "trackersPage",
             icon: "images/qbittorrent-tray.svg",
             title: "QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]",
             loadMethod: "iframe",
-            contentURL: `edittracker.html?v=${CACHEID}&hash=${current_hash}&url=${trackerUrl}`,
+            contentURL: contentURL.toString(),
             scrollbars: true,
             resizable: false,
             maximizable: false,
@@ -269,7 +277,7 @@ window.qBittorrent.PropTrackers ??= (() => {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: window.qBittorrent.Dialog.limitWidthToViewport(500),
-            height: 150,
+            height: 200,
             onCloseComplete: () => {
                 updateData();
             }


### PR DESCRIPTION
This PR adds the ability to direct modify a tracker's tier from the WebUI. This process is notably different than the GUI, which provides arrows for increasing/decreasing a tracker's tier.

Closes #12233

![Screenshot 2025-07-05 at 06 13 52](https://github.com/user-attachments/assets/a1982c84-ca07-45c6-bedd-a42e57b72aa6)
