### PR TITLE
Propagate error messages from search engine

### DIFF
--- a/src/base/search/searchdownloadhandler.h
+++ b/src/base/search/searchdownloadhandler.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <QObject>
+#include <QString>
 
 class QProcess;
 
@@ -44,11 +45,13 @@ class SearchDownloadHandler : public QObject
     SearchDownloadHandler(const QString &pluginName, const QString &url, SearchPluginManager *manager);
 
 signals:
-    void downloadFinished(const QString &path);
+    void downloadFinished(const QString &path, const QString &errorMessage);
 
 private:
     void downloadProcessFinished(int exitcode);
 
+    QString m_pluginName;
+    QString m_url;
     SearchPluginManager *m_manager = nullptr;
     QProcess *m_downloadProcess = nullptr;
 };

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -31,12 +31,14 @@
 
 #include <chrono>
 
+#include <QtLogging>
 #include <QList>
 #include <QMetaObject>
 #include <QProcess>
 #include <QTimer>
 
 #include "base/global.h"
+#include "base/logger.h"
 #include "base/path.h"
 #include "base/utils/bytearray.h"
 #include "base/utils/foreignapps.h"
@@ -58,6 +60,26 @@ namespace
         PL_DESC_LINK,
         PL_PUB_DATE,
         NB_PLUGIN_COLUMNS
+    };
+
+    QString toString(const QProcess::ProcessError error)
+    {
+        switch (error)
+        {
+        case QProcess::FailedToStart:
+            return SearchHandler::tr("Process failed to start");
+        case QProcess::Crashed:
+            return SearchHandler::tr("Process crashed");
+        case QProcess::Timedout:
+            return SearchHandler::tr("Process timed out");
+        case QProcess::WriteError:
+            return SearchHandler::tr("Process write error");
+        case QProcess::ReadError:
+            return SearchHandler::tr("Process read error");
+        case QProcess::UnknownError:
+            return SearchHandler::tr("Process unknown error");
+        }
+        return {};
     };
 }
 
@@ -86,7 +108,16 @@ SearchHandler::SearchHandler(const QString &pattern, const QString &category, co
     };
     m_searchProcess->setArguments(params + m_pattern.split(u' '));
 
-    connect(m_searchProcess, &QProcess::errorOccurred, this, &SearchHandler::processFailed);
+    connect(m_searchProcess, &QProcess::errorOccurred, this, [this](const QProcess::ProcessError error)
+    {
+        if (!m_searchCancelled)
+        {
+            const auto errMsg = toString(error);
+            LogMsg(tr("Search process failed. Search query: \"%1\". Category: \"%2\". Engines: \"%3\". Error: \"%4\".")
+                .arg(m_pattern, m_category, m_usedPlugins.join(u", "), errMsg), Log::WARNING);
+            emit searchFailed(errMsg);
+        }
+    });
     connect(m_searchProcess, &QProcess::readyReadStandardOutput, this, &SearchHandler::readSearchOutput);
     connect(m_searchProcess, qOverload<int, QProcess::ExitStatus>(&QProcess::finished)
             , this, &SearchHandler::processFinished);
@@ -127,12 +158,20 @@ void SearchHandler::processFinished(const int exitcode)
 {
     m_searchTimeout->stop();
 
+    const auto errMsg = QString::fromUtf8(m_searchProcess->readAllStandardError()).trimmed();
+    if (!errMsg.isEmpty())
+    {
+        qWarning("%s", qUtf8Printable(errMsg));
+        LogMsg(tr("Error occurred in search engine. Search query: \"%1\". Category: \"%2\". Engines: \"%3\". Error: \"%4\".")
+            .arg(m_pattern, m_category, m_usedPlugins.join(u", "), errMsg), Log::WARNING);
+    }
+
     if (m_searchCancelled)
         emit searchFinished(true);
     else if ((m_searchProcess->exitStatus() == QProcess::NormalExit) && (exitcode == 0))
         emit searchFinished(false);
     else
-        emit searchFailed();
+        emit searchFailed(errMsg);
 }
 
 // search QProcess return output as soon as it gets new
