### PR TITLE
WebUI: Fix add torrent spinner in Firefox

### DIFF
--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -124,6 +124,15 @@
             background-color: initial;
         }
 
+        #loadingSpinner {
+            position: absolute;
+            left: 6px;
+            bottom: 2px;
+            width: 16px;
+            height: 16px;
+            display: block;
+        }
+
     </style>
 </head>
 
@@ -388,7 +397,7 @@
             </div>
         </div>
         <div id="submitbutton" style="display: flex; margin-top: 10px; align-items: center; position: relative;">
-            <div id="loadingSpinner" class="mochaSpinner" style="display: block; bottom: 2px;"></div>
+            <img id="loadingSpinner" src="images/spinner.svg" alt="" aria-hidden="true">
             <div id="errorIcon" class="mochaErrorIcon invisible" style="bottom: 2px;"></div>
             <span id="metadataStatus" style="padding-left: 28px;">Retrieving metadata</span>
             <button id="saveTorrent" type="button" class="invisible" style="font-size: 1em;">QBT_TR(Save as .torrent file)QBT_TR[CONTEXT=AddNewTorrentDialog]</button>

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -3151,7 +3151,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                         img_path = "images/task-reject.svg";
                         break;
                     case "isLoading":
-                        img_path = "images/spinner.gif";
+                        img_path = "images/spinner.svg";
                         break;
                     case "unread":
                         img_path = "images/mail-inbox.svg";


### PR DESCRIPTION
Firefox seems to have an issue where svgs loaded via `background-url` are not animated. Loading the svg directly as an `img` fixes this.

Related: #23074
