### PR TITLE
macOS: add checkbox in settings for speed indicator in dock

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1477,6 +1477,21 @@ void Preferences::setUpdateCheckEnabled(const bool enabled)
 }
 #endif
 
+#ifdef Q_OS_MACOS
+bool Preferences::isSpeedInDockEnabled() const
+{
+    return value(u"Preferences/Speed/ShowSpeedInDock"_s, true);
+}
+
+void Preferences::setSpeedInDockEnabled(const bool enabled)
+{
+    if (enabled == isSpeedInDockEnabled())
+        return;
+
+    setValue(u"Preferences/Speed/ShowSpeedInDock"_s, enabled);
+}
+#endif
+
 bool Preferences::confirmTorrentDeletion() const
 {
     return value(u"Preferences/Advanced/confirmTorrentDeletion"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -319,6 +319,10 @@ public:
     bool isUpdateCheckEnabled() const;
     void setUpdateCheckEnabled(bool enabled);
 #endif
+#ifdef Q_OS_MACOS
+    bool isSpeedInDockEnabled() const;
+    void setSpeedInDockEnabled(bool enabled);
+#endif
     bool confirmTorrentDeletion() const;
     void setConfirmTorrentDeletion(bool enabled);
     bool confirmTorrentRecheck() const;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1452,6 +1452,12 @@ void MainWindow::loadPreferences()
     }
 #endif
 
+#ifdef Q_OS_MACOS
+    // Clear dock badge immediately if speed display is disabled
+    if (!pref->isSpeedInDockEnabled())
+        m_badger->updateSpeed(0, 0);
+#endif
+
     qDebug("GUI settings loaded");
 }
 
@@ -1464,7 +1470,10 @@ void MainWindow::loadSessionStats()
 
     // update global information
 #ifdef Q_OS_MACOS
-    m_badger->updateSpeed(status.payloadDownloadRate, status.payloadUploadRate);
+    if (Preferences::instance()->isSpeedInDockEnabled())
+        m_badger->updateSpeed(status.payloadDownloadRate, status.payloadUploadRate);
+    else
+        m_badger->updateSpeed(0, 0);
 #else
     refreshTrayIconTooltip();
 #endif  // Q_OS_MACOS

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1044,6 +1044,12 @@ void OptionsDialog::loadSpeedTabOptions()
     m_ui->checkLimitTransportOverhead->setChecked(session->includeOverheadInLimits());
     m_ui->checkLimitLocalPeerRate->setChecked(!session->ignoreLimitsOnLAN());
 
+#ifdef Q_OS_MACOS
+    m_ui->checkShowSpeedInDock->setChecked(pref->isSpeedInDockEnabled());
+#else
+    m_ui->dockDisplayBox->hide();
+#endif
+
     connect(m_ui->spinUploadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinDownloadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
 
@@ -1058,6 +1064,10 @@ void OptionsDialog::loadSpeedTabOptions()
     connect(m_ui->checkLimituTPConnections, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkLimitTransportOverhead, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkLimitLocalPeerRate, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+
+#ifdef Q_OS_MACOS
+    connect(m_ui->checkShowSpeedInDock, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+#endif
 }
 
 void OptionsDialog::saveSpeedTabOptions() const
@@ -1079,6 +1089,10 @@ void OptionsDialog::saveSpeedTabOptions() const
     session->setUTPRateLimited(m_ui->checkLimituTPConnections->isChecked());
     session->setIncludeOverheadInLimits(m_ui->checkLimitTransportOverhead->isChecked());
     session->setIgnoreLimitsOnLAN(!m_ui->checkLimitLocalPeerRate->isChecked());
+
+#ifdef Q_OS_MACOS
+    pref->setSpeedInDockEnabled(m_ui->checkShowSpeedInDock->isChecked());
+#endif
 }
 
 void OptionsDialog::loadBittorrentTabOptions()

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2636,6 +2636,22 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="dockDisplayBox">
+              <property name="title">
+               <string>Display</string>
+              </property>
+              <layout class="QVBoxLayout" name="dockDisplayBoxLayout">
+               <item>
+                <widget class="QCheckBox" name="checkShowSpeedInDock">
+                 <property name="text">
+                  <string>Show speed in Dock</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>


### PR DESCRIPTION
Add checkbox in Speed section of Settings to disable showing speed in MacOS dock

Closes #20783