### PR TITLE
GHA CI: use preinstalled packages on macOS

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -43,8 +43,8 @@ jobs:
           command: |
             brew update > /dev/null
             brew install \
-              cmake ninja \
               openssl@3 zlib
+            # preinstalled on the image: cmake ninja
 
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1


### PR DESCRIPTION
This is to address the following error:
https://github.com/qbittorrent/qBittorrent/actions/runs/17323566048/job/49182687551?pr=23182#step:4:745
> Error: cmake was installed from the local/pinned tap
> but you are trying to install it from the homebrew/core tap.
> Formulae with the same name from different taps cannot be installed at the same time.

