### PR TITLE
Use class instead of struct

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -137,7 +137,7 @@ namespace
     };
 
     // Option with string value. May not have a shortcut
-    struct StringOption : protected Option
+    class StringOption : protected Option
     {
     public:
         explicit constexpr StringOption(const QStringView name)


### PR DESCRIPTION
use `class` instead of `struct` for consistency

all objects that extends `Option` in `src/app/cmdoptions.cpp` uses the `class` keyword except `StringOption`

no change in behavior.

makes the `public` in the mean something now in the `StringOption` class