### PR TITLE
WebUI: Redesign login form

### DIFF
--- a/src/webui/www/public/css/login.css
+++ b/src/webui/www/public/css/login.css
@@ -16,10 +16,21 @@ body {
 }
 
 #main {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
     margin-left: auto;
     margin-right: auto;
     padding-top: 5em;
     text-align: center;
+}
+
+.login-input {
+    box-sizing: border-box;
+    font-size: 1rem;
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    width: 100%;
 }
 
 #formplace {
@@ -33,7 +44,9 @@ body {
 }
 
 #loginButton {
-    float: right;
+    font-size: 1rem;
+    padding: 0.5rem;
+    width: 100%;
 }
 
 #logo img {

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -32,11 +32,11 @@
             <form id="loginform">
                 <div class="row">
                     <label for="username">QBT_TR(Username)QBT_TR[CONTEXT=Login]</label><br>
-                    <input type="text" id="username" name="username" autocomplete="username" autocapitalize="none" autofocus required>
+                    <input type="text" class="login-input" id="username" name="username" autocomplete="username" autocapitalize="none" autofocus required>
                 </div>
                 <div class="row">
                     <label for="password">QBT_TR(Password)QBT_TR[CONTEXT=Login]</label><br>
-                    <input type="password" id="password" name="password" autocomplete="current-password" required>
+                    <input type="password" class="login-input" id="password" name="password" autocomplete="current-password" required>
                 </div>
                 <div class="row">
                     <input type="submit" id="loginButton" value="QBT_TR(Login)QBT_TR[CONTEXT=Login]">


### PR DESCRIPTION
# Summary

Make the Web UI login more mobile friendly.
The main action is moving to a column layout for the logo and form. This way it's easier for mobile to view the page but it doesn't affect the desktop experience much.

Secondary it set the input font size to be default text size, this in turn makes it so the mobile ui doesn't zoom in when you focus the inputs. [You can read more about it here](https://wsform.com/knowledgebase/why-forms-zoom-on-some-mobile-devices-and-browsers-and-how-to-control-it/).

# Screenshots (on Firefox)

## Before

<img width="100%" height="553" alt="Screenshot 2025-10-09 at 20 48 50" src="https://github.com/user-attachments/assets/fa0a3627-bdbd-4b05-92a8-e25ae5cce5b5" />
<img width="25%" height="3200" alt="Screen Shot 2025-10-09 at 21 33 28" src="https://github.com/user-attachments/assets/de7531dd-6b3e-4811-8423-fc73d74ca52c" />


# After

<img width="100%" height="553" alt="Screenshot 2025-10-09 at 21 13 56" src="https://github.com/user-attachments/assets/14306e9a-7691-4856-b09e-d233932067c1" />
<img width="25%" height="3200" alt="Screen Shot 2025-10-09 at 21 33 38" src="https://github.com/user-attachments/assets/3bac6cac-eb4c-4aa1-b57e-8437f4afac4f" />


# Test plan

Made sure the UI looks fine in both FF 143.0.4, Chrome 141.0.7390.55 and Safari 26.0.1.
No functionality has been tested as this is strictly CSS changes.