### PR TITLE
WebUI: fix invalid method

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -176,7 +176,7 @@ window.qBittorrent.Client ??= (() => {
     const uploadTorrentFiles = (files) => {
         const fileNames = [];
         const formData = new FormData();
-        for (const [i, file] of files.entries()) {
+        for (const [i, file] of Array.prototype.entries.call(files)) {
             fileNames.push(file.name);
             // send dummy file name as file name won't be used and may not be encoded properly
             formData.append("file", file, i);


### PR DESCRIPTION
The FileList type has no `entries()` method. Use the generic function from `Array` instead.
Addresses https://github.com/qbittorrent/qBittorrent/pull/23182#discussion_r2319408410

Closes #23224.