### PR TITLE
Don't leave an empty folder when deleting or moving torrents

### DIFF
--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -104,7 +104,7 @@ bool Utils::Fs::smartRemoveEmptyFolderTree(const Path &path)
         if (!dir.isEmpty(QDir::Dirs | QDir::NoDotAndDotDot))
             continue;
 
-        const QStringList tmpFileList = dir.entryList(QDir::Files);
+        const QStringList tmpFileList = dir.entryList(QDir::Files | QDir::Hidden);
 
         // deleteFilesList contains unwanted files, usually created by the OS
         // temp files on linux usually end with '~', e.g. `filename~`


### PR DESCRIPTION
Currently when you delete or move a torrent sometimes an empty folder will stay. This is because hidden files will stay which didn't got deleted. Currently there is code that detects and deletes these files however it is not working correctly at the moment. The detected files are:
Windows: `Thumbs.db` and `desktop.ini`
Linux: `.directory`
Mac: `.DS_Store`

The reason that it is not working is that `QDir::Files` is used which doesn't lists hidden files. Adding `QDir::Hidden` will make the code work as expected. At least on Windows and macOS `QDir::Files` doesn't lists hidden files I can't test on linux.