@@ -159,12 +198,6 @@ void SearchHandler::readSearchOutput()
         m_results.append(searchResultList);
         emit newSearchResults(searchResultList);
     }
-}
-
-void SearchHandler::processFailed()
-{
-    if (!m_searchCancelled)
-        emit searchFailed();
 }
 
 // Parse one line of search results list

--- a/src/base/search/searchhandler.h
+++ b/src/base/search/searchhandler.h
@@ -74,12 +74,11 @@ public:
 
 signals:
     void searchFinished(bool cancelled = false);
-    void searchFailed();
+    void searchFailed(const QString &errorMessage);
     void newSearchResults(const QList<SearchResult> &results);
 
 private:
     void readSearchOutput();
-    void processFailed();
     void processFinished(int exitcode);
     bool parseSearchResult(QByteArrayView line, SearchResult &searchResult);
 

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -31,6 +31,7 @@
 
 #include <memory>
 
+#include <QtLogging>
 #include <QDir>
 #include <QDirIterator>
 #include <QDomDocument>
@@ -558,6 +559,13 @@ void SearchPluginManager::update()
     };
     nova.start(Utils::ForeignApps::pythonInfo().executablePath.data(), params, QIODevice::ReadOnly);
     nova.waitForFinished();
+
+    if (const auto errMsg = QString::fromUtf8(nova.readAllStandardError()).trimmed()
+        ; !errMsg.isEmpty())
+    {
+        qWarning("%s", qUtf8Printable(errMsg));
+        LogMsg(tr("Error occurred when fetching search engine capabilities. Error: \"%1\".").arg(errMsg), Log::WARNING);
+    }
 
     const auto capabilities = QString::fromUtf8(nova.readAllStandardOutput());
     QDomDocument xmlDoc;

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -112,7 +112,7 @@ private:
     void contextMenuEvent(QContextMenuEvent *event) override;
     void onItemDoubleClicked(const QModelIndex &index);
     void searchFinished(bool cancelled);
-    void searchFailed();
+    void searchFailed(const QString &errorMessage);
     void appendSearchResults(const QList<SearchResult> &results);
     void updateResultsCount();
     void setStatus(Status value);

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -114,8 +114,8 @@ void SearchController::startAction()
 
     const auto id = generateSearchId();
     const std::shared_ptr<SearchHandler> searchHandler {SearchPluginManager::instance()->startSearch(pattern, category, pluginsToUse)};
-    QObject::connect(searchHandler.get(), &SearchHandler::searchFinished, this, [id, this]() { m_activeSearches.remove(id); });
-    QObject::connect(searchHandler.get(), &SearchHandler::searchFailed, this, [id, this]() { m_activeSearches.remove(id); });
+    connect(searchHandler.get(), &SearchHandler::searchFinished, this, [this, id] { m_activeSearches.remove(id); });
+    connect(searchHandler.get(), &SearchHandler::searchFailed, this, [this, id]([[maybe_unused]] const QString &errorMessage) { m_activeSearches.remove(id); });
 
     m_searchHandlers.insert(id, searchHandler);
 
@@ -235,8 +235,8 @@ void SearchController::downloadTorrentAction()
     else
     {
         SearchDownloadHandler *downloadHandler = SearchPluginManager::instance()->downloadTorrent(pluginName, torrentUrl);
-        connect(downloadHandler, &SearchDownloadHandler::downloadFinished
-                , this, [this, downloadHandler](const QString &source)
+        connect(downloadHandler, &SearchDownloadHandler::downloadFinished, this
+            , [this, downloadHandler](const QString &source, [[maybe_unused]] const QString &errorMessage)
         {
             app()->addTorrentManager()->addTorrent(source);
             downloadHandler->deleteLater();


### PR DESCRIPTION
This will be useful for development and debugging issues. The messages will be outputted to both console and qbt logger.
Note that having stderr messages does not always mean the operation failed but there might be some (non-fatal) issues.

