### PR TITLE
Migrate away from deprecated iconForFileType

### DIFF
--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -46,7 +46,7 @@ namespace MacUtils
     {
         @autoreleasepool
         {
-            NSImage *image = [[NSWorkspace sharedWorkspace]
+            const NSImage *image = [[NSWorkspace sharedWorkspace]
                 iconForContentType:[UTType typeWithFilenameExtension:ext.toNSString()]];
             if (image)
             {


### PR DESCRIPTION
Currently `iconForFileType` is used on MacOS to display the file icons in the content tab. However this is marked as deprecated and should be replaced with `iconForContentType`

```
/Users/runner/work/qBittorrent/qBittorrent/src/gui/macutilities.mm:48:61: warning: 'iconForFileType:' is deprecated: first deprecated in macOS 12.0 - Use -[NSWorkspace iconForContentType:] instead. [-Wdeprecated-declarations]
            NSImage *image = [[NSWorkspace sharedWorkspace] iconForFileType:ext.toNSString()];
```

Icon is still shown after the change:

<img width="736" height="196" alt="Content Tab" src="https://github.com/user-attachments/assets/36ec2c9f-1146-4f97-9aca-72e7a63f8804" />

Related https://github.com/qbittorrent/qBittorrent/issues/15630
