### PR TITLE
GHA CI: Disable the hardened runtime in the codesigning workflow for macOS

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -131,7 +131,7 @@ jobs:
           macdeployqt "$appName.app" -no-strip
           # code signing
           xattr -cr "$appName.app"
-          codesign --force --sign - --options runtime \
+          codesign --force --sign - \
             "$appName.app" \
             "$appName.app/Contents/Frameworks"/* \
             "$appName.app/Contents/MacOS/$appName"


### PR DESCRIPTION
Currently the hardened runtime is enabled for code signing in the github workflow for macOS. However in this thread https://github.com/qbittorrent/qBittorrent/discussions/23041#discussioncomment-13969415 a user had a problem to open the nightly builds from github. Relevant part of the error:

```
Reason: tried: '/private/var/folders/y0/jmsflc717tn_tj2x9d1g3d9w0000gn/T/AppTranslocation/8B53E367-2E0C-42C1-A4D5-6787109EE46E/d/qbittorrent.app/Contents/Frameworks/QtWidgets.framework/Versions/A/QtWidgets' (code signature in '/private/var/folders/y0/jmsflc717tn_tj2x9d1g3d9w0000gn/T/AppTranslocation/8B53E367-2E0C-42C1-A4D5-6787109EE46E/d/qbittorrent.app/Contents/Frameworks/QtWidgets.framework/Versions/A/QtWidgets' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/private/var/folders/y0/jmsflc717tn_tj2x9d1g3d9w0000gn/T/AppTranslocation/8B53E367-2E0C-42C1-A4D5-6787109EE46E/d/qbittorrent.app/Contents/Frameworks/QtWidgets.framework/Versions/
(terminated at launch; ignore backtrace)
```

Further investigation showed that when disabling the hardened runtime this won't occur any more. I haven't noticed this before because the error wouldn't occur when SIP (system integrity protection) is disabled and I have it disabled now.