### PR TITLE
WebUI: fix adding torrent when using virtual tables

### DIFF
--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -85,10 +85,7 @@
             });
 
             window.qBittorrent.pathAutofill.attachPathAutofill();
-            window.qBittorrent.TorrentContent.init("addTorrentFilesTableDiv", window.qBittorrent.DynamicTable.AddTorrentFilesTable);
-
-            if (fetchMetadata)
-                window.qBittorrent.AddTorrent.loadMetadata(source, downloader);
+            window.qBittorrent.AddTorrent.init(source, downloader, fetchMetadata);
         });
     </script>
 

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -29,14 +29,15 @@ window.qBittorrent.AddTorrent ??= (() => {
         return {
             changeCategorySelect: changeCategorySelect,
             changeTMM: changeTMM,
-            loadMetadata: loadMetadata,
             metadataCompleted: metadataCompleted,
             populateMetadata: populateMetadata,
             setWindowId: setWindowId,
-            submitForm: submitForm
+            submitForm: submitForm,
+            init: init
         };
     };
 
+    let table = null;
     let defaultSavePath = "";
     let defaultTempPath = "";
     let defaultTempPathEnabled = false;
@@ -307,10 +308,10 @@ window.qBittorrent.AddTorrent ??= (() => {
         document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
         document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
 
-        document.getElementById("filePriorities").value = [...document.getElementsByClassName("combo_priority")]
-            .filter((el) => !window.qBittorrent.TorrentContent.isFolder(Number(el.dataset.fileId)))
-            .sort((el1, el2) => Number(el1.dataset.fileId) - Number(el2.dataset.fileId))
-            .map((el) => Number(el.value));
+        document.getElementById("filePriorities").value = table.getFileTreeArray()
+            .filter((node) => !node.isFolder)
+            .sort((node1, node2) => (node1.fileId - node2.fileId))
+            .map((node) => node.priority);
 
         if (!isAutoTMMEnabled())
             document.getElementById("useDownloadPathHidden").value = document.getElementById("useDownloadPath").checked;
@@ -324,6 +325,12 @@ window.qBittorrent.AddTorrent ??= (() => {
             else
                 localPreferences.set("add_torrent_default_category", category);
         }
+    };
+
+    const init = (source, downloader, fetchMetadata) => {
+        table = window.qBittorrent.TorrentContent.init("addTorrentFilesTableDiv", window.qBittorrent.DynamicTable.AddTorrentFilesTable);
+        if (fetchMetadata)
+            loadMetadata(source, downloader);
     };
 
     window.addEventListener("load", async (event) => {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -2480,6 +2480,10 @@ window.qBittorrent.DynamicTable ??= (() => {
                 this.#addNodeToTable(child, depth + 1, node);
         }
 
+        getFileTreeArray() {
+            return this.fileTree.toArray();
+        }
+
         getRoot() {
             return this.fileTree.getRoot();
         }


### PR DESCRIPTION
When using virtual tables we can't rely on fetching the values from the DOM. We should always fetch values directly from the file tree.

Closes #23241.