### PR TITLE
Fix link on MinGW cross-compilation

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -247,7 +247,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         ${IOKit_LIBRARY}
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(qbt_base PRIVATE Iphlpapi PowrProf)
+    target_link_libraries(qbt_base PRIVATE iphlpapi powrprof)
 endif()
 
 if (NOT GUI)


### PR DESCRIPTION
Library names are all lower-case.
