### PR TITLE
Fix screen reader accessibility in torrent list

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1306,9 +1306,16 @@ void TransferListWidget::displayListMenu()
     listMenu->popup(QCursor::pos());
 }
 
-void TransferListWidget::currentChanged(const QModelIndex &current, const QModelIndex&)
+void TransferListWidget::currentChanged(const QModelIndex &current, const QModelIndex &previous)
 {
     qDebug("CURRENT CHANGED");
+
+    // Call base class to ensure Qt's accessibility system is notified of focus changes.
+    // This is critical for screen readers to announce the currently selected torrent.
+    // Without this call, users relying on assistive technologies cannot effectively
+    // navigate the torrent list with keyboard arrow keys.
+    QTreeView::currentChanged(current, previous);
+
     BitTorrent::Torrent *torrent = nullptr;
     if (current.isValid())
     {

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -111,7 +111,7 @@ private slots:
     void torrentDoubleClicked();
     void displayListMenu();
     void displayColumnHeaderMenu();
-    void currentChanged(const QModelIndex &current, const QModelIndex&) override;
+    void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
     void setSelectedTorrentsSuperSeeding(bool enabled) const;
     void setSelectedTorrentsSequentialDownload(bool enabled) const;
     void setSelectedFirstLastPiecePrio(bool enabled) const;


### PR DESCRIPTION
### Link to Issue
Closes #20393

### Description
Navigating the torrent list with arrow keys did not announce selection changes to screen readers.

### Development Approach
Call QTreeView::currentChanged() to ensure Qt's accessibility system is notified of focus changes. This enables screen readers to announce the currently selected torrent when navigating with arrow keys.
Without this call, the base class accessibility notification is never triggered, making the torrent list nearly unusable for screen reader users.

### Testing
In Windows X64 test builds, arrow navigation correctly announces the torrent that gains focus on an arrow press.