### PR TITLE
WebUI: Continue polling after network error

### DIFF
--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -237,6 +237,10 @@ window.qBittorrent.AddTorrent ??= (() => {
                     metadataCompleted();
                 else
                     loadMetadataTimer = loadMetadata.delay(1000);
+            }, (error) => {
+                console.error(error);
+
+                loadMetadataTimer = loadMetadata.delay(1000);
             });
     };
 

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -234,6 +234,12 @@ window.qBittorrent.PropGeneral ??= (() => {
                 }
                 clearTimeout(loadTorrentDataTimer);
                 loadTorrentDataTimer = loadTorrentData.delay(5000);
+            }, (error) => {
+                console.error(error);
+
+                document.getElementById("error_div").textContent = "QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]";
+                clearTimeout(loadTorrentDataTimer);
+                loadTorrentDataTimer = loadTorrentData.delay(10000);
             });
 
         const pieceStatesURL = new URL("api/v2/torrents/pieceStates", window.location);
@@ -262,6 +268,12 @@ window.qBittorrent.PropGeneral ??= (() => {
 
                 clearTimeout(loadTorrentDataTimer);
                 loadTorrentDataTimer = loadTorrentData.delay(5000);
+            }, (error) => {
+                console.error(error);
+
+                document.getElementById("error_div").textContent = "QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]";
+                clearTimeout(loadTorrentDataTimer);
+                loadTorrentDataTimer = loadTorrentData.delay(10000);
             });
     };
 

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -918,6 +918,11 @@ window.qBittorrent.Search ??= (() => {
 
                 clearTimeout(state.loadResultsTimer);
                 state.loadResultsTimer = loadSearchResultsData.delay(2000, this, searchId);
+            }, (error) => {
+                console.error(error);
+
+                clearTimeout(state.loadResultsTimer);
+                state.loadResultsTimer = loadSearchResultsData.delay(3000, this, searchId);
             });
     };
 

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -415,6 +415,12 @@
 
                     tableInfo[curTab].progress = false;
                     syncLogWithInterval(getSyncLogDataInterval());
+                }, (error) => {
+                    console.error(error);
+
+                    document.getElementById("error_div").textContent = "QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]";
+                    tableInfo[curTab].progress = false;
+                    syncLogWithInterval(10000);
                 });
         };
 


### PR DESCRIPTION
These `fetch` calls properly handle 4xx and 5xx errors by checking `response.ok`, but don't handle network errors that throw. In all cases, I've used the same logic as the `!response.ok` branch of each individual fetch function. This should ensure consistent behavior.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
