### PR TITLE
Fix MinGW compiler warnings

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -127,10 +127,12 @@ namespace
 #endif
     }
 
+#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
     void displayVersion()
     {
         printf("%s %s\n", qUtf8Printable(qApp->applicationName()), QBT_VERSION);
     }
+#endif
 
 #ifndef DISABLE_GUI
     void showSplashScreen()

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -65,7 +65,7 @@ namespace
     bool hasDriveLetter(const QStringView path)
     {
         const QRegularExpression driveLetterRegex {u"^[A-Za-z]:/"_s};
-        return driveLetterRegex.match(path).hasMatch();
+        return driveLetterRegex.matchView(path).hasMatch();
     }
 #endif
 }
@@ -104,7 +104,7 @@ bool Path::isValid() const
 
     // \\37 is using base-8 number system
     const QRegularExpression regex {u"[\\0-\\37:?\"*<>|]"_s};
-    return !regex.match(view).hasMatch();
+    return !regex.matchView(view).hasMatch();
 #elif defined(Q_OS_MACOS)
     const QRegularExpression regex {u"[\\0:]"_s};
 #else

--- a/src/base/utils/os.cpp
+++ b/src/base/utils/os.cpp
@@ -275,11 +275,11 @@ bool Utils::OS::applyMarkOfTheWeb(const Path &file, const QString &url)
     const QByteArray zoneID = QByteArrayLiteral("[ZoneTransfer]\r\nZoneId=3\r\n")
         + u"HostUrl=%1\r\n"_s.arg(hostURL).toUtf8();
 
-    if (LARGE_INTEGER streamSize = {0};
+    if (LARGE_INTEGER streamSize {};
         ::GetFileSizeEx(handle, &streamSize) && (streamSize.QuadPart > 0))
     {
         const DWORD expectedReadSize = std::min<LONGLONG>(streamSize.QuadPart, 1024);
-        QByteArray buf {expectedReadSize, '\0'};
+        QByteArray buf {static_cast<qsizetype>(expectedReadSize), '\0'};
 
         if (DWORD actualReadSize = 0;
             ::ReadFile(handle, buf.data(), expectedReadSize, &actualReadSize, nullptr) && (actualReadSize == expectedReadSize))
@@ -289,14 +289,14 @@ bool Utils::OS::applyMarkOfTheWeb(const Path &file, const QString &url)
         }
     }
 
-    if (!::SetFilePointerEx(handle, {0}, nullptr, FILE_BEGIN))
+    if (!::SetFilePointerEx(handle, {}, nullptr, FILE_BEGIN))
         return false;
     if (!::SetEndOfFile(handle))
         return false;
 
     DWORD written = 0;
     const BOOL writeResult = ::WriteFile(handle, zoneID.constData(), zoneID.size(), &written, nullptr);
-    return writeResult && (written == zoneID.size());
+    return writeResult && (static_cast<qsizetype>(written) == zoneID.size());
 #endif
 }
 #endif // Q_OS_MACOS || Q_OS_WIN


### PR DESCRIPTION
Cross-compiling with mxe on linux.

```
/opt/mxe/gits/qbittorrent-5.1.2/src/base/path.cpp: In function 'bool {anonymous}::hasDriveLetter(QStringView)':
/opt/mxe/gits/qbittorrent-5.1.2/src/base/path.cpp:68:38: warning: 'QRegularExpressionMatch QRegularExpression::match(QStringView, qsizetype, MatchType, MatchOptions) const' is deprecated: Use matchView instead. [-Wdeprecated-declarations]
   68 |         return driveLetterRegex.match(path).hasMatch();
      |                ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
In file included from /opt/mxe/usr/i686-w64-mingw32.static/qt6/include/QtCore/QRegularExpression:1,
                 from /opt/mxe/gits/qbittorrent-5.1.2/src/base/path.cpp:39:
/opt/mxe/usr/i686-w64-mingw32.static/qt6/include/QtCore/qregularexpression.h:97:29: note: declared here
   97 |     QRegularExpressionMatch match(QStringView subjectView,
      |                             ^~~~~
/opt/mxe/gits/qbittorrent-5.1.2/src/base/path.cpp: In member function 'bool Path::isValid() const':
/opt/mxe/gits/qbittorrent-5.1.2/src/base/path.cpp:101:24: warning: 'QRegularExpressionMatch QRegularExpression::match(QStringView, qsizetype, MatchType, MatchOptions) const' is deprecated: Use matchView instead. [-Wdeprecated-declarations]
  101 |     return !regex.match(view).hasMatch();
      |             ~~~~~~~~~~~^~~~~~
/opt/mxe/usr/i686-w64-mingw32.static/qt6/include/QtCore/qregularexpression.h:97:29: note: declared here
   97 |     QRegularExpressionMatch match(QStringView subjectView,
      |                             ^~~~~
/opt/mxe/gits/qbittorrent-5.1.2/src/base/utils/os.cpp: In function 'bool Utils::OS::applyMarkOfTheWeb(const Path&, const QString&)':
/opt/mxe/gits/qbittorrent-5.1.2/src/base/utils/os.cpp:344:38: warning: missing initializer for member '_LARGE_INTEGER::<unnamed struct>::HighPart' [-Wmissing-field-initializers]
  344 |     if (LARGE_INTEGER streamSize = {0};
      |                                      ^
/opt/mxe/gits/qbittorrent-5.1.2/src/base/utils/os.cpp:348:25: error: narrowing conversion of '(DWORD)expectedReadSize' from 'DWORD' {aka 'long unsigned int'} to 'qsizetype' {aka 'int'} [-Wnarrowing]
  348 |         QByteArray buf {expectedReadSize, '\0'};
      |                         ^~~~~~~~~~~~~~~~
/opt/mxe/gits/qbittorrent-5.1.2/src/base/utils/os.cpp:358:28: warning: missing initializer for member '_LARGE_INTEGER::<unnamed struct>::HighPart' [-Wmissing-field-initializers]
  358 |     if (!::SetFilePointerEx(handle, {0}, nullptr, FILE_BEGIN))
      |          ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/mxe/gits/qbittorrent-5.1.2/src/base/utils/os.cpp:365:36: warning: comparison of integer expressions of different signedness: 'DWORD' {aka 'long unsigned int'} and 'qsizetype' {aka 'int'} [-Wsign-compare]
  365 |     return writeResult && (written == zoneID.size());
      |                            ~~~~~~~~^~~~~~~~~~~~~~~~
/opt/mxe/gits/qbittorrent-5.1.2/src/app/main.cpp:130:10: warning: 'void {anonymous}::displayVersion()' defined but not used [-Wunused-function]
  130 |     void displayVersion()
      |          ^~~~~~~~~~~~~~
```