### PR TITLE
Run all WebUI CI checks regardless of failure

### DIFF
--- a/.github/workflows/ci_webui.yaml
+++ b/.github/workflows/ci_webui.yaml
@@ -42,18 +42,22 @@ jobs:
         run: npm test
 
       - name: Lint code
+        if: ${{ !cancelled() }}
         run: npm run lint
 
       - name: Format code
+        if: ${{ !cancelled() }}
         run: |
           npm run format
           git diff --exit-code
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
+        if: ${{ !cancelled() }}
         with:
           config-file: .github/workflows/helper/codeql/js.yaml
           languages: javascript
 
       - name: Run CodeQL analysis
+        if: ${{ !cancelled() }}
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This fixes an annoyance I've hit with the WebUI CI checks. If the linter fails, the GH Action immediately exits before the formatter has run. This can mean fixing the lint error and pushing up a change, only for the GH Action to then fail due to the formatter check.

This PR makes it so that all checks always run, with the job still failing if any of the checks failed. It should allow for a quicker feedback loop. For an example, see #23199

GitHub Action docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context