### PR TITLE
Bring back Minimize and implement Fill (MacOS only)

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -209,6 +209,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 
 #ifdef Q_OS_MACOS
     m_ui->menuView->addAction(m_ui->actionMinimize);
+    m_ui->menuView->addAction(m_ui->actionFill);
 #endif
 
     updateAltSpeedsBtn(BitTorrent::Session::instance()->isAltGlobalSpeedLimitEnabled());
@@ -323,6 +324,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     connect(m_ui->actionDecreaseQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::decreaseQueuePosSelectedTorrents);
     connect(m_ui->actionBottomQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::bottomQueuePosSelectedTorrents);
     connect(m_ui->actionMinimize, &QAction::triggered, this, &MainWindow::minimizeWindow);
+    connect(m_ui->actionFill, &QAction::triggered, this, &MainWindow::fillWindow);
     connect(m_ui->actionUseAlternativeSpeedLimits, &QAction::triggered, this, &MainWindow::toggleAlternativeSpeeds);
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
@@ -927,6 +929,7 @@ void MainWindow::createKeyboardShortcuts()
 #ifdef Q_OS_MACOS
     m_ui->actionMinimize->setShortcut(Qt::CTRL | Qt::Key_M);
     addAction(m_ui->actionMinimize);
+    m_ui->actionFill->setShortcut(Qt::CTRL | Qt::Key_F);
 #endif
 }
 
@@ -1731,6 +1734,11 @@ void MainWindow::showConnectionSettings()
 void MainWindow::minimizeWindow()
 {
     setWindowState(windowState() | Qt::WindowMinimized);
+}
+
+void MainWindow::fillWindow()
+{
+    setWindowState(windowState() | Qt::WindowMaximized);
 }
 
 void MainWindow::on_actionExecutionLogs_triggered(bool checked)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -121,6 +121,7 @@ private slots:
     void notifyOfUpdate(const QString &);
     void showConnectionSettings();
     void minimizeWindow();
+    void fillWindow();
     // Keyboard shortcuts
     void createKeyboardShortcuts();
     void displayTransferTab() const;

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -481,6 +481,11 @@
     <string>Close Window</string>
    </property>
   </action>
+  <action name="actionFill">
+   <property name="text">
+    <string>Fill</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
fixes: #23418

For MacOS only, this PR adds `Minimize`and `Fill` (thats how they call it in Mac instead of Maximize) menu item under the `View` menu. Cmd+M keyboard to minimize the app. Cmd+F keyboard to maximize the app.

<img width="242" height="350" alt="Screenshot 2025-10-31 at 7 14 28 PM" src="https://github.com/user-attachments/assets/4286e5d9-9b0c-46f0-bc3e-2fc25be75557" />


Minimize on MacOS was implement here: https://github.com/qBittorrent/qBittorrent/commit/dd7e515f9c0e48b4ab4ca787a799ef47cbfe36ea

I'm not sure what this existing `addAction` does, so i'm leaving it as is but I think its safe to be removed:

https://github.com/qbittorrent/qBittorrent/blob/ee62dd3cda4fd9873ea2aa6fc0f8ae8b0b3a72f2/src/gui/mainwindow.cpp#L925