### PR TITLE
WebUI: Fix path input label layout in torrent creator

### DIFF
--- a/src/webui/www/private/views/createtorrent.html
+++ b/src/webui/www/private/views/createtorrent.html
@@ -3,8 +3,8 @@
         text-align: center;
     }
 
-    #createTorrentForm input[type="text"],
-    #createTorrentForm textarea,
+    #createTorrentForm table input[type="text"],
+    #createTorrentForm table textarea,
     #createTorrentForm table {
         width: 100%;
     }


### PR DESCRIPTION
|before|after|
|----|----|
|<img width="374" height="252" alt="image" src="https://github.com/user-attachments/assets/ae428222-09df-4f23-ae0b-6c023787cbfb" />|<img width="371" height="235" alt="image" src="https://github.com/user-attachments/assets/432d2c94-88f3-4c1f-8fd6-e19ca87fa605" />|
