### PR TITLE
Add Torrent Creator toolbar button

### DIFF
--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>914</width>
+    <width>932</width>
     <height>563</height>
    </rect>
   </property>
@@ -34,8 +34,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>914</width>
-     <height>22</height>
+     <width>932</width>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">
@@ -159,6 +159,8 @@
    <addaction name="actionIncreaseQueuePos"/>
    <addaction name="actionDecreaseQueuePos"/>
    <addaction name="actionBottomQueuePos"/>
+   <addaction name="separator"/>
+   <addaction name="actionCreateTorrent"/>
    <addaction name="separator"/>
    <addaction name="actionOptions"/>
    <addaction name="actionLock"/>

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>932</width>
+    <width>960</width>
     <height>563</height>
    </rect>
   </property>
@@ -34,7 +34,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>932</width>
+     <width>960</width>
      <height>20</height>
     </rect>
    </property>

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>960</width>
+    <width>914</width>
     <height>563</height>
    </rect>
   </property>
@@ -34,8 +34,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>960</width>
-     <height>20</height>
+     <width>914</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -135,6 +135,7 @@
                     <a id="decreasePrioButton"><img class="mochaToolButton" title="QBT_TR(Move down in the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
                     <a id="bottomPrioButton"><img class="mochaToolButton" title="QBT_TR(Move to the bottom of the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
                 </span>
+                <a id="torrentCreatorButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Torrent Creator)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-creator.svg" alt="QBT_TR(Torrent Creator)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
                 <a id="preferencesButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" src="images/configure.svg" alt="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" width="24" height="24"></a>
                 <div id="mainWindowTabs" class="toolbarTabs">
                     <menu id="mainWindowTabsList" class="tab-menu">


### PR DESCRIPTION
**Summary**: 
This PR adds a "Torrent Creator" button to the toolbar in qBittorrent, placing it next to existing buttons for improved accessibility.

**Problem**: 
The torrent creator functionality exists but is currently only accessible via the Tools dropdown menu "Torrent Creator" or shortcut (CTRL+N), making it less convenient for quick access without menu navigation. Due to it being a frequently used action, there have been requests to add it to the quick access toolbar, such as here: https://github.com/qbittorrent/qBittorrent/issues/21489.

**Solution**: 
- Added the torrent creator button to the main toolbar, positioned next to the existing buttons.
- The button triggers the existing torrent creator dialog.
- Updated the toolbar layout to ensure consistent spacing and alignment.

**Implementation Notes**: 
- From left to right, the existing toolbar button arrangement typically mirrors the sequence of dropdown menu items, with buttons aligned in the same order as they appear in the menus.
- The "Torrent Creator" button has been placed before the preferences icon, mirroring the Tools menu order (i.e top to bottom, with a separator between "Torrent Creator" and "Preferences").

**New toolbar including "Torrent Creator" button**:  
<img width="273" height="40" alt="image" src="https://github.com/user-attachments/assets/20abeff4-59ca-4053-8241-710ced36ca6a" />


**Existing "Torrent Creator" menu item (unchanged)**:
<img width="233" height="117" alt="image" src="https://github.com/user-attachments/assets/815533f2-5505-41f1-9154-c3c843ef54aa" />

**Testing**: Verified on Windows 11 and Linux Mint 22.1, confirming the button is correctly placed, functional, and visually consistent with the toolbar. Not tested on macOS.

Resolves #21489