### PR TITLE
Revise command-line show message condition

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -182,9 +182,6 @@ int main(int argc, char *argv[])
     adjustFileDescriptorLimit();
 #endif
 
-    // We must save it here because QApplication constructor may change it
-    const bool isOneArg = (argc == 2);
-
     // `app` must be declared out of try block to allow display message box in case of exception
     std::unique_ptr<Application> app;
     try
@@ -204,33 +201,26 @@ int main(int argc, char *argv[])
 #endif
 
         const QBtCommandLineParameters params = app->commandLineArgs();
+
+        // "show help/version" takes priority over other flags
+        if (params.showHelp)
+        {
+            displayUsage(QString::fromLocal8Bit(argv[0]));
+            return EXIT_SUCCESS;
+        }
+#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
+        if (params.showVersion)
+        {
+            displayVersion();
+            return EXIT_SUCCESS;
+        }
+#endif
+
         if (!params.unknownParameter.isEmpty())
         {
             throw CommandLineParameterError(QCoreApplication::translate("Main", "%1 is an unknown command line parameter.",
                                                         "--random-parameter is an unknown command line parameter.")
                                                         .arg(params.unknownParameter));
-        }
-#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
-        if (params.showVersion)
-        {
-            if (isOneArg)
-            {
-                displayVersion();
-                return EXIT_SUCCESS;
-            }
-            throw CommandLineParameterError(QCoreApplication::translate("Main", "%1 must be the single command line parameter.")
-                                     .arg(u"-v (or --version)"_s));
-        }
-#endif
-        if (params.showHelp)
-        {
-            if (isOneArg)
-            {
-                displayUsage(QString::fromLocal8Bit(argv[0]));
-                return EXIT_SUCCESS;
-            }
-            throw CommandLineParameterError(QCoreApplication::translate("Main", "%1 must be the single command line parameter.")
-                                 .arg(u"-h (or --help)"_s));
         }
 
         // Check if qBittorrent is already running


### PR DESCRIPTION
Now when user specified 'help' or 'version' flag, the program will process them first and ignore all other flags (even invalid flags).
This improves program usability since user will be able to consult the help description without ensuring existing flags are all valid (or removing all flags). And user can revise the flags after reading the help description.
