### PR TITLE
Don't create lock file in internal data folders

### DIFF
--- a/src/base/asyncfilestorage.cpp
+++ b/src/base/asyncfilestorage.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2017-2024  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2017-2025  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -34,52 +34,15 @@
 #include "base/utils/fs.h"
 #include "base/utils/io.h"
 
-QHash<Path, std::weak_ptr<QFile>> AsyncFileStorage::m_reservedPaths;
-QReadWriteLock AsyncFileStorage::m_reservedPathsLock;
-
 AsyncFileStorage::AsyncFileStorage(const Path &storageFolderPath, QObject *parent)
     : QObject(parent)
     , m_storageDir(storageFolderPath)
 {
     Q_ASSERT(m_storageDir.isAbsolute());
 
-    const Path lockFilePath = m_storageDir / Path(u"storage.lock"_s);
-
-    {
-        const QReadLocker readLocker {&m_reservedPathsLock};
-        m_lockFile = m_reservedPaths.value(lockFilePath).lock();
-    }
-
-    if (!m_lockFile)
-    {
-        const QWriteLocker writeLocker {&m_reservedPathsLock};
-        if (std::weak_ptr<QFile> &lockFile = m_reservedPaths[lockFilePath]; lockFile.expired()) [[likely]]
-        {
-            if (!Utils::Fs::mkpath(m_storageDir))
-                throw AsyncFileStorageError(tr("Could not create directory '%1'.").arg(m_storageDir.toString()));
-
-            auto lockFileDeleter = [](QFile *file)
-            {
-                file->close();
-                file->remove();
-                delete file;
-            };
-            m_lockFile = std::shared_ptr<QFile>(new QFile(lockFilePath.data()), std::move(lockFileDeleter));
-
-            // TODO: This folder locking approach does not work for UNIX systems. Implement it.
-            if (!m_lockFile->open(QFile::WriteOnly))
-                throw AsyncFileStorageError(m_lockFile->errorString());
-
-            lockFile = m_lockFile;
-        }
-        else
-        {
-            m_lockFile = lockFile.lock();
-        }
-    }
+    if (!Utils::Fs::mkpath(m_storageDir))
+        throw AsyncFileStorageError(tr("Could not create directory '%1'.").arg(m_storageDir.toString()));
 }
-
-AsyncFileStorage::~AsyncFileStorage() = default;
 
 void AsyncFileStorage::store(const Path &filePath, const QByteArray &data)
 {

--- a/src/base/asyncfilestorage.h
+++ b/src/base/asyncfilestorage.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2017-2024  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2017-2025  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,12 +28,7 @@
 
 #pragma once
 
-#include <memory>
-
-#include <QFile>
-#include <QHash>
 #include <QObject>
-#include <QReadWriteLock>
 
 #include "base/exceptions.h"
 #include "base/path.h"
@@ -51,7 +46,6 @@ class AsyncFileStorage final : public QObject
 
 public:
     explicit AsyncFileStorage(const Path &storageFolderPath, QObject *parent = nullptr);
-    ~AsyncFileStorage() override;
 
     void store(const Path &filePath, const QByteArray &data);
 
@@ -64,8 +58,4 @@ private:
     Q_INVOKABLE void store_impl(const Path &fileName, const QByteArray &data);
 
     Path m_storageDir;
-    std::shared_ptr<QFile> m_lockFile;
-
-    static QHash<Path, std::weak_ptr<QFile>> m_reservedPaths;
-    static QReadWriteLock m_reservedPathsLock;
 };


### PR DESCRIPTION
It is actually overkill to create such "lock" files in internal data folders. They have no desired effect on Linux and there were no problem on such systems for  years. But on Windows there are many error reports related to them.