### PR TITLE
WebUI: replace callback with promise chaining

### DIFF
--- a/src/webui/www/private/scripts/cache.js
+++ b/src/webui/www/private/scripts/cache.js
@@ -76,77 +76,52 @@ window.qBittorrent.Cache ??= (() => {
     class PreferencesCache {
         #m_store = {};
 
-        // obj: {
-        //   onFailure: () => {},
-        //   onSuccess: () => {}
-        // }
-        init(obj = {}) {
-            return fetch("api/v2/app/preferences", {
+        async init() {
+            return await fetch("api/v2/app/preferences", {
                     method: "GET",
                     cache: "no-store"
                 })
                 .then(async (response) => {
-                        if (!response.ok)
-                            return;
+                    if (!response.ok)
+                        return;
 
-                        const responseText = await response.text();
-                        const responseJSON = JSON.parse(responseText);
-                        deepFreeze(responseJSON);
-                        this.#m_store = responseJSON;
+                    const responseText = await response.text();
+                    const responseJSON = JSON.parse(responseText);
+                    deepFreeze(responseJSON);
+                    this.#m_store = responseJSON;
 
-                        if (typeof obj.onSuccess === "function")
-                            obj.onSuccess(responseJSON, responseText);
-                    },
-                    (error) => {
-                        if (typeof obj.onFailure === "function")
-                            obj.onFailure(error);
-                    });
+                    return responseJSON;
+                });
         }
 
         get() {
             return this.#m_store;
         }
 
-        // obj: {
-        //   data: {},
-        //   onFailure: () => {},
-        //   onSuccess: () => {}
-        // }
-        set(obj) {
-            if (typeof obj !== "object")
-                throw new Error("`obj` is not an object.");
-            if (typeof obj.data !== "object")
+        async set(data) {
+            if (typeof data !== "object")
                 throw new Error("`data` is not an object.");
 
-            fetch("api/v2/app/setPreferences", {
+            return await fetch("api/v2/app/setPreferences", {
                     method: "POST",
                     body: new URLSearchParams({
-                        json: JSON.stringify(obj.data)
+                        json: JSON.stringify(data)
                     })
                 })
-                .then(async (response) => {
-                        if (!response.ok)
-                            return;
+                .then((response) => {
+                    if (!response.ok)
+                        return;
 
-                        this.#m_store = structuredClone(this.#m_store);
-                        for (const key in obj.data) {
-                            if (!Object.hasOwn(obj.data, key))
-                                continue;
+                    this.#m_store = structuredClone(this.#m_store);
+                    for (const key in data) {
+                        if (!Object.hasOwn(data, key))
+                            continue;
 
-                            const value = obj.data[key];
-                            this.#m_store[key] = value;
-                        }
-                        deepFreeze(this.#m_store);
-
-                        if (typeof obj.onSuccess === "function") {
-                            const responseText = await response.text();
-                            obj.onSuccess(responseText);
-                        }
-                    },
-                    (error) => {
-                        if (typeof obj.onFailure === "function")
-                            obj.onFailure(error);
-                    });
+                        const value = data[key];
+                        this.#m_store[key] = value;
+                    }
+                    deepFreeze(this.#m_store);
+                });
         }
     }
 

--- a/src/webui/www/private/views/confirmdeletion.html
+++ b/src/webui/www/private/views/confirmdeletion.html
@@ -58,13 +58,10 @@
         // Set current "Delete files" choice as the default
         rememberButton.addEventListener("click", (e) => {
             window.qBittorrent.Cache.preferences.set({
-                data: {
-                    delete_torrent_content_files: deleteCB.checked
-                },
-                onSuccess: () => {
-                    prefDeleteContentFiles = deleteCB.checked;
-                    setRememberBtnEnabled(false);
-                }
+                delete_torrent_content_files: deleteCB.checked
+            }).then(() => {
+                prefDeleteContentFiles = deleteCB.checked;
+                setRememberBtnEnabled(false);
             });
         });
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2228,8 +2228,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         const loadPreferences = () => {
-            window.parent.qBittorrent.Cache.preferences.init({
-                onSuccess: (pref) => {
+            window.parent.qBittorrent.Cache.preferences.init()
+                .then((pref) => {
                     // Behavior tab
                     // Language
                     updateWebuiLocaleSelect(pref.locale);
@@ -2650,8 +2650,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("i2pOutboundQuantity").value = pref.i2p_outbound_quantity;
                     document.getElementById("i2pInboundLength").value = pref.i2p_inbound_length;
                     document.getElementById("i2pOutboundLength").value = pref.i2p_outbound_length;
-                }
-            });
+                });
         };
 
         const applyPreferences = () => {
@@ -3169,18 +3168,15 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["i2p_outbound_length"] = Number(document.getElementById("i2pOutboundLength").value);
 
             // Send it to qBT
-            window.parent.qBittorrent.Cache.preferences.set({
-                data: settings,
-                onFailure: () => {
-                    alert("QBT_TR(Unable to save program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
-                    window.parent.qBittorrent.Client.closeWindow(document.getElementById("preferencesPage"));
-                },
-                onSuccess: () => {
+            window.parent.qBittorrent.Cache.preferences.set(settings)
+                .then(() => {
                     // Close window
                     window.parent.location.reload();
                     window.parent.qBittorrent.Client.closeWindow(document.getElementById("preferencesPage"));
-                }
-            });
+                }).catch((error) => {
+                    alert("QBT_TR(Unable to save program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
+                    window.parent.qBittorrent.Client.closeWindow(document.getElementById("preferencesPage"));
+                });
         };
 
         const setup = () => {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2650,6 +2650,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("i2pOutboundQuantity").value = pref.i2p_outbound_quantity;
                     document.getElementById("i2pInboundLength").value = pref.i2p_inbound_length;
                     document.getElementById("i2pOutboundLength").value = pref.i2p_outbound_length;
+                }).catch((error) => {
+                    console.error(error);
+                    alert("QBT_TR(Unable to load program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
                 });
         };
 


### PR DESCRIPTION
We should use modern promise chaining over legacy callbacks wherever possible. This will also make some future async work I'm doing a bit easier.