### PR TITLE
NSIS: Add support for Windows ARM64 build

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -10,8 +10,8 @@ concurrency:
 
 jobs:
   ci:
-    name: Build
-    runs-on: windows-latest
+    name: Build (${{ matrix.libt_version }}, ${{ matrix.config.arch }})
+    runs-on: ${{ matrix.config.os }}
     permissions:
       actions: write
 
@@ -19,6 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         libt_version: ["2.0.11", "1.2.20"]
+        config:
+        - os: windows-latest
+          arch: x64
+          qt_arch: win64_msvc2022_64
 
     env:
       boost_path: "${{ github.workspace }}/../boost"
@@ -33,6 +37,8 @@ jobs:
 
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.config.arch }}
 
       - name: Install build tools
         run: |
@@ -57,19 +63,19 @@ jobs:
           New-Item `
             -Force `
             -ItemType File `
-            -Path "${{ env.vcpkg_path }}/triplets_overlay/x64-windows-static-md-release.cmake"
+            -Path "${{ env.vcpkg_path }}/triplets_overlay/${{ matrix.config.arch }}-windows-static-md-release.cmake"
           # OpenSSL isn't compatible with `/guard:cf` flag so we omit it for now, see: https://github.com/openssl/openssl/issues/22554
           Add-Content `
-            -Path "${{ env.vcpkg_path }}/triplets_overlay/x64-windows-static-md-release.cmake" `
-            -Value @("set(VCPKG_TARGET_ARCHITECTURE x64)",
+            -Path "${{ env.vcpkg_path }}/triplets_overlay/${{ matrix.config.arch }}-windows-static-md-release.cmake" `
+            -Value @("set(VCPKG_TARGET_ARCHITECTURE ${{ matrix.config.arch }})",
               "set(VCPKG_LIBRARY_LINKAGE static)",
               "set(VCPKG_CRT_LINKAGE dynamic)",
               "set(VCPKG_BUILD_TYPE release)")
           # clear buildtrees after each package installation to reduce disk space requirements
           $packages = `
-            "boost-build:x64-windows-static-md-release",
-            "openssl:x64-windows-static-md-release",
-            "zlib:x64-windows-static-md-release"
+            "boost-build:${{ matrix.config.arch }}-windows-static-md-release",
+            "openssl:${{ matrix.config.arch }}-windows-static-md-release",
+            "zlib:${{ matrix.config.arch }}-windows-static-md-release"
           ${{ env.vcpkg_path }}/vcpkg.exe upgrade `
             --no-dry-run `
             --overlay-triplets="${{ env.vcpkg_path }}/triplets_overlay"
@@ -97,7 +103,7 @@ jobs:
           move "${{ github.workspace }}/../boost_*" "${{ env.boost_path }}"
           cd "${{ env.boost_path }}"
           #.\bootstrap.bat
-          ${{ env.vcpkg_path }}/installed/x64-windows-static-md-release/tools/boost-build/b2.exe `
+          ${{ env.vcpkg_path }}/installed/${{ matrix.config.arch }}-windows-static-md-release/tools/boost-build/b2.exe `
             stage `
             toolset=msvc `
             --stagedir=.\ `
@@ -107,7 +113,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: "6.9.1"
-          arch: win64_msvc2022_64
+          arch: ${{ matrix.config.qt_arch }}
           archives: qtbase qtsvg qttools
           cache: true
 
@@ -134,7 +140,7 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF `
             -Ddeprecated-functions=OFF `
             -Dstatic_runtime=OFF `
-            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md-release
+            -DVCPKG_TARGET_TRIPLET=${{ matrix.config.arch }}-windows-static-md-release
           cmake --build build
           cmake --install build
 
@@ -151,7 +157,7 @@ jobs:
             -DLibtorrentRasterbar_DIR="${{ env.libtorrent_path }}/install/lib/cmake/LibtorrentRasterbar" `
             -DMSVC_RUNTIME_DYNAMIC=ON `
             -DTESTING=ON `
-            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md-release `
+            -DVCPKG_TARGET_TRIPLET=${{ matrix.config.arch }}-windows-static-md-release `
             -DVERBOSE_CONFIGURE=ON `
             --graphviz=build/target_graph.dot
           cmake --build build --target qbt_update_translations
@@ -196,7 +202,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: qBittorrent-CI_Windows-x64_libtorrent-${{ matrix.libt_version }}
+          name: qBittorrent-CI_Windows-${{ matrix.config.arch }}_libtorrent-${{ matrix.libt_version }}
           path: upload
 
       - name: Install NSIS
@@ -207,10 +213,10 @@ jobs:
       - name: Create installer
         run: |
           7z x -o"dist/windows/" "dist/windows/NSISPlugins.zip"
-          makensis /DQBT_DIST_DIR="../../upload/qBittorrent" /WX dist/windows/qbittorrent.nsi
+          makensis /DQBT_CPU_ARCH="${{ matrix.config.arch }}" /DQBT_DIST_DIR="../../upload/qBittorrent" /WX dist/windows/qbittorrent.nsi
 
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:
-          name: qBittorrent-CI_Windows-x64_libtorrent-${{ matrix.libt_version }}-setup
+          name: qBittorrent-CI_Windows-${{ matrix.config.arch }}_libtorrent-${{ matrix.libt_version }}-setup
           path: dist/windows/qbittorrent_*_setup.exe

--- a/dist/windows/config.nsh
+++ b/dist/windows/config.nsh
@@ -35,12 +35,15 @@
 ;End of user configurable options
 ;==============================================================================
 
+; QBT_CPU_ARCH (x64 or arm64)
+!define /ifndef QBT_CPU_ARCH "x64"
+
 !ifndef QBT_INSTALLER_WINDOWNAME | QBT_INSTALLER_FILENAME
   ; The name of the installer
-  !define QBT_INSTALLER_WINDOWNAME "${QBT_VERSION} x64"
+  !define QBT_INSTALLER_WINDOWNAME "${QBT_VERSION} ${QBT_CPU_ARCH}"
 
   ; The file to write
-  !define QBT_INSTALLER_FILENAME "${QBT_VERSION}_x64"
+  !define QBT_INSTALLER_FILENAME "${QBT_VERSION}_${QBT_CPU_ARCH}"
 !endif
 
 !define /ifndef QBT_DIST_DIR "qBittorrent"

--- a/dist/windows/installer-translations/afrikaans.nsh
+++ b/dist/windows/installer-translations/afrikaans.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_AFRIKAANS} "This installer works only in 6
 LangString inst_requires_win10 ${LANG_AFRIKAANS}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_AFRIKAANS} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_AFRIKAANS} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_AFRIKAANS} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/albanian.nsh
+++ b/dist/windows/installer-translations/albanian.nsh
@@ -34,6 +34,11 @@ LangString inst_requires_win7 ${LANG_ALBANIAN} "This qBittorrent version require
 LangString inst_requires_win10 ${LANG_ALBANIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ALBANIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ALBANIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ALBANIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/arabic.nsh
+++ b/dist/windows/installer-translations/arabic.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_ARABIC} "هذا المثبت يعمل فق
 LangString inst_requires_win10 ${LANG_ARABIC}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ARABIC} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ARABIC} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ARABIC} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/basque.nsh
+++ b/dist/windows/installer-translations/basque.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_BASQUE} "This installer works only in 64-b
 LangString inst_requires_win10 ${LANG_BASQUE}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_BASQUE} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BASQUE} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BASQUE} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/belarusian.nsh
+++ b/dist/windows/installer-translations/belarusian.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_BELARUSIAN} "This installer works only in 
 LangString inst_requires_win10 ${LANG_BELARUSIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_BELARUSIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BELARUSIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BELARUSIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/bosnian.nsh
+++ b/dist/windows/installer-translations/bosnian.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_BOSNIAN} "This installer works only in 64-
 LangString inst_requires_win10 ${LANG_BOSNIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_BOSNIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BOSNIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BOSNIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/breton.nsh
+++ b/dist/windows/installer-translations/breton.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_BRETON} "This installer works only in 64-b
 LangString inst_requires_win10 ${LANG_BRETON}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_BRETON} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BRETON} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BRETON} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/bulgarian.nsh
+++ b/dist/windows/installer-translations/bulgarian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_BULGARIAN} "This installer works only in 6
 LangString inst_requires_win10 ${LANG_BULGARIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_BULGARIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BULGARIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BULGARIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/catalan.nsh
+++ b/dist/windows/installer-translations/catalan.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_CATALAN} "This installer works only in 64-
 LangString inst_requires_win10 ${LANG_CATALAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_CATALAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_CATALAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_CATALAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/croatian.nsh
+++ b/dist/windows/installer-translations/croatian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_CROATIAN} "This installer works only in 64
 LangString inst_requires_win10 ${LANG_CROATIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_CROATIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_CROATIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_CROATIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/czech.nsh
+++ b/dist/windows/installer-translations/czech.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_CZECH} "Tento instalátor funguje pouze v 
 LangString inst_requires_win10 ${LANG_CZECH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_CZECH} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_CZECH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_CZECH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/danish.nsh
+++ b/dist/windows/installer-translations/danish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_DANISH} "Installationsprogrammet virker ku
 LangString inst_requires_win10 ${LANG_DANISH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_DANISH} "Afinstaller qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_DANISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_DANISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/dutch.nsh
+++ b/dist/windows/installer-translations/dutch.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_DUTCH} "Dit installatieprogramma werkt all
 LangString inst_requires_win10 ${LANG_DUTCH}  "Dit installatieprogramma vereist ten minste Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_DUTCH} "qBittorrent verwijderen"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_DUTCH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_DUTCH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/english.nsh
+++ b/dist/windows/installer-translations/english.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_ENGLISH} "This installer works only in 64-
 LangString inst_requires_win10 ${LANG_ENGLISH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/esperanto.nsh
+++ b/dist/windows/installer-translations/esperanto.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_ESPERANTO} "This installer works only in 6
 LangString inst_requires_win10 ${LANG_ESPERANTO}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ESPERANTO} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ESPERANTO} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ESPERANTO} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/estonian.nsh
+++ b/dist/windows/installer-translations/estonian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_ESTONIAN} "See installer töötab ainult 6
 LangString inst_requires_win10 ${LANG_ESTONIAN}  "Selle installeri jaoks on vajalik vähemalt Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ESTONIAN} "Desinstalli qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ESTONIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ESTONIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/farsi.nsh
+++ b/dist/windows/installer-translations/farsi.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_FARSI} "This installer works only in 64-bi
 LangString inst_requires_win10 ${LANG_FARSI}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_FARSI} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_FARSI} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_FARSI} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/finnish.nsh
+++ b/dist/windows/installer-translations/finnish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_FINNISH} "Tämä asennusohjelma toimii vai
 LangString inst_requires_win10 ${LANG_FINNISH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_FINNISH} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_FINNISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_FINNISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/french.nsh
+++ b/dist/windows/installer-translations/french.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_FRENCH} "Cet installateur ne fonctionne qu
 LangString inst_requires_win10 ${LANG_FRENCH}  "Cet installateur nécessite au moins Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_FRENCH} "Désinstaller qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_FRENCH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_FRENCH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/galician.nsh
+++ b/dist/windows/installer-translations/galician.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_GALICIAN} "This installer works only in 64
 LangString inst_requires_win10 ${LANG_GALICIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_GALICIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_GALICIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_GALICIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/german.nsh
+++ b/dist/windows/installer-translations/german.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_GERMAN} "Diese Installation funktioniert n
 LangString inst_requires_win10 ${LANG_GERMAN}  "Diese Installation erfordert mindestens Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_GERMAN} "qBittorrent deinstallieren"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_GERMAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_GERMAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/greek.nsh
+++ b/dist/windows/installer-translations/greek.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_GREEK} "Αυτό το αρχείο εγκ�
 LangString inst_requires_win10 ${LANG_GREEK}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_GREEK} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_GREEK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_GREEK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/hebrew.nsh
+++ b/dist/windows/installer-translations/hebrew.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_HEBREW} "התקנה זו עובדת רק �
 LangString inst_requires_win10 ${LANG_HEBREW}  "התקנה זו דורשת לפחות Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_HEBREW} "הסר את ההתקנה של qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_HEBREW} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_HEBREW} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/hungarian.nsh
+++ b/dist/windows/installer-translations/hungarian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_HUNGARIAN} "A telepítő csak 64-bites Win
 LangString inst_requires_win10 ${LANG_HUNGARIAN}  "A telepítéshez minimum Windows 10 (1809) / Windows Server 2019 szükséges."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_HUNGARIAN} "qBittorrent eltávolítása"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_HUNGARIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_HUNGARIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/icelandic.nsh
+++ b/dist/windows/installer-translations/icelandic.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_ICELANDIC} "This installer works only in 6
 LangString inst_requires_win10 ${LANG_ICELANDIC}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ICELANDIC} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ICELANDIC} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ICELANDIC} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/indonesian.nsh
+++ b/dist/windows/installer-translations/indonesian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_INDONESIAN} "Aplikasi ini hanya berjalan p
 LangString inst_requires_win10 ${LANG_INDONESIAN}  "Penginstal ini membutuhkan setidaknya Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_INDONESIAN} "Hapus qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_INDONESIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_INDONESIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/irish.nsh
+++ b/dist/windows/installer-translations/irish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_IRISH} "This installer works only in 64-bi
 LangString inst_requires_win10 ${LANG_IRISH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_IRISH} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_IRISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_IRISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/italian.nsh
+++ b/dist/windows/installer-translations/italian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_ITALIAN} "Questo installer funziona solo c
 LangString inst_requires_win10 ${LANG_ITALIAN}  "Questo installer richiede almeno Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ITALIAN} "Disinstalla qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ITALIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ITALIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/japanese.nsh
+++ b/dist/windows/installer-translations/japanese.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_JAPANESE} "このインストーラは 64 
 LangString inst_requires_win10 ${LANG_JAPANESE}  "このインストーラの実行には Windows 10 (1809) / Windows Server 2019 以降が必要です。"
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_JAPANESE} "qBittorrent をアンインストール"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_JAPANESE} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_JAPANESE} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/korean.nsh
+++ b/dist/windows/installer-translations/korean.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_KOREAN} "이 설치 프로그램은 64비�
 LangString inst_requires_win10 ${LANG_KOREAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_KOREAN} "qBittorrent 제거"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_KOREAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_KOREAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/kurdish.nsh
+++ b/dist/windows/installer-translations/kurdish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_KURDISH} "This installer works only in 64-
 LangString inst_requires_win10 ${LANG_KURDISH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_KURDISH} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_KURDISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_KURDISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/latvian.nsh
+++ b/dist/windows/installer-translations/latvian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_LATVIAN} "Šī instalēšanas programma da
 LangString inst_requires_win10 ${LANG_LATVIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_LATVIAN} "Atinstalēt qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_LATVIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_LATVIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/lithuanian.nsh
+++ b/dist/windows/installer-translations/lithuanian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_LITHUANIAN} "Šis įdiegėjas veikia tik s
 LangString inst_requires_win10 ${LANG_LITHUANIAN}  "Šis įdiegėjas reikalauja bent Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_LITHUANIAN} "Pašalinti qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_LITHUANIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_LITHUANIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/luxembourgish.nsh
+++ b/dist/windows/installer-translations/luxembourgish.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_LUXEMBOURGISH} "Dësen Installateur funkti
 LangString inst_requires_win10 ${LANG_LUXEMBOURGISH} "Dësen Installateur erfuerdert mindestens Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_LUXEMBOURGISH} "qBittorrent deinstalléieren"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_LUXEMBOURGISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_LUXEMBOURGISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/macedonian.nsh
+++ b/dist/windows/installer-translations/macedonian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_MACEDONIAN} "This installer works only in 
 LangString inst_requires_win10 ${LANG_MACEDONIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_MACEDONIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_MACEDONIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_MACEDONIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/malay.nsh
+++ b/dist/windows/installer-translations/malay.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_MALAY} "This installer works only in 64-bi
 LangString inst_requires_win10 ${LANG_MALAY}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_MALAY} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_MALAY} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_MALAY} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/mongolian.nsh
+++ b/dist/windows/installer-translations/mongolian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_MONGOLIAN} "This installer works only in 6
 LangString inst_requires_win10 ${LANG_MONGOLIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_MONGOLIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_MONGOLIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_MONGOLIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/norwegian.nsh
+++ b/dist/windows/installer-translations/norwegian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_NORWEGIAN} "This installer works only in 6
 LangString inst_requires_win10 ${LANG_NORWEGIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_NORWEGIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_NORWEGIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_NORWEGIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/norwegiannynorsk.nsh
+++ b/dist/windows/installer-translations/norwegiannynorsk.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_NORWEGIANNYNORSK} "This installer works on
 LangString inst_requires_win10 ${LANG_NORWEGIANNYNORSK}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_NORWEGIANNYNORSK} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_NORWEGIANNYNORSK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_NORWEGIANNYNORSK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/polish.nsh
+++ b/dist/windows/installer-translations/polish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_POLISH} "Ten instalator działa tylko w 64
 LangString inst_requires_win10 ${LANG_POLISH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_POLISH} "Odinstaluj qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_POLISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_POLISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/portuguese.nsh
+++ b/dist/windows/installer-translations/portuguese.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_PORTUGUESE} "Este instalador funciona apen
 LangString inst_requires_win10 ${LANG_PORTUGUESE}  "Este instalador requer, pelo menos, o Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_PORTUGUESE} "Desinstalar qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_PORTUGUESE} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_PORTUGUESE} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/portugueseBR.nsh
+++ b/dist/windows/installer-translations/portugueseBR.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_PORTUGUESEBR} "Este instalador só funcion
 LangString inst_requires_win10 ${LANG_PORTUGUESEBR}  "Este instalador requer no mínimo o Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_PORTUGUESEBR} "Desinstalar o qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_PORTUGUESEBR} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_PORTUGUESEBR} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/romanian.nsh
+++ b/dist/windows/installer-translations/romanian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_ROMANIAN} "Acest program de instalare func
 LangString inst_requires_win10 ${LANG_ROMANIAN}  "Acest program de instalare necesită cel puțin Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_ROMANIAN} "Dezinstalați qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ROMANIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ROMANIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/russian.nsh
+++ b/dist/windows/installer-translations/russian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_RUSSIAN} "Этот установщик р
 LangString inst_requires_win10 ${LANG_RUSSIAN}  "Для работы этого установщика требуется Windows 10 (1809) / Windows Server 2019 или выше."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_RUSSIAN} "Удалить qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_RUSSIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_RUSSIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/serbian.nsh
+++ b/dist/windows/installer-translations/serbian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SERBIAN} "This installer works only in 64-
 LangString inst_requires_win10 ${LANG_SERBIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SERBIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SERBIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SERBIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/serbianlatin.nsh
+++ b/dist/windows/installer-translations/serbianlatin.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SERBIANLATIN} "This installer works only i
 LangString inst_requires_win10 ${LANG_SERBIANLATIN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SERBIANLATIN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SERBIANLATIN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SERBIANLATIN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/simpchinese.nsh
+++ b/dist/windows/installer-translations/simpchinese.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SIMPCHINESE} "此安装程序仅支持 64 
 LangString inst_requires_win10 ${LANG_SIMPCHINESE}  "此安装程序仅支持 Windows 10 (1809) / Windows Server 2019 或更新的系统。"
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SIMPCHINESE} "卸载 qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SIMPCHINESE} "X64 版本的 qBittorrent 不能运行在 ARM64 系统上。请下载 ARM64 安装程序。"
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SIMPCHINESE} "ARM64 版本的 qBittorrent 不能运行在 X64 系统上。请下载 X64 安装程序。"
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/slovak.nsh
+++ b/dist/windows/installer-translations/slovak.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SLOVAK} "Táto inštalácia funguje iba na
 LangString inst_requires_win10 ${LANG_SLOVAK}  "Tento inštalátor vyžaduje aspoň Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SLOVAK} "Odinštalovať qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SLOVAK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SLOVAK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/slovenian.nsh
+++ b/dist/windows/installer-translations/slovenian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SLOVENIAN} "This installer works only in 6
 LangString inst_requires_win10 ${LANG_SLOVENIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SLOVENIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SLOVENIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SLOVENIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/spanish.nsh
+++ b/dist/windows/installer-translations/spanish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SPANISH} "Este instalador solo funciona en
 LangString inst_requires_win10 ${LANG_SPANISH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SPANISH} "Desinstalar qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SPANISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SPANISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/spanishinternational.nsh
+++ b/dist/windows/installer-translations/spanishinternational.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SPANISHINTERNATIONAL} "Este instalador sol
 LangString inst_requires_win10 ${LANG_SPANISHINTERNATIONAL}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SPANISHINTERNATIONAL} "Desinstalar qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SPANISHINTERNATIONAL} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SPANISHINTERNATIONAL} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/swedish.nsh
+++ b/dist/windows/installer-translations/swedish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_SWEDISH} "Det här installationsprogrammet
 LangString inst_requires_win10 ${LANG_SWEDISH}  "Det här installationsprogrammet kräver minst Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_SWEDISH} "Avinstallera qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SWEDISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SWEDISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/thai.nsh
+++ b/dist/windows/installer-translations/thai.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_THAI} "This installer works only in 64-bit
 LangString inst_requires_win10 ${LANG_THAI}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_THAI} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_THAI} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_THAI} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/tradchinese.nsh
+++ b/dist/windows/installer-translations/tradchinese.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_TRADCHINESE} "此安裝程式僅支援 64 
 LangString inst_requires_win10 ${LANG_TRADCHINESE}  "此安裝程式僅支援 Windows 10 (1809) / Windows Server 2019 以上的系統。"
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_TRADCHINESE} "移除 qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_TRADCHINESE} "X64 版本的 qBittorrent 無法在 ARM64 系統上執行。請下載 ARM64 安裝程式。"
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_TRADCHINESE} "ARM64 版本的 qBittorrent 無法在 X64 系統上執行。請下載 X64 安裝程式。"
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/turkish.nsh
+++ b/dist/windows/installer-translations/turkish.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_TURKISH} "Bu yükleyici sadece 64-bit Wind
 LangString inst_requires_win10 ${LANG_TURKISH}  "Bu yükleyici en az Windows 10 (1809) / Windows Server 2019 gerektirir."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_TURKISH} "qBittorrent'i kaldır"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_TURKISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_TURKISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/ukrainian.nsh
+++ b/dist/windows/installer-translations/ukrainian.nsh
@@ -32,6 +32,10 @@ LangString inst_requires_64bit ${LANG_UKRAINIAN} "Ця програма уста
 LangString inst_requires_win10 ${LANG_UKRAINIAN}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_UKRAINIAN} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_UKRAINIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_UKRAINIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/uzbek.nsh
+++ b/dist/windows/installer-translations/uzbek.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_UZBEK} "Bu oʻrnatuvchi faqat Windows 64-b
 LangString inst_requires_win10 ${LANG_UZBEK}  "Bu oʻrnatuvchi  kamida Windows 10 (1809) / Windows Server 2019 talab qiladi."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_UZBEK} "qBittorrent oʻchirilsin"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_UZBEK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_UZBEK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/welsh.nsh
+++ b/dist/windows/installer-translations/welsh.nsh
@@ -32,6 +32,11 @@ LangString inst_requires_64bit ${LANG_WELSH} "This installer works only in 64-bi
 LangString inst_requires_win10 ${LANG_WELSH}  "This installer requires at least Windows 10 (1809) / Windows Server 2019."
 ;LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorrent"
 LangString inst_uninstall_link_description ${LANG_WELSH} "Uninstall qBittorrent"
+;LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "Error: This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+LangString inst_arch_mismatch_x64_on_arm64 ${LANG_WELSH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
+;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+LangString inst_arch_mismatch_arm64_on_x64 ${LANG_WELSH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer.nsh
+++ b/dist/windows/installer.nsh
@@ -128,6 +128,19 @@ Function .onInit
     Abort
   ${EndIf}
 
+  ; check installer and current system architecture
+  ${If} "${QBT_CPU_ARCH}" == "x64"
+  ${AndIf} ${IsNativeARM64}  ;x64 use arm64 installer
+    MessageBox MB_OK|MB_ICONEXCLAMATION $(inst_arch_mismatch_x64_on_arm64) /SD IDOK
+    SetErrorLevel 1654 # WinError.h: `ERROR_INSTALL_REJECTED`
+    Abort
+  ${ElseIf} "${QBT_CPU_ARCH}" == "arm64"
+  ${AndIf} ${IsNativeAMD64}  ;arm64 use x64 installer
+    MessageBox MB_OK|MB_ICONEXCLAMATION $(inst_arch_mismatch_arm64_on_x64) /SD IDOK
+    SetErrorLevel 1654 # WinError.h: `ERROR_INSTALL_REJECTED`
+    Abort
+  ${EndIf}
+
   ;Search if qBittorrent is already installed.
   FindFirst $0 $1 "$INSTDIR\uninst.exe"
   FindClose $0


### PR DESCRIPTION
Qt >=6.8 can native compile on Windows ARM64 machine, and GitHub also provides windows-11-arm runner. so I think It's time to add support.

I've tested from my branch and Snapdragon 8cx gen3 computer. all ci build passed.

PS: NSIS's support for ARM64 is not so good. The installer will run using x86 emulation, but the binary is natively arm64.

Closes #11465.

