### PR TITLE
NSIS: use proper data type when invoking dll functions

### DIFF
--- a/dist/windows/config.nsh
+++ b/dist/windows/config.nsh
@@ -73,8 +73,8 @@ XPStyle on
 !define SHCNF_IDLIST 0
 
 ;For special folder detection
-!define CSIDL_APPDATA '0x1A' ;Application Data path
-!define CSIDL_LOCALAPPDATA '0x1C' ;Local Application Data path
+!define FOLDERID_RoamingAppData {3EB685DB-65F9-4CF6-A03A-E3EF65729F3D} ; %APPDATA% (%USERPROFILE%\AppData\Roaming)
+!define FOLDERID_LocalAppData {F1B32785-6FBA-4FCF-9D55-7B8E7F157091} ; %LOCALAPPDATA% (%USERPROFILE%\AppData\Local)
 
 !define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_RUN_FUNCTION PageFinishRun

--- a/dist/windows/installer.nsh
+++ b/dist/windows/installer.nsh
@@ -51,7 +51,7 @@ Section $(inst_qbt_req) ;"qBittorrent (required)"
   WriteRegStr HKLM "Software\Classes\magnet" "Content Type" "application/x-magnet"
   WriteRegStr HKLM "Software\Classes\magnet" "URL Protocol" ""
 
-  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, p 0, p 0)'
+  System::Call 'shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, p 0, p 0)'
 
   ; Write the uninstall keys for Windows
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "DisplayName" "qBittorrent"

--- a/dist/windows/uninstaller.nsh
+++ b/dist/windows/uninstaller.nsh
@@ -27,7 +27,7 @@ Section "un.$(remove_registry)" ;"un.Remove registry keys"
   ; Remove ProgIDs
   DeleteRegKey HKLM "Software\Classes\qBittorrent.File.Torrent"
   DeleteRegKey HKLM "Software\Classes\qBittorrent.Url.Magnet"
-  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, p 0, p 0)'
+  System::Call 'shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, p 0, p 0)'
 SectionEnd
 
 Section "un.$(remove_firewall)" ;
@@ -45,8 +45,9 @@ SectionEnd
 
 Function un.remove_conf_user
 
-  System::Call 'shell32::SHGetSpecialFolderPath(i $HWNDPARENT, t .r1, i ${CSIDL_APPDATA}, i0)i.r0'
+  System::Call 'shell32::SHGetKnownFolderPath(g "${FOLDERID_RoamingAppData}", i 0, p 0, *w . r1) i . r0'
   RMDir /r "$1\qBittorrent"
+  System::Call 'ole32::CoTaskMemFree(p r1)'
 
 FunctionEnd
 
@@ -58,8 +59,9 @@ SectionEnd
 
 Function un.remove_cache_user
 
-  System::Call 'shell32::SHGetSpecialFolderPath(i $HWNDPARENT, t .r1, i ${CSIDL_LOCALAPPDATA}, i0)i.r0'
-  RMDir /r "$1\qBittorrent\"
+  System::Call 'shell32::SHGetKnownFolderPath(g "${FOLDERID_LocalAppData}", i 0, p 0, *w . r1) i . r0'
+  RMDir /r "$1\qBittorrent"
+  System::Call 'ole32::CoTaskMemFree(p r1)'
 
 FunctionEnd
 


### PR DESCRIPTION
Also migrate away from unsupported function `SHGetSpecialFolderPath()` to `SHGetKnownFolderPath()`.

Ref:
https://nsis.sourceforge.io/Docs/System/System.html#callfuncs
https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath