### PR TITLE
Migrate away from deprecated API on MacOS

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -296,7 +296,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         programupdater.h
         programupdater.cpp
     )
-    target_link_libraries(qbt_gui PRIVATE objc)
+    target_link_libraries(qbt_gui PRIVATE
+        objc
+        "-framework UserNotifications"
+    )
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -80,6 +80,7 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
 {
 #ifdef Q_OS_MACOS
     desktopIntegrationInstance = this;
+    MacUtils::askForNotificationPermission();
     MacUtils::overrideDockClickHandler(handleDockClicked);
     m_menu->setAsDockMenu();
 #else

--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -40,6 +40,7 @@ namespace MacUtils
 {
     QPixmap pixmapForExtension(const QString &ext, const QSize &size);
     void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...));
+    void askForNotificationPermission();
     void displayNotification(const QString &title, const QString &message);
     void openFiles(const PathList &pathList);
 


### PR DESCRIPTION
Currently `NSUserNotifications API` is used on MacOS to display notifications. However this is marked as deprecated and should be replaced with `UserNotifications.frameworks API`. With the new API it is required to ask for permission before notifications can be send. The program will ask for permission to send notifications on the start.

Asking for permission to send notifications:

<img width="360" height="134" alt="Asking for permission to send notifications" src="https://github.com/user-attachments/assets/0d51b141-c18b-4e62-b2ef-21ea4bade259" />

Notification for added torrent:

<img width="347" height="91" alt="Notification for added torrent" src="https://github.com/user-attachments/assets/494b4490-b805-43c7-ad87-49b8ec9cbeea" />

Notification for finished torrent:

<img width="342" height="77" alt="Notification for finished torrent" src="https://github.com/user-attachments/assets/7130f9ff-237b-4249-8750-dcaffe3c1e70" />

Related: https://github.com/qbittorrent/qBittorrent/issues/15630