### PR TITLE
Save settings only when visible columns is resized

### DIFF
--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -149,11 +149,7 @@ SearchJobWidget::SearchJobWidget(const QString &id, IGUIApplication *app, QWidge
 
     header()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(header(), &QWidget::customContextMenuRequested, this, &SearchJobWidget::displayColumnHeaderMenu);
-    connect(header(), &QHeaderView::sectionResized, this, [this](int logicalIndex)
-    {
-        if (logicalIndex < SearchSortModel::DL_LINK)
-            saveSettings();
-    });
+    connect(header(), &QHeaderView::sectionResized, this, &SearchJobWidget::saveSettings, Qt::QueuedConnection);
     connect(header(), &QHeaderView::sectionMoved, this, &SearchJobWidget::saveSettings);
     connect(header(), &QHeaderView::sortIndicatorChanged, this, &SearchJobWidget::saveSettings);
 


### PR DESCRIPTION
Fixes #23396

Switching the `Search in:` dropdown in the search result triggers a `QHeaderView::sectionResized` signal on both hidden columns (`DL_LINK` and `DESC_LINK`). This in turn calls `SearchJobWidget::saveSettings()` function which saves, somehow, an invalid state in  `GUI/Qt6/SearchTab/HeaderState`  settings. This can be verified be logging the return value of `header()->restoreState()` in this line (returns false):

https://github.com/qbittorrent/qBittorrent/blob/9ce5463d9d7b19e00b23aeffb70524d2cb7bcf4c/src/gui/search/searchjobwidget.cpp#L567

which means the state wasn't restored:

https://doc.qt.io/qt-6/qheaderview.html#restoreState

This PR adds a check if the  `QHeaderView::sectionResized` signal is called on the hidden column and just does nothing if those columns triggered the signal.

I wanted to use `bool QTreeView::isColumnHidden(int column) const` but somehow that returns `false` on those columns.
`columnWidth(i)` on those 2 column returns `0`