### PR TITLE
WebUI: add I2P peers to peer list

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1834,7 +1834,7 @@ window.qBittorrent.DynamicTable ??= (() => {
     class TorrentPeersTable extends DynamicTable {
         initColumns() {
             this.newColumn("country", "", "QBT_TR(Country/Region)QBT_TR[CONTEXT=PeerListWidget]", 22, true);
-            this.newColumn("ip", "", "QBT_TR(IP)QBT_TR[CONTEXT=PeerListWidget]", 80, true);
+            this.newColumn("ip", "", "QBT_TR(IP/Address)QBT_TR[CONTEXT=PeerListWidget]", 80, true);
             this.newColumn("port", "", "QBT_TR(Port)QBT_TR[CONTEXT=PeerListWidget]", 35, true);
             this.newColumn("connection", "", "QBT_TR(Connection)QBT_TR[CONTEXT=PeerListWidget]", 50, true);
             this.newColumn("flags", "", "QBT_TR(Flags)QBT_TR[CONTEXT=PeerListWidget]", 50, true);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1876,15 +1876,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const ip1 = this.getRowValue(row1);
                 const ip2 = this.getRowValue(row2);
 
-                const a = ip1.split(".");
-                const b = ip2.split(".");
-
-                for (let i = 0; i < 4; ++i) {
-                    if (a[i] !== b[i])
-                        return a[i] - b[i];
-                }
-
-                return 0;
+                return window.qBittorrent.Misc.naturalSortCollator.compare(ip1, ip2);
             };
 
             // flags

--- a/src/webui/www/private/scripts/prop-peers.js
+++ b/src/webui/www/private/scripts/prop-peers.js
@@ -86,6 +86,12 @@ window.qBittorrent.PropPeers ??= (() => {
                                 continue;
 
                             responseJSON["peers"][key]["rowId"] = key;
+
+                            if (Object.hasOwn(responseJSON["peers"][key], "i2p_dest")) {
+                                responseJSON["peers"][key]["ip"] = responseJSON["peers"][key]["i2p_dest"];
+                                responseJSON["peers"][key]["port"] = "N/A";
+                            }
+
                             torrentPeersTable.updateRowData(responseJSON["peers"][key]);
                         }
                     }


### PR DESCRIPTION
The WebUI part of the changes for #23061. Now qBittorrent will display I2P peers in WebUI peers tab.

Fixes the second part of #19794 ("i2p peer list does not show in GUI").

<img width="1092" height="596" alt="scr" src="https://github.com/user-attachments/assets/df94569a-57f3-4ad6-ade5-9e1653886166" />
