### PR TITLE
Do not allow orphan processes

### DIFF
--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -492,14 +492,14 @@ void TorrentContentWidget::openItem(const QModelIndex &index) const
     Utils::Gui::openPath(getFullPath(index));
 }
 
-void TorrentContentWidget::openParentFolder(const QModelIndex &index) const
+void TorrentContentWidget::openParentFolder(const QModelIndex &index)
 {
     const Path path = getFullPath(index);
     m_model->contentHandler()->flushCache();  // Flush data
 #ifdef Q_OS_MACOS
     MacUtils::openFiles({path});
 #else
-    Utils::Gui::openFolderSelect(path);
+    Utils::Gui::openFolderSelect(path, this);
 #endif
 }
 

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -113,7 +113,7 @@ private:
     void displayColumnHeaderMenu();
     void displayContextMenu();
     void openItem(const QModelIndex &index) const;
-    void openParentFolder(const QModelIndex &index) const;
+    void openParentFolder(const QModelIndex &index);
     void openSelectedFile();
     void renameSelectedFile();
     void applyPriorities(BitTorrent::DownloadPriority priority);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -104,20 +104,6 @@ namespace
         return false;
     }
 
-    void openDestinationFolder(const BitTorrent::Torrent *const torrent)
-    {
-        const Path contentPath = torrent->contentPath();
-        const Path openedPath = (!contentPath.isEmpty() ? contentPath : torrent->savePath());
-#ifdef Q_OS_MACOS
-        MacUtils::openFiles({openedPath});
-#else
-        if (torrent->filesCount() == 1)
-            Utils::Gui::openFolderSelect(openedPath);
-        else
-            Utils::Gui::openPath(openedPath);
-#endif
-    }
-
     void removeTorrents(const QList<BitTorrent::Torrent *> &torrents, const bool isDeleteFileSelected)
     {
         auto *session = BitTorrent::Session::instance();
@@ -592,7 +578,7 @@ void TransferListWidget::hideQueuePosColumn(bool hide)
         resizeColumnToContents(TransferListModel::TR_QUEUE_POSITION);
 }
 
-void TransferListWidget::openSelectedTorrentsFolder() const
+void TransferListWidget::openSelectedTorrentsFolder()
 {
     QSet<Path> paths;
 #ifdef Q_OS_MACOS
@@ -612,13 +598,27 @@ void TransferListWidget::openSelectedTorrentsFolder() const
         if (!paths.contains(openedPath))
         {
             if (torrent->filesCount() == 1)
-                Utils::Gui::openFolderSelect(openedPath);
+                Utils::Gui::openFolderSelect(openedPath, this);
             else
                 Utils::Gui::openPath(openedPath);
         }
         paths.insert(openedPath);
     }
 #endif // Q_OS_MACOS
+}
+
+void TransferListWidget::openDestinationFolder(const BitTorrent::Torrent *const torrent)
+{
+    const Path contentPath = torrent->contentPath();
+    const Path openedPath = (!contentPath.isEmpty() ? contentPath : torrent->savePath());
+#ifdef Q_OS_MACOS
+    MacUtils::openFiles({openedPath});
+#else
+    if (torrent->filesCount() == 1)
+        Utils::Gui::openFolderSelect(openedPath, this);
+    else
+        Utils::Gui::openPath(openedPath);
+#endif
 }
 
 void TransferListWidget::previewSelectedTorrents()

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -89,7 +89,8 @@ public slots:
     void copySelectedInfohashes(CopyInfohashPolicy policy) const;
     void copySelectedIDs() const;
     void copySelectedComments() const;
-    void openSelectedTorrentsFolder() const;
+    void openSelectedTorrentsFolder();
+    void openDestinationFolder(const BitTorrent::Torrent *torrent);
     void recheckSelectedTorrents();
     void reannounceSelectedTorrents();
     void setTorrentOptions();

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -144,7 +144,7 @@ void Utils::Gui::openPath(const Path &path)
 
 // Open the parent directory of the given path with a file manager and select
 // (if possible) the item at the given path
-void Utils::Gui::openFolderSelect(const Path &path)
+void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *parent)
 {
     // If the item to select doesn't exist, try to open its parent
     if (!path.exists())
@@ -175,11 +175,11 @@ void Utils::Gui::openFolderSelect(const Path &path)
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     const int lineMaxLength = 64;
 
-    auto lookupProc = new QProcess();
+    auto lookupProc = new QProcess(parent);
     lookupProc->setProcessChannelMode(QProcess::ForwardedErrorChannel);
     lookupProc->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
     QObject::connect(lookupProc, &QProcess::finished, lookupProc
-        , [path, lookupProc]([[maybe_unused]] const int exitCode, [[maybe_unused]] const QProcess::ExitStatus exitStatus)
+        , [parent, path, lookupProc]([[maybe_unused]] const int exitCode, [[maybe_unused]] const QProcess::ExitStatus exitStatus)
     {
         lookupProc->deleteLater();
 
@@ -191,7 +191,7 @@ void Utils::Gui::openFolderSelect(const Path &path)
         else if ((output == u"nautilus.desktop") || (output == u"org.gnome.Nautilus.desktop")
             || (output == u"nautilus-folder-handler.desktop"))
         {
-            auto deProcess = new QProcess();
+            auto deProcess = new QProcess(parent);
             deProcess->setProcessChannelMode(QProcess::ForwardedErrorChannel);
             deProcess->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
             QObject::connect(deProcess, &QProcess::finished, deProcess

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -31,6 +31,7 @@
 
 #include "base/pathfwd.h"
 
+class QObject;
 class QPixmap;
 class QPoint;
 class QSize;
@@ -52,7 +53,7 @@ namespace Utils::Gui
     QPoint screenCenter(const QWidget *w);
 
     void openPath(const Path &path);
-    void openFolderSelect(const Path &path);
+    void openFolderSelect(const Path &path, QObject *parent);
 
     QString tagToWidgetText(const Tag &tag);
     Tag widgetTextToTag(const QString &text);


### PR DESCRIPTION
If a process is an orphan (without a parent) then the process won't exit when qbt exits and the process will still be running. This is unwanted behavior.
