### PR TITLE
UI restore multi-selection inside torrent content widget 

### DIFF
--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -40,6 +40,8 @@
 #include <QWheelEvent>
 #include <qevent.h>
 #include <qobject.h>
+#include <qstyle.h>
+#include <qstyleoption.h>
 
 #include "base/bittorrent/torrentcontenthandler.h"
 #include "base/path.h"
@@ -82,8 +84,6 @@ TorrentContentWidget::TorrentContentWidget(QWidget *parent)
     header()->setSortIndicator(0, Qt::AscendingOrder);
     header()->setFirstSectionMovable(true);
     header()->setContextMenuPolicy(Qt::CustomContextMenu);
-
-    allowDrag = true;
 
     m_model = new TorrentContentModel(this);
     connect(m_model, &TorrentContentModel::renameFailed, this, [this](const QString &errorMessage)
@@ -549,23 +549,24 @@ bool TorrentContentWidget::shouldDrag(QMouseEvent *event)
 
     if (columnIndex == TorrentContentWidget::Name)
     {
-        QModelIndex cIndex = indexAt(pressPosition.toPoint());
-        if (!cIndex.isValid())
+        QModelIndex rowIndex = indexAt(pressPosition.toPoint());
+        if (!rowIndex.isValid())
             return false;
 
-        int namePosX = columnViewportPosition(columnIndex);
         int depth = 0;
-        while(cIndex != cIndex.parent())
+        while(rowIndex != rowIndex.parent())
         {
             depth++;
-            cIndex = cIndex.parent();
+            rowIndex = rowIndex.parent();
         }
+        const int nameColumnX = columnViewportPosition(columnIndex);
+        const int checkboxWidth = 24;
+        const int areaWidth = 24;
+        const int areaLeft = nameColumnX + (indentation() * depth) + checkboxWidth;
+        const int areaRight = areaLeft + areaWidth;
 
-        int iconLeft = namePosX + (indentation() * (depth + 1));
-        int iconRight = iconLeft + indentation();
-
-        if (pressPosition.x() > iconLeft &&
-            pressPosition.x() < iconRight)
+        if (pressPosition.x() > areaLeft &&
+            pressPosition.x() < areaRight)
             return true;
     }
 

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -133,5 +133,5 @@ private:
     ColumnsVisibilityMode m_columnsVisibilityMode = ColumnsVisibilityMode::Editable;
     QShortcut *m_openFileHotkeyEnter = nullptr;
     QShortcut *m_openFileHotkeyReturn = nullptr;
-    bool allowDrag;
+    bool allowDrag = true;
 };


### PR DESCRIPTION
Closes https://github.com/qbittorrent/qBittorrent/issues/22686
Another version of https://github.com/qbittorrent/qBittorrent/pull/22850

Drag by icon inside "Name" column
Drag disabled inside "add torrent..." popup

<img width="159" height="121" alt="grabZone" src="https://github.com/user-attachments/assets/893966ef-9241-4b80-9b2b-2420982ea25e" />

