### PR TITLE
WebAPI: Remove outdated TODO

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1059,7 +1059,6 @@ void TorrentsController::addAction()
 
     BitTorrent::AddTorrentParams addTorrentParams
     {
-        // TODO: Check if destination actually exists
         .name = torrentName,
         .category = category,
         .tags = {tags.cbegin(), tags.cend()},


### PR DESCRIPTION
This TODO has been in the code for 8 years since it was added in #6475 (commit b271fa9f001f96cb0d934918ccbd181d86c8a326). It appears to have been related to the `skipChecking` variable, though what it actually means has been lost over time. Note that both the `savePath` and the `downloadPath` are recursively created if they don't yet exist.
