### PR TITLE
WebUI: Fix opening "Add torrent" window with double click on RSS item

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -3245,7 +3245,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 if (!tr)
                     return;
 
-                const { name, torrentURL } = this._this.rows.get(this.rowId).full_data;
+                const { name, torrentURL } = this.getRow(tr.rowId).full_data;
                 qBittorrent.Client.createAddTorrentWindow(name, torrentURL);
             });
         }


### PR DESCRIPTION
Restores the ability to open the "Add torrent" dialogue, when double clicking on an RSS feed item.
Broke in: 02892d12501e9ba96cb5a0375da42d447bc5ece2 as part of #21645
