### PR TITLE
WebAPI: Correctly handle uploaded files with non-ascii name

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -356,7 +356,10 @@ void WebApplication::doProcessRequest()
 
     DataMap data;
     for (const Http::UploadedFile &torrent : request().files)
-        data[torrent.filename] = torrent.data;
+    {
+        const QString fileName = QString::fromUtf8(torrent.filename.toLatin1());
+        data[fileName] = torrent.data;
+    }
 
     try
     {


### PR DESCRIPTION
This fixes an issue reported by @HanabishiRecca where non-ascii file names were improperly handled (https://github.com/qbittorrent/qBittorrent/pull/21645#issuecomment-3171913930). This has always been an issue but wasn't identified because the file name was only used for error messaging, until #21645 was merged.