### PR TITLE
Use Permanent Cookie

### DIFF
--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -51,6 +51,7 @@ namespace Http
     inline const QString HEADER_CONTENT_LENGTH = u"content-length"_s;
     inline const QString HEADER_CONTENT_SECURITY_POLICY = u"content-security-policy"_s;
     inline const QString HEADER_CONTENT_TYPE = u"content-type"_s;
+    inline const QString HEADER_COOKIE = u"cookie"_s;
     inline const QString HEADER_CROSS_ORIGIN_OPENER_POLICY  = u"cross-origin-opener-policy"_s;
     inline const QString HEADER_DATE = u"date"_s;
     inline const QString HEADER_HOST = u"host"_s;


### PR DESCRIPTION
Previously, WebUI was using a HTTP Session Cookie. This type of cookie is tend to be dropped by the browser on mobile platforms and gives a bad experience on the WebUI. Now the cookie is a permanent one and is guaranteed to be persisted between browser restarts.

Supersedes #23350.
Closes #20993.