### PR TITLE
Use source URL for search plugins

### DIFF
--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -87,7 +87,7 @@ namespace
 QPointer<SearchPluginManager> SearchPluginManager::m_instance = nullptr;
 
 SearchPluginManager::SearchPluginManager()
-    : m_updateUrl(u"https://searchplugins.qbittorrent.org/nova3/engines/"_s)
+    : m_updateUrl(u"https://raw.githubusercontent.com/qbittorrent/search-plugins/refs/heads/master/nova3/engines/"_s)
     , m_proxyEnv {QProcessEnvironment::systemEnvironment()}
 {
     Q_ASSERT(!m_instance); // only one instance is allowed


### PR DESCRIPTION
This saves a few URL redirections. And avoids potential issues related to Cloudflare protections/blockages on qbt domain.

Closes #22990.
