### PR TITLE
Use appropriate icon for "error" status in search tab

### DIFF
--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -138,6 +138,7 @@ namespace
         case SearchJobWidget::Status::Aborted:
             return u"task-reject"_s;
         case SearchJobWidget::Status::Error:
+            return u"error"_s;
         case SearchJobWidget::Status::NoResults:
             return u"dialog-warning"_s;
         default:


### PR DESCRIPTION
* Use appropriate icon for "error" status in search tab
  * Previously `Error/NoResults` status shared the same icon

### Before:
![Screenshot 2025-09-27 224023](https://github.com/user-attachments/assets/69035332-c6cd-475b-aa08-28213d58a25a)
![Screenshot 2025-09-27 224047](https://github.com/user-attachments/assets/4f4864cd-0d8c-475a-bbbe-93cdbbee0308)
____

### After:
![Screenshot 2025-09-27 215204](https://github.com/user-attachments/assets/55eb79d0-6fad-476a-9bc5-ffdaf841b151)
![Screenshot 2025-09-27 215234](https://github.com/user-attachments/assets/21fa14a0-4cf5-41a8-a50f-b820a9b17c74)
____

### All Status Icons:
![Screenshot 2025-09-27 220208](https://github.com/user-attachments/assets/ce0dc86b-a95b-4841-9cf3-51a4b467f9c5)
