### PR TITLE
WebUI: Add delay when closing submenu in WebUI

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -386,8 +386,7 @@ a.propButton img {
     margin: -29px 0 0 100%;
     padding: 0;
     position: absolute;
-    transition: left 1s;
-    transition-behavior: allow-discrete;
+    transition: left 1s allow-discrete;
     width: max-content;
     z-index: 8000;
 }
@@ -411,8 +410,7 @@ a.propButton img {
 .contextMenu li:not(.disabled):hover > ul {
     /* lists nested under hovered list items */
     left: auto;
-    transition: left 0s;
-    transition-behavior: allow-discrete;
+    transition: left 0s allow-discrete;
 }
 
 .contextMenu li img {


### PR DESCRIPTION
fixes #23252

this is a CSS-only fix to add a delay when closing the sub-menu in WebUI.

video show it works (ubuntu screen recorder doesn't show the mouse pointer), you can see the `copy` submenu doesn't go away immediately when the `export .torrent` menu item gets hovered

[Screencast from 2025-09-09 15-08-45.webm](https://github.com/user-attachments/assets/d6138cca-422e-4699-bbf3-634450f1e9b1)

Though adding a delay can result a small window of overlapping submenu (can be also screen in the video)
