### PR TITLE
Add alternative URL for program update checking

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1662,7 +1662,7 @@ void MainWindow::handleUpdateCheckFinished(ProgramUpdater *updater, const bool i
         updater->deleteLater();
     };
 
-    const auto newVersion = updater->getNewVersion();
+    const ProgramUpdater::Version newVersion = updater->getNewVersion();
     if (newVersion.isValid())
     {
         const QString msg {tr("A new version is available.") + u"<br/>"

--- a/src/gui/programupdater.h
+++ b/src/gui/programupdater.h
@@ -45,10 +45,11 @@ class ProgramUpdater final : public QObject
     Q_DISABLE_COPY_MOVE(ProgramUpdater)
 
 public:
-    using QObject::QObject;
     using Version = Utils::Version<4, 3>;
 
-    void checkForUpdates() const;
+    using QObject::QObject;
+
+    void checkForUpdates();
     Version getNewVersion() const;
     bool updateProgram() const;
 
@@ -57,14 +58,22 @@ signals:
 
 private slots:
     void rssDownloadFinished(const Net::DownloadResult &result);
-    void fallbackDownloadFinished(const Net::DownloadResult &result);
+    void fallbackDownloadFinished(const Net::DownloadResult &result, Version &version);
 
 private:
-    void handleFinishedRequest();
-    bool shouldUseFallback() const;
+    enum class RemoteSource
+    {
+        Fosshub,
+        QbtMain,
+        QbtBackup
+    };
 
-    mutable bool m_hasCompletedOneReq = false;
-    Version m_remoteVersion;
-    Version m_fallbackRemoteVersion;
+    void handleFinishedRequest();
+    RemoteSource getLatestRemoteSource() const;
+
+    int m_pendingRequestCount = 0;
+    Version m_fosshubVersion;
+    Version m_qbtMainVersion;
+    Version m_qbtBackupVersion;
     QUrl m_updateURL;
 };


### PR DESCRIPTION
The alternative URL is hosted on GitHub and users are able to access it:
https://github.com/qbittorrent/qBittorrent/issues/23000#issuecomment-3092538814
https://github.com/qbittorrent/qBittorrent/issues/23009#issuecomment-3093201180

Also, disguise the user agent as a normal browser to avoid standing out from the crowd and avoid whatever issues from CDN. This only applies to non-fosshub URLs.

Closes #23000.
Closes #23009.
