### PR TITLE
NSIS: add ManifestDPIAwareness function

### DIFF
--- a/dist/windows/config.nsh
+++ b/dist/windows/config.nsh
@@ -51,6 +51,8 @@
 
 Unicode true
 ManifestDPIAware true
+; add an undocumented function in NSIS, PMv2 requires Win10 1703+
+ManifestDPIAwareness "PerMonitorV2,System"
 
 !ifdef USE_UPX
 !packhdr "$%TEMP%\exehead.tmp" 'upx.exe -9 --best --ultra-brute "$%TEMP%\exehead.tmp"'
@@ -59,7 +61,6 @@ ManifestDPIAware true
 ;Setting the compression
 SetCompressor /SOLID LZMA
 SetCompressorDictSize 64
-XPStyle on
 
 !include "MUI2.nsh"
 !include "UAC.nsh"


### PR DESCRIPTION
* This PR added an undocumented function `ManifestDPIAwareness` and enable `PerMonitorV2` support (requires Win10 1703+)

https://github.com/NSIS-Dev/nsis/blob/691211035c2aaaebe8fbca48ee02d4de93594a52/Docs/src/attributes.but#L290-L292



* remove `XPStyle` because this function do nothing on NSIS 3.x