### PR TITLE
Add tracker status column to Web UI torrent list

### DIFF
--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -70,6 +70,7 @@ inline const QString KEY_TORRENT_ROOT_PATH = u"root_path"_s;
 inline const QString KEY_TORRENT_ADDED_ON = u"added_on"_s;
 inline const QString KEY_TORRENT_COMPLETION_ON = u"completion_on"_s;
 inline const QString KEY_TORRENT_TRACKER = u"tracker"_s;
+inline const QString KEY_TORRENT_TRACKER_STATUS = u"tracker_status"_s;
 inline const QString KEY_TORRENT_TRACKERS_COUNT = u"trackers_count"_s;
 inline const QString KEY_TORRENT_DL_LIMIT = u"dl_limit"_s;
 inline const QString KEY_TORRENT_UP_LIMIT = u"up_limit"_s;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1123,6 +1123,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("added_on", "", "QBT_TR(Added On)QBT_TR[CONTEXT=TransferListModel]", 100, true);
             this.newColumn("completion_on", "", "QBT_TR(Completed On)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("tracker", "", "QBT_TR(Tracker)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("tracker_status", "", "QBT_TR(Tracker Status)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("dl_limit", "", "QBT_TR(Down Limit)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("up_limit", "", "QBT_TR(Up Limit)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("downloaded", "", "QBT_TR(Downloaded)QBT_TR[CONTEXT=TransferListModel]", 100, false);
@@ -1448,6 +1449,15 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const tracker = displayFullURLTrackerColumn ? value : window.qBittorrent.Misc.getHost(value);
                 td.textContent = tracker;
                 td.title = value;
+            };
+
+            // tracker_status
+            this.columns["tracker_status"].updateTd = function(td, row) {
+                const trackerStatus = this.getRowValue(row);
+                // Display the tracker message directly (now a string from backend)
+                const statusText = trackerStatus || "QBT_TR(Unknown)QBT_TR[CONTEXT=TrackerListWidget]";
+                td.textContent = statusText;
+                td.title = statusText;
             };
 
             //  dl_limit, up_limit

--- a/src/webui/www/translations/webui_en.ts
+++ b/src/webui/www/translations/webui_en.ts
@@ -2777,6 +2777,11 @@ Use ';' to split multiple entries. Can use wildcard '*'.</source>
         <translation type="unfinished" />
     </message>
     <message>
+        <source>Tracker Status</source>
+        <comment>Torrent tracker status (e.g. working, not working)</comment>
+        <translation type="unfinished" />
+    </message>
+    <message>
         <source>Down Limit</source>
         <comment>i.e: Download limit</comment>
         <translation type="unfinished" />


### PR DESCRIPTION
Display actual tracker messages in the torrent list. Shows specific error messages from trackers (e.g. 'Tracker is down', 'Authentication failed') or default status text when no specific message is available.

Implements both backend API changes to serialize tracker status messages and frontend table column with proper translation support.
