### PR TITLE
Fix random function detection with static PIE builds

### DIFF
--- a/src/base/utils/randomlayer_linux.cpp
+++ b/src/base/utils/randomlayer_linux.cpp
@@ -45,7 +45,7 @@ namespace
 
         RandomLayer()
         {
-            if (::getrandom(nullptr, 0, 0) < 0)
+            if (unsigned char buf = 0; ::getrandom(&buf, sizeof(buf), 0) < 0)
             {
                 if (errno == ENOSYS)
                 {


### PR DESCRIPTION
Certain build options didn't like the detection with an no-op. So make it really fetch a random value.

Closes #22981.