### PR TITLE
WebUI: don't send HTTP Referer header to other servers

### DIFF
--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -503,7 +503,7 @@
                 const iframeElement = document.createElement("iframe");
                 iframeElement.id = "rssDescription";
                 iframeElement.sandbox = "allow-same-origin"; // allowed to get parent css
-                iframeElement.srcdoc = `<html ${rootColor}><head><meta charset="utf-8"><link rel="stylesheet" type="text/css" href="css/style.css?v=${CACHEID}"></head><body>${articleDescription}</body></html>`;
+                iframeElement.srcdoc = `<html ${rootColor}><head><meta charset="utf-8"><meta name="referrer" content="same-origin"><link rel="stylesheet" type="text/css" href="css/style.css?v=${CACHEID}"></head><body>${articleDescription}</body></html>`;
 
                 detailsView.append(iframeElement);
             }


### PR DESCRIPTION
`same-origin`:
> Sends the full URL (stripped of parameters) for same-origin requests. Cross-origin requests will contain no referrer header.

This would be helpful for 3rd party WebUI that were forked from the official one. The official WebUI is not affected by this change since the request is currently blocked by CSP.

