### PR TITLE
Improve tab key focus in hidable tab bar widget

### DIFF
--- a/src/gui/hidabletabwidget.cpp
+++ b/src/gui/hidabletabwidget.cpp
@@ -38,25 +38,28 @@
 HidableTabWidget::HidableTabWidget(QWidget *parent)
     : QTabWidget(parent)
 {
-    // Skip tab bar in keyboard navigation when there's only one tab (no point navigating to it)
-    // Focus policy is dynamically adjusted in tabInserted/tabRemoved based on tab count
+    // Skip single tab in keyboard navigation (no point navigating to it)
     tabBar()->setFocusPolicy(Qt::NoFocus);
 }
 
 void HidableTabWidget::tabInserted(const int index)
 {
     QTabWidget::tabInserted(index);
-    tabBar()->setVisible(count() != 1);
-    // Skip single tab in keyboard navigation (no point navigating to it)
-    tabBar()->setFocusPolicy((count() > 1) ? Qt::StrongFocus : Qt::NoFocus);
+    tabsCountChanged();
 }
 
 void HidableTabWidget::tabRemoved(const int index)
 {
     QTabWidget::tabRemoved(index);
-    tabBar()->setVisible(count() != 1);
+    tabsCountChanged();
+}
+
+void HidableTabWidget::tabsCountChanged()
+{
+    const qsizetype tabsCount = count();
+    tabBar()->setVisible(tabsCount != 1);
     // Skip single tab in keyboard navigation (no point navigating to it)
-    tabBar()->setFocusPolicy((count() > 1) ? Qt::StrongFocus : Qt::NoFocus);
+    tabBar()->setFocusPolicy((tabsCount > 1) ? Qt::StrongFocus : Qt::NoFocus);
 }
 
 #ifdef Q_OS_MACOS

--- a/src/gui/hidabletabwidget.h
+++ b/src/gui/hidabletabwidget.h
@@ -42,6 +42,7 @@ public:
 private:
     void tabInserted(int index) override;
     void tabRemoved(int index) override;
+    void tabsCountChanged();
 
 #ifdef Q_OS_MACOS
     void paintEvent(QPaintEvent *event) override;


### PR DESCRIPTION
## Related Issue
Related to #20393

## Summary
- Fixed keyboard navigation being trapped by the tab bar when only a single tab is visible
- Tab bar now dynamically adjusts its focus policy based on the number of tabs
- When there is only one tab, the tab bar is skipped during keyboard navigation (no need to focus on a single unchangeable tab)
- When there are multiple tabs, normal keyboard navigation is enabled

## Changes
Modified `HidableTabWidget` to set `Qt::NoFocus` on the tab bar when there is only one tab, and `Qt::StrongFocus` when there are multiple tabs. This prevents the tab bar from capturing keyboard focus unnecessarily.

## Test plan
- [x] Open qBittorrent GUI
- [x] Navigate with Tab key - verify tab bar is skipped when only one tab exists
- [x] Open multiple tabs (e.g., search results)
- [x] Navigate with Tab key - verify tab bar can be focused and tabs can be switched with arrow keys
- [x] Close tabs until one remains - verify tab bar is again skipped in navigation