### PR TITLE
Add a small gap between progress bars

### DIFF
--- a/src/gui/progressbarpainter.cpp
+++ b/src/gui/progressbarpainter.cpp
@@ -65,7 +65,7 @@ void ProgressBarPainter::paint(QPainter *painter, const QStyleOptionViewItem &op
     styleOption.text = text;
     styleOption.textVisible = true;
     // QStyleOption fields
-    styleOption.rect = option.rect;
+    styleOption.rect = option.rect.adjusted(0, 1, 0, -1);
     // Qt 6 requires QStyle::State_Horizontal to be set for correctly drawing horizontal progress bar
     styleOption.state = option.state | QStyle::State_Horizontal;
 


### PR DESCRIPTION
Before:

<img width="615" height="79" alt="000" src="https://github.com/user-attachments/assets/a38d0c06-32f8-41a3-8b2a-7b867bf06d89" />


After:
<img width="622" height="83" alt="001" src="https://github.com/user-attachments/assets/e5aa90dd-3b65-4d47-b8c7-e3b773bfe733" />


