### PR TITLE
GHA CI: Install `NSIS` via third party action on Windows

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -199,6 +199,11 @@ jobs:
           name: qBittorrent-CI_Windows-x64_libtorrent-${{ matrix.libt_version }}
           path: upload
 
+      - name: Install NSIS
+        uses: repolevedavaj/install-nsis@265e893c16602d8ccfb0a9ca44173b084078917c # v1.0.3
+        with:
+          nsis-version: '3.11'
+
       - name: Create installer
         run: |
           7z x -o"dist/windows/" "dist/windows/NSISPlugins.zip"


### PR DESCRIPTION
* Install `NSIS` via https://github.com/repolevedavaj/install-nsis
* `NSIS` is no longer installed on GitHub provided Runner Image as of `windows-2025`
* `NSIS: 3.10` was only available on `windows-2019 / windows-2022`
* We can use newer release now eg. `NSIS: 3.11`.

👍 to @glassez for the tip!