### PR TITLE
Allow to filter RSS by simple string

### DIFF
--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -64,7 +64,7 @@ QListWidgetItem *ArticleListWidget::mapRSSArticle(RSS::Article *rssArticle) cons
     return m_rssArticleToListItemMapping.value(rssArticle);
 }
 
-void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly, QString const& filter)
+void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly, const QString &filter)
 {
     // Clear the list first
     clear();

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -80,7 +80,6 @@ void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly, const QS
         connect(m_rssItem, &RSS::Item::articleRead, this, &ArticleListWidget::handleArticleRead);
         connect(m_rssItem, &RSS::Item::articleAboutToBeRemoved, this, &ArticleListWidget::handleArticleAboutToBeRemoved);
 
-        const QString loweredFilter = filter.toLower();
         for (auto *article : asConst(rssItem->articles()))
         {
             if (!(m_unreadOnly && article->isRead()) && (filter.isEmpty() || article->title().contains(filter, Qt::CaseInsensitive)))

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -64,7 +64,7 @@ QListWidgetItem *ArticleListWidget::mapRSSArticle(RSS::Article *rssArticle) cons
     return m_rssArticleToListItemMapping.value(rssArticle);
 }
 
-void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly)
+void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly, QString const& filter)
 {
     // Clear the list first
     clear();
@@ -80,9 +80,10 @@ void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly)
         connect(m_rssItem, &RSS::Item::articleRead, this, &ArticleListWidget::handleArticleRead);
         connect(m_rssItem, &RSS::Item::articleAboutToBeRemoved, this, &ArticleListWidget::handleArticleAboutToBeRemoved);
 
+        QString loweredFilter = filter.toLower();
         for (auto *article : asConst(rssItem->articles()))
         {
-            if (!(m_unreadOnly && article->isRead()))
+            if (!(m_unreadOnly && article->isRead()) && (filter.isEmpty() || article->title().toLower().contains(loweredFilter)))
             {
                 auto *item = createItem(article);
                 addItem(item);

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -80,7 +80,7 @@ void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly, const QS
         connect(m_rssItem, &RSS::Item::articleRead, this, &ArticleListWidget::handleArticleRead);
         connect(m_rssItem, &RSS::Item::articleAboutToBeRemoved, this, &ArticleListWidget::handleArticleAboutToBeRemoved);
 
-        QString loweredFilter = filter.toLower();
+        const QString loweredFilter = filter.toLower();
         for (auto *article : asConst(rssItem->articles()))
         {
             if (!(m_unreadOnly && article->isRead()) && (filter.isEmpty() || article->title().toLower().contains(loweredFilter)))

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -83,7 +83,7 @@ void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly, const QS
         const QString loweredFilter = filter.toLower();
         for (auto *article : asConst(rssItem->articles()))
         {
-            if (!(m_unreadOnly && article->isRead()) && (filter.isEmpty() || article->title().toLower().contains(loweredFilter)))
+            if (!(m_unreadOnly && article->isRead()) && (filter.isEmpty() || article->title().contains(filter, Qt::CaseInsensitive)))
             {
                 auto *item = createItem(article);
                 addItem(item);

--- a/src/gui/rss/articlelistwidget.h
+++ b/src/gui/rss/articlelistwidget.h
@@ -48,7 +48,7 @@ public:
     RSS::Article *getRSSArticle(QListWidgetItem *item) const;
     QListWidgetItem *mapRSSArticle(RSS::Article *rssArticle) const;
 
-    void setRSSItem(RSS::Item *rssItem, bool unreadOnly = false);
+    void setRSSItem(RSS::Item *rssItem, bool unreadOnly, QString const& filter);
 
 private slots:
     void handleArticleAdded(RSS::Article *rssArticle);

--- a/src/gui/rss/articlelistwidget.h
+++ b/src/gui/rss/articlelistwidget.h
@@ -48,7 +48,7 @@ public:
     RSS::Article *getRSSArticle(QListWidgetItem *item) const;
     QListWidgetItem *mapRSSArticle(RSS::Article *rssArticle) const;
 
-    void setRSSItem(RSS::Item *rssItem, bool unreadOnly, QString const& filter);
+    void setRSSItem(RSS::Item *rssItem, bool unreadOnly, const QString &filter);
 
 private slots:
     void handleArticleAdded(RSS::Article *rssArticle);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -109,6 +109,7 @@ namespace
 RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     : GUIApplicationComponent(app, parent)
     , m_ui {new Ui::RSSWidget}
+    , m_rssFilter {new LineEdit(this)}
 {
     m_ui->setupUi(this);
 
@@ -131,7 +132,6 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     m_ui->rssDownloaderBtn->setIcon(UIThemeManager::instance()->getIcon(u"downloading"_s, u"download"_s));
 #endif
 
-    m_rssFilter = new LineEdit(this);
     m_rssFilter->setMaximumWidth(200);
     m_rssFilter->setPlaceholderText(tr("Filter feed items..."));
 

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -135,8 +135,8 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     m_rssFilter->setMaximumWidth(200);
     m_rssFilter->setPlaceholderText(tr("Filter feed items..."));
 
-    const auto spacer_index = m_ui->horizontalLayout->indexOf(m_ui->spacer1);
-    m_ui->horizontalLayout->insertWidget(spacer_index+1, m_rssFilter);
+    const int spacerIndex = m_ui->horizontalLayout->indexOf(m_ui->spacer1);
+    m_ui->horizontalLayout->insertWidget(spacerIndex + 1, m_rssFilter);
 
     connect(m_rssFilter, &QLineEdit::textChanged, this, &RSSWidget::handleRSSFilterTextChanged);
     connect(m_ui->articleListWidget, &ArticleListWidget::customContextMenuRequested, this, &RSSWidget::displayItemsListMenu);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -135,14 +135,14 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     QSizePolicy sizePolicy {QSizePolicy::Policy::Fixed, QSizePolicy::Policy::Fixed};
     sizePolicy.setHorizontalStretch(200);
     sizePolicy.setVerticalStretch(0);
-    sizePolicy.setHeightForWidth(rssFilter->sizePolicy().hasHeightForWidth());
+    sizePolicy.setHeightForWidth(m_rssFilter->sizePolicy().hasHeightForWidth());
     m_rssFilter->setSizePolicy(sizePolicy);
     m_rssFilter->setPlaceholderText(tr("Filter torrents..."));
 
     const auto spacer_index = m_ui->horizontalLayout->indexOf(m_ui->spacer1);
-    m_ui->horizontalLayout->insertWidget(spacer_index+1, rssFilter);
+    m_ui->horizontalLayout->insertWidget(spacer_index+1, m_rssFilter);
 
-    connect(rssFilter, &QLineEdit::textChanged, this, &RSSWidget::handleRSSFilterTextChanged);
+    connect(m_rssFilter, &QLineEdit::textChanged, this, &RSSWidget::handleRSSFilterTextChanged);
     connect(m_ui->articleListWidget, &ArticleListWidget::customContextMenuRequested, this, &RSSWidget::displayItemsListMenu);
     connect(m_ui->articleListWidget, &ArticleListWidget::currentItemChanged, this, &RSSWidget::handleCurrentArticleItemChanged);
     connect(m_ui->articleListWidget, &ArticleListWidget::itemDoubleClicked, this, &RSSWidget::downloadSelectedTorrents);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -132,12 +132,7 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
 #endif
 
     m_rssFilter = new LineEdit(this);
-    m_rssFilter->setObjectName("rssFilter");
-    QSizePolicy sizePolicy {QSizePolicy::Policy::Fixed, QSizePolicy::Policy::Fixed};
-    sizePolicy.setHorizontalStretch(200);
-    sizePolicy.setVerticalStretch(0);
-    sizePolicy.setHeightForWidth(m_rssFilter->sizePolicy().hasHeightForWidth());
-    m_rssFilter->setSizePolicy(sizePolicy);
+    m_rssFilter->setMaximumWidth(200);
     m_rssFilter->setPlaceholderText(tr("Filter feed items..."));
 
     const auto spacer_index = m_ui->horizontalLayout->indexOf(m_ui->spacer1);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -130,15 +130,14 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     m_ui->rssDownloaderBtn->setIcon(UIThemeManager::instance()->getIcon(u"downloading"_s, u"download"_s));
 #endif
 
-    auto *rssFilter = new LineEdit(this);
-    rssFilter->setObjectName("rssFilter");
-    QSizePolicy sizePolicy(QSizePolicy::Policy::Fixed, QSizePolicy::Policy::Fixed);
+    m_rssFilter = new LineEdit(this);
+    m_rssFilter->setObjectName("rssFilter");
+    QSizePolicy sizePolicy {QSizePolicy::Policy::Fixed, QSizePolicy::Policy::Fixed};
     sizePolicy.setHorizontalStretch(200);
     sizePolicy.setVerticalStretch(0);
     sizePolicy.setHeightForWidth(rssFilter->sizePolicy().hasHeightForWidth());
-    rssFilter->setSizePolicy(sizePolicy);
-    rssFilter->setProperty("placeholderText", tr("Filter torrents..."));
-    m_rssFilter = rssFilter;
+    m_rssFilter->setSizePolicy(sizePolicy);
+    m_rssFilter->setPlaceholderText(tr("Filter torrents..."));
 
     const auto spacer_index = m_ui->horizontalLayout->indexOf(m_ui->spacer1);
     m_ui->horizontalLayout->insertWidget(spacer_index+1, rssFilter);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -656,7 +656,7 @@ void RSSWidget::handleUnreadCountChanged()
     emit unreadCountUpdated(RSS::Session::instance()->rootFolder()->unreadCount());
 }
 
-void RSSWidget::handleRSSFilterTextChanged([[maybe_unused]] const QString& newFilter)
+void RSSWidget::handleRSSFilterTextChanged(const QString &newFilter)
 {
     auto *currentItem = m_ui->feedListWidget->currentItem();
     m_ui->articleListWidget->setRSSItem(m_ui->feedListWidget->getRSSItem(currentItem)

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -137,7 +137,7 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     sizePolicy.setVerticalStretch(0);
     sizePolicy.setHeightForWidth(m_rssFilter->sizePolicy().hasHeightForWidth());
     m_rssFilter->setSizePolicy(sizePolicy);
-    m_rssFilter->setPlaceholderText(tr("Filter torrents..."));
+    m_rssFilter->setPlaceholderText(tr("Filter feed items..."));
 
     const auto spacer_index = m_ui->horizontalLayout->indexOf(m_ui->spacer1);
     m_ui->horizontalLayout->insertWidget(spacer_index+1, m_rssFilter);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -136,7 +136,7 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     m_rssFilter->setPlaceholderText(tr("Filter feed items..."));
 
     const int spacerIndex = m_ui->horizontalLayout->indexOf(m_ui->spacer1);
-    m_ui->horizontalLayout->insertWidget(spacerIndex + 1, m_rssFilter);
+    m_ui->horizontalLayout->insertWidget((spacerIndex + 1), m_rssFilter);
 
     connect(m_rssFilter, &QLineEdit::textChanged, this, &RSSWidget::handleRSSFilterTextChanged);
     connect(m_ui->articleListWidget, &ArticleListWidget::customContextMenuRequested, this, &RSSWidget::displayItemsListMenu);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -653,7 +653,7 @@ void RSSWidget::handleUnreadCountChanged()
 
 void RSSWidget::handleRSSFilterTextChanged(const QString &newFilter)
 {
-    auto *currentItem = m_ui->feedListWidget->currentItem();
+    QTreeWidgetItem *currentItem = m_ui->feedListWidget->currentItem();
     m_ui->articleListWidget->setRSSItem(m_ui->feedListWidget->getRSSItem(currentItem)
                                     , (currentItem == m_ui->feedListWidget->stickyUnreadItem())
                                     , newFilter);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -137,7 +137,7 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     sizePolicy.setVerticalStretch(0);
     sizePolicy.setHeightForWidth(rssFilter->sizePolicy().hasHeightForWidth());
     rssFilter->setSizePolicy(sizePolicy);
-    rssFilter->setProperty("placeholderText", u"Filter..."_s);
+    rssFilter->setProperty("placeholderText", tr("Filter torrents..."));
     m_rssFilter = rssFilter;
 
     const auto spacer_index = m_ui->horizontalLayout->indexOf(m_ui->spacer1);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -49,6 +49,7 @@
 #include "base/rss/rss_session.h"
 #include "gui/autoexpandabledialog.h"
 #include "gui/interfaces/iguiapplication.h"
+#include "gui/lineedit.h"
 #include "gui/uithememanager.h"
 #include "gui/utils/keysequence.h"
 #include "articlelistwidget.h"

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -92,6 +92,6 @@ private:
     bool eventFilter(QObject *obj, QEvent *event) override;
     void renderArticle(const RSS::Article *article) const;
 
-    LineEdit *m_rssFilter = nullptr;
     Ui::RSSWidget *m_ui = nullptr;
+    LineEdit *m_rssFilter = nullptr;
 };

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -86,12 +86,12 @@ private slots:
     void on_rssDownloaderBtn_clicked();
     void handleSessionProcessingStateChanged(bool enabled);
     void handleUnreadCountChanged();
-    void handleRSSFilterTextChanged(const QString& newFilter);
+    void handleRSSFilterTextChanged(const QString &newFilter);
 
 private:
     bool eventFilter(QObject *obj, QEvent *event) override;
     void renderArticle(const RSS::Article *article) const;
 
-    LineEdit* m_rssFilter = nullptr;
+    LineEdit *m_rssFilter = nullptr;
     Ui::RSSWidget *m_ui = nullptr;
 };

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -33,6 +33,7 @@
 #include <QWidget>
 
 #include "gui/guiapplicationcomponent.h"
+#include "gui/lineedit.h"
 
 class QListWidgetItem;
 class QTreeWidgetItem;
@@ -85,10 +86,12 @@ private slots:
     void on_rssDownloaderBtn_clicked();
     void handleSessionProcessingStateChanged(bool enabled);
     void handleUnreadCountChanged();
+    void handleRSSFilterTextChanged(const QString& newFilter);
 
 private:
     bool eventFilter(QObject *obj, QEvent *event) override;
     void renderArticle(const RSS::Article *article) const;
 
+    LineEdit* m_rssFilter = nullptr;
     Ui::RSSWidget *m_ui = nullptr;
 };

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -33,8 +33,8 @@
 #include <QWidget>
 
 #include "gui/guiapplicationcomponent.h"
-#include "gui/lineedit.h"
 
+class LineEdit;
 class QListWidgetItem;
 class QTreeWidgetItem;
 

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -89,8 +89,30 @@
         padding: 3px 6px;
     }
 
+    #rssButtonBar input {
+        background-color: var(--color-background-default);
+        background-image: url("../images/edit-find.svg");
+        background-position: 2px;
+        background-repeat: no-repeat;
+        background-size: 1.5em;
+        border: 1px solid var(--color-border-default);
+        border-radius: 3px;
+        min-width: 170px;
+        padding: 2px 2px 2px 25px;
+    }
+
+    #rssButtonBar div {
+        display: inline-block;
+        vertical-align: top;
+    }
+
     #rssButtonBar button img {
         margin: 0 5px -3px 0;
+    }
+
+    #rssFilterToolbar {
+        float: right;
+        margin-right: 5px;
     }
 
     #rssContentView table {
@@ -120,9 +142,12 @@
             <button type="button" id="updateAllButton" onclick="qBittorrent.Rss.refreshAllFeeds()">
                 <img alt="QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]" src="images/view-refresh.svg" width="16" height="16">QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]
             </button>
-            <button type="button" id="rssDownloaderButton" class="alignRight" onclick="qBittorrent.Rss.openRssDownloader()">
-                <img alt="QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]" src="images/downloading.svg" width="16" height="16">QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]
-            </button>
+            <div id="rssFilterToolbar" class="alignRight">
+                <input type="search" id="rssFilterInput" placeholder="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" aria-label="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" autocorrect="off" autocapitalize="none">
+                <button type="button" id="rssDownloaderButton" onclick="qBittorrent.Rss.openRssDownloader()">
+                    <img alt="QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]" src="images/downloading.svg" width="16" height="16">QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]
+                </button>
+            </div>
         </div>
     </div>
     <div id="rssContentView">
@@ -277,6 +302,17 @@
                     rssFeedContextMenu.updateMenuItems();
                 }
             });
+            document.getElementById("rssFilterInput").addEventListener("input", (event) => {
+                const rowId = rssFeedTable.selectedRows[0];
+                let path = "";
+                for (const row of rssFeedTable.getRowValues()) {
+                    if (row.rowId === rowId) {
+                        path = row.full_data.dataPath;
+                        break;
+                    }
+                }
+                qBittorrent.Rss.showRssFeed(path)
+            });
 
             document.getElementById("CopyFeedURL").addEventListener("click", async (event) => {
                 let joined = "";
@@ -405,6 +441,12 @@
             // filter read articles if "Unread" feed is selected
             if (path === "")
                 visibleArticles = visibleArticles.filter((a) => !a.isRead);
+
+            const rssFilterInput = document.getElementById("rssFilterInput");
+            if (rssFilterInput.value) {
+                const lowerFilter = rssFilterInput.value.toLowerCase();
+                visibleArticles = visibleArticles.filter((a) => a.title.toLowerCase().includes(lowerFilter));
+            }
 
             let rowID = -1;
             visibleArticles.sort((e1, e2) => new Date(e2.date) - new Date(e1.date))

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -143,7 +143,7 @@
                 <img alt="QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]" src="images/view-refresh.svg" width="16" height="16">QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]
             </button>
             <div id="rssFilterToolbar" class="alignRight">
-                <input type="search" id="rssFilterInput" placeholder="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" aria-label="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" autocorrect="off" autocapitalize="none">
+                <input type="search" id="rssFilterInput" placeholder="QBT_TR(Filter feed items...)QBT_TR[CONTEXT=MainWindow]" aria-label="QBT_TR(Filter feed items...)QBT_TR[CONTEXT=MainWindow]" autocorrect="off" autocapitalize="none">
                 <button type="button" id="rssDownloaderButton" onclick="qBittorrent.Rss.openRssDownloader()">
                     <img alt="QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]" src="images/downloading.svg" width="16" height="16">QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]
                 </button>

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -311,7 +311,7 @@
                         break;
                     }
                 }
-                qBittorrent.Rss.showRssFeed(path)
+                qBittorrent.Rss.showRssFeed(path);
             });
 
             document.getElementById("CopyFeedURL").addEventListener("click", async (event) => {

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -443,7 +443,7 @@
                 visibleArticles = visibleArticles.filter((a) => !a.isRead);
 
             const rssFilterInput = document.getElementById("rssFilterInput");
-            if (rssFilterInput.value) {
+            if (rssFilterInput.value.length > 0) {
                 const lowerFilter = rssFilterInput.value.toLowerCase();
                 visibleArticles = visibleArticles.filter((a) => a.title.toLowerCase().includes(lowerFilter));
             }


### PR DESCRIPTION
Adds a search bar for RSS items. It supports plain text search (no regex), applies only to the selected tab, updates results as you type, and shows all items when the field is empty.


GUI
<img width="1280" height="720" alt="GUI" src="https://github.com/user-attachments/assets/e7f729f5-fb3b-4b2d-9db7-2b801fa25b22" />

webui
<img width="1274" height="723" alt="webui" src="https://github.com/user-attachments/assets/f27b8975-db8f-4aae-bbaf-45f6ede959a8" />


resolves #15538, resolves #22570, resolves #14719, resolves #18444, resolves #18183