### PR TITLE
Make the active torrents filter reflect actual transfers

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1186,25 +1186,7 @@ bool TorrentImpl::isCompleted() const
 
 bool TorrentImpl::isActive() const
 {
-    switch (m_state)
-    {
-    case TorrentState::StalledDownloading:
-        return (uploadPayloadRate() > 0);
-
-    case TorrentState::DownloadingMetadata:
-    case TorrentState::ForcedDownloadingMetadata:
-    case TorrentState::Downloading:
-    case TorrentState::ForcedDownloading:
-    case TorrentState::Uploading:
-    case TorrentState::ForcedUploading:
-    case TorrentState::Moving:
-        return true;
-
-    default:
-        break;
-    };
-
-    return false;
+    return ((uploadPayloadRate() > 0) || (downloadPayloadRate() > 0));
 }
 
 bool TorrentImpl::isInactive() const

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1552,7 +1552,7 @@ window.qBittorrent.DynamicTable ??= (() => {
         }
 
         applyFilter(row, filterName, category, tag, trackerHost, filterTerms) {
-            const state = row["full_data"].state;
+            const { state, upspeed, dlspeed } = row["full_data"];
             let inactive = false;
 
             switch (filterName) {
@@ -1592,11 +1592,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     inactive = true;
                     // fallthrough
                 case "active": {
-                    let r;
-                    if (state === "stalledDL")
-                        r = (row["full_data"].upspeed > 0);
-                    else
-                        r = (state === "metaDL") || (state === "forcedMetaDL") || (state === "downloading") || (state === "forcedDL") || (state === "uploading") || (state === "forcedUP");
+                    const r = (upspeed > 0) || (dlspeed > 0);
                     if (r === inactive)
                         return false;
                     break;


### PR DESCRIPTION
Some users find current behavior of the active torrents filter annoying. Especially when it comes to "forced" torrent states.
It seems more logical to reflect actual active transfers instead of relying on statuses.

Closes #23121 + see the discussion there for details.
