### PR TITLE
Render a transparent bar for progress less than 1

### DIFF
--- a/src/gui/progressbarpainter.cpp
+++ b/src/gui/progressbarpainter.cpp
@@ -72,8 +72,16 @@ void ProgressBarPainter::paint(QPainter *painter, const QStyleOptionViewItem &op
     const bool isEnabled = option.state.testFlag(QStyle::State_Enabled);
     styleOption.palette.setCurrentColorGroup(isEnabled ? QPalette::Active : QPalette::Disabled);
 
-    if (m_chunkColor.isValid())
+    if (progress < 1)
+    {
+        // display a white transparent bar for progress < 1
+        // workaround for QT rendering a 1-pixel wide progress bar even though the progress is still at 0 to 1 %
+        styleOption.palette.setColor(QPalette::Highlight, QColor(255, 255, 255, 0));
+    }
+    else if (m_chunkColor.isValid())
+    {
         styleOption.palette.setColor(QPalette::Highlight, m_chunkColor);
+    }
 
     painter->save();
     const QStyle *style = m_dummyProgressBar.style();


### PR DESCRIPTION
Not sure if this is the right way to fix.

The QT progress bar renders a 1 pixel wide bar even though the progress is at 0.

I tried playing around with different values for `QStyleOptionProgressBar` props and still no fix

This works around it by rendering a transparent 1 pixel bar if the progress is less than 1.

master:

<img width="481" alt="Screenshot 2025-07-06 at 8 01 49 PM" src="https://github.com/user-attachments/assets/e2be0257-573d-48ed-8048-331a0d5c8993" />

This PR with `progress < 1`

<img width="372" alt="Screenshot 2025-07-06 at 8 23 39 PM" src="https://github.com/user-attachments/assets/b16d8fb0-477c-4580-b7db-b8246016fdca" />
<img width="401" alt="Screenshot 2025-07-06 at 8 24 22 PM" src="https://github.com/user-attachments/assets/4c3b9eff-edf0-4887-9c85-8cb73f3472e1" />

This PR with `progress > 1`

<img width="421" alt="Screenshot 2025-07-06 at 8 23 14 PM" src="https://github.com/user-attachments/assets/48fc9870-aeef-40b1-941a-1efd6a84498e" />




fixes #22728 and #18293