### PR TITLE
WebAPI: Omit file names in `parseMetadata` response

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -10,6 +10,8 @@
   * `torrents/editTracker` endpoint now supports setting a tracker's tier via `tier` parameter
   * `torrents/editTracker` endpoint always responds with a 204 when successful
   * `torrents/editTracker` endpoint `origUrl` parameter renamed to `url`
+* [#23085](https://github.com/qbittorrent/qBittorrent/pull/23085)
+  * `torrents/parseMetadata` now responds with an array of metadata in the same order as the files in the request. It previously responded with an object keyed off of the submitted file name.
 
 ## 2.12.1
 * [#23031](https://github.com/qbittorrent/qBittorrent/pull/23031)

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -2099,16 +2099,14 @@ void TorrentsController::parseMetadataAction()
     if (uploadedTorrents.isEmpty())
         throw APIError(APIErrorType::BadParams, tr("Must specify torrent file(s)"));
 
-    QJsonObject result;
+    QJsonArray result;
     for (auto it = uploadedTorrents.constBegin(); it != uploadedTorrents.constEnd(); ++it)
     {
         if (const auto loadResult = BitTorrent::TorrentDescriptor::load(it.value()))
         {
             const BitTorrent::TorrentDescriptor &torrentDescr = loadResult.value();
             m_torrentMetadataCache.insert(torrentDescr.infoHash().toTorrentID(), torrentDescr);
-
-            const QString &fileName = it.key();
-            result.insert(fileName, serializeTorrentInfo(torrentDescr));
+            result.append(serializeTorrentInfo(torrentDescr));
         }
         else
         {

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -175,9 +175,11 @@ window.qBittorrent.Client ??= (() => {
     const uploadTorrentFiles = (files) => {
         const fileNames = [];
         const formData = new FormData();
-        for (const file of files) {
+        for (let i = 0; i < files.length; ++i) {
+            const file = files[i];
             fileNames.push(file.name);
-            formData.append("file", file);
+            // send dummy file name as file name won't be used and may not be encoded properly
+            formData.append("file", file, i);
         }
 
         fetch("api/v2/torrents/parseMetadata", {
@@ -191,12 +193,9 @@ window.qBittorrent.Client ??= (() => {
                 }
 
                 const json = await response.json();
-                for (const fileName of fileNames) {
-                    let title = fileName;
-                    const metadata = json[fileName];
-                    if (metadata !== undefined)
-                        title = metadata.name;
-
+                for (let i = 0; i < json.length; ++i) {
+                    const metadata = json[i];
+                    const title = metadata.name || fileNames[i];
                     const hash = metadata.infohash_v2 || metadata.infohash_v1;
                     createAddTorrentWindow(title, hash, metadata);
                 }


### PR DESCRIPTION
This allows us to bypass any issues related to non-ascii file names.

Supersedes #23080.