### PR TITLE
GHA CI: Bump some pre-commit hook revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
           - ts
 
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     - id: check-json
       name: Check JSON files
@@ -88,7 +88,7 @@ repos:
         - ts
 
   - repo: https://github.com/crate-ci/typos.git
-    rev: v1.32.0
+    rev: v1.35.3
     hooks:
     - id: typos
       name: Check spelling (typos)


### PR DESCRIPTION
* Bumped `pre-commit-hooks` -> v6.0.0
* Bumped `typos` -> v1.35.3