### PR TITLE
[macOS] macos-latest YAML-label will use macos-15 in August 2025 

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -43,8 +43,7 @@ jobs:
           command: |
             brew update > /dev/null
             brew install \
-              cmake ninja \
-              openssl@3 zlib
+              zlib
 
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/12520

So it seems this change has been applied.

cmake/ninja/openssl are pre installed.

[Cmake 3.31.6](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#tools)

[ninja 1.13.1](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#utilities)

openssl I saw the warning in the run saying it is installed.

<img width="515" height="83" alt="image" src="https://github.com/user-attachments/assets/daf1f506-8490-4955-9668-47ecf8a08a32" />

So if you removed them the workflow works again.