### PR TITLE
WebUI: migrate away from outdated config in ESLint

### DIFF
--- a/src/webui/www/eslint.config.mjs
+++ b/src/webui/www/eslint.config.mjs
@@ -57,7 +57,7 @@ export default [
                 "double",
                 {
                     avoidEscape: true,
-                    allowTemplateLiterals: true
+                    allowTemplateLiterals: "avoidEscape"
                 }
             ],
             "Stylistic/quote-props": ["error", "consistent-as-needed"],

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1008,7 +1008,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
         document.getElementById("UpInfos").textContent = transfer_info;
 
         document.title = (speedInTitle
-                ? (`QBT_TR([D: %1, U: %2])QBT_TR[CONTEXT=MainWindow] `
+                ? ("QBT_TR([D: %1, U: %2])QBT_TR[CONTEXT=MainWindow] "
                     .replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.dl_info_speed, true))
                     .replace("%2", window.qBittorrent.Misc.friendlyUnit(serverState.up_info_speed, true)))
                 : "")

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -73,9 +73,9 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.dynamicTableDiv = document.getElementById(dynamicTableDivId);
             this.useVirtualList = useVirtualList && (LocalPreferences.get("use_virtual_list", "false") === "true");
             this.fixedTableHeader = document.querySelector(`#${dynamicTableFixedHeaderDivId} thead tr`);
-            this.hiddenTableHeader = this.dynamicTableDiv.querySelector(`thead tr`);
-            this.table = this.dynamicTableDiv.querySelector(`table`);
-            this.tableBody = this.dynamicTableDiv.querySelector(`tbody`);
+            this.hiddenTableHeader = this.dynamicTableDiv.querySelector("thead tr");
+            this.table = this.dynamicTableDiv.querySelector("table");
+            this.tableBody = this.dynamicTableDiv.querySelector("tbody");
             this.rowHeight = 26;
             this.rows = new Map();
             this.cachedElements = [];

--- a/src/webui/www/private/speedlimit.html
+++ b/src/webui/www/private/speedlimit.html
@@ -98,8 +98,8 @@
 
             document.getElementById("limitUpdateLabel").textContent =
                 isUpload
-                ? `QBT_TR(Upload limit:)QBT_TR[CONTEXT=SpeedLimit]`
-                : `QBT_TR(Download limit:)QBT_TR[CONTEXT=SpeedLimit]`;
+                ? "QBT_TR(Upload limit:)QBT_TR[CONTEXT=SpeedLimit]"
+                : "QBT_TR(Download limit:)QBT_TR[CONTEXT=SpeedLimit]";
 
             fetch(`api/v2/transfer/${getLimitMethod}`, {
                     method: "GET",

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1856,15 +1856,15 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const pos = document.getElementById("watched_folders_tab").getChildren("tbody")[0].getChildren("tr").length;
             const myinput = `<input id='text_watch_${pos}' type='text' value='${folder}'>`;
             const disableInput = (sel !== "other");
-            const mycb = `<div class='select-watched-folder-editable'>`
+            const mycb = "<div class='select-watched-folder-editable'>"
                 + `<select id ='cb_watch_${pos}' onchange='qBittorrent.Preferences.changeWatchFolderSelect(this);'>`
-                + `<option value='watch_folder'>QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]</option>`
-                + `<option value='default_folder'>QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>`
-                + `<option value='other'>QBT_TR(Other...)QBT_TR[CONTEXT=ScanFoldersModel]</option>`
-                + `</select>`
+                + "<option value='watch_folder'>QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
+                + "<option value='default_folder'>QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
+                + "<option value='other'>QBT_TR(Other...)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
+                + "</select>"
                 + `<input id='cb_watch_txt_${pos}' type='text' ${disableInput ? "hidden " : ""}/>`
                 + `<img src='images/list-add.svg' id='addFolderImg_${pos}' alt='Add' style='padding-left:170px;width:16px;cursor:pointer;' onclick='qBittorrent.Preferences.addWatchFolder();'>`
-                + `</div>`;
+                + "</div>";
 
             watchedFoldersTable.push([myinput, mycb]);
             document.getElementById(`cb_watch_${pos}`).value = sel;


### PR DESCRIPTION
The following message appears when using the outdated value:
>[@stylistic/eslint-plugin]: You are using deprecated value(boolean) for "allowTemplateLiterals"
>in "quotes", please use "always"/"never" instead.

Also prefer using double quotes over backticks for strings.
