### PR TITLE
Restore default drag behavior in Torrent Content widget

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -372,6 +372,19 @@ void Preferences::setToolbarDisplayed(const bool displayed)
     setValue(u"Preferences/General/ToolbarDisplayed"_s, displayed);
 }
 
+bool Preferences::isTorrentContentDragEnabled() const
+{
+    return value(u"Preferences/General/TorrentContentDragEnabled"_s, false);
+}
+
+void Preferences::setTorrentContentDragEnabled(const bool enabled)
+{
+    if (enabled == isTorrentContentDragEnabled())
+        return;
+
+    setValue(u"Preferences/General/TorrentContentDragEnabled"_s, enabled);
+}
+
 bool Preferences::isStatusbarDisplayed() const
 {
     return value(u"Preferences/General/StatusbarDisplayed"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -129,6 +129,8 @@ public:
     void setStatusbarExternalIPDisplayed(bool displayed);
     bool isToolbarDisplayed() const;
     void setToolbarDisplayed(bool displayed);
+    bool isTorrentContentDragEnabled() const;
+    void setTorrentContentDragEnabled(bool enabled);
     bool isSplashScreenDisabled() const;
     void setSplashScreenDisabled(bool b);
     bool preventFromSuspendWhenDownloading() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -290,6 +290,8 @@ void OptionsDialog::loadBehaviorTabOptions()
 
     m_ui->checkBoxHideZeroStatusFilters->setChecked(pref->getHideZeroStatusFilters());
 
+    m_ui->checkTorrentContentDrag->setChecked(pref->isTorrentContentDragEnabled());
+
 #ifndef Q_OS_WIN
     m_ui->checkStartup->setVisible(false);
 #endif
@@ -402,6 +404,8 @@ void OptionsDialog::loadBehaviorTabOptions()
     connect(m_ui->actionTorrentFnOnDblClBox, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkBoxHideZeroStatusFilters, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 
+    connect(m_ui->checkTorrentContentDrag, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+
 #ifdef Q_OS_WIN
     connect(m_ui->checkStartup, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 #endif
@@ -498,6 +502,8 @@ void OptionsDialog::saveBehaviorTabOptions() const
     pref->setActionOnDblClOnTorrentFn(m_ui->actionTorrentFnOnDblClBox->currentData().toInt());
 
     pref->setHideZeroStatusFilters(m_ui->checkBoxHideZeroStatusFilters->isChecked());
+
+    pref->setTorrentContentDragEnabled(m_ui->checkTorrentContentDrag->isChecked());
 
     pref->setSplashScreenDisabled(isSplashScreenDisabled());
     pref->setConfirmOnExit(m_ui->checkProgramExitConfirm->isChecked());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -460,6 +460,25 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="boxTorrentContent">
+              <property name="title">
+               <string>Torrent Content View</string>
+              </property>
+              <layout class="QVBoxLayout" name="layoutTorrentContent">
+               <item>
+                <widget class="QCheckBox" name="checkTorrentContentDrag">
+                 <property name="toolTip">
+                  <string>Replaces multi-selection (hold Alt key to invert)</string>
+                 </property>
+                 <property name="text">
+                  <string>Drag content from qBittorrent</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <widget class="QGroupBox" name="systrayBox">
               <property name="title">
                <string>Desktop</string>

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -86,6 +86,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     connect(m_contentFilterLine, &LineEdit::textChanged, this, &PropertiesWidget::setContentFilterPattern);
     m_ui->contentFilterLayout->insertWidget(3, m_contentFilterLine);
 
+    m_ui->filesList->setContentDragAllowed(true);
     m_ui->filesList->setDoubleClickAction(TorrentContentWidget::DoubleClickAction::Open);
     m_ui->filesList->setOpenByEnterKey(true);
 
@@ -572,8 +573,13 @@ void PropertiesWidget::displayWebSeedListMenu()
 
 void PropertiesWidget::configure()
 {
+    const auto *preferences = Preferences::instance();
+
+    // Torrent Content Widget
+    m_ui->filesList->setContentDragEnabled(preferences->isTorrentContentDragEnabled());
+
     // Speed widget
-    if (Preferences::instance()->isSpeedWidgetEnabled())
+    if (preferences->isSpeedWidgetEnabled())
     {
         if (!qobject_cast<SpeedWidget *>(m_speedWidget))
         {

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -71,8 +71,9 @@ namespace
 TorrentContentWidget::TorrentContentWidget(QWidget *parent)
     : QTreeView(parent)
 {
-    setDragEnabled(true);
     setDragDropMode(QAbstractItemView::DragOnly);
+    setDragEnabled(false);
+    setSelectionMode(QAbstractItemView::MultiSelection);
     setExpandsOnDoubleClick(false);
     setSortingEnabled(true);
     setUniformRowHeights(true);
@@ -222,6 +223,27 @@ void TorrentContentWidget::checkNone()
 {
     for (int i = 0; i < model()->rowCount(); ++i)
         model()->setData(model()->index(i, TorrentContentModelItem::COL_NAME), Qt::Unchecked, Qt::CheckStateRole);
+}
+
+void TorrentContentWidget::setContentDragAllowed(const bool allowed)
+{
+    m_contentDragAllowed = allowed;
+}
+
+void TorrentContentWidget::setContentDragEnabled(const bool enabled)
+{
+    m_contentDragEnabled = enabled;
+}
+
+void TorrentContentWidget::mousePressEvent(QMouseEvent *event)
+{
+    if (m_contentDragAllowed)
+    {
+        const bool hasAlt = event->modifiers().testFlag(Qt::AltModifier);
+        setDragEnabled(hasAlt ? !m_contentDragEnabled : m_contentDragEnabled);
+    }
+
+    QTreeView::mousePressEvent(event);
 }
 
 void TorrentContentWidget::keyPressEvent(QKeyEvent *event)

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -98,11 +98,15 @@ public:
     void checkAll();
     void checkNone();
 
+    void setContentDragAllowed(bool allowed);
+    void setContentDragEnabled(bool enabled);
+
 signals:
     void stateChanged();
 
 private:
     void setModel(QAbstractItemModel *model) override;
+    void mousePressEvent(QMouseEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     QModelIndex currentNameCell() const;
@@ -126,4 +130,7 @@ private:
     ColumnsVisibilityMode m_columnsVisibilityMode = ColumnsVisibilityMode::Editable;
     QShortcut *m_openFileHotkeyEnter = nullptr;
     QShortcut *m_openFileHotkeyReturn = nullptr;
+
+    bool m_contentDragAllowed = false;
+    bool m_contentDragEnabled = false;
 };


### PR DESCRIPTION
Multi-selection for default LMB action, as before 5.1 update

Adds option to select grab as the default behavior,
for users who don't have the Alt key available.

Holding the Alt key toggles between grab/multi-selection.

Closes https://github.com/qbittorrent/qBittorrent/issues/22686

<img width="440" height="260" alt="image" src="https://github.com/user-attachments/assets/e50e49c2-7ea1-403c-9334-7fbe3058ec2f" />