### PR TITLE
GHA CI: ensure AppRun hook folder exists

### DIFF
--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -164,7 +164,8 @@ jobs:
         run: |
           rm -f "${{ runner.workspace }}/Qt/${{ matrix.qt_version }}/gcc_64/plugins/sqldrivers/libqsqlmimer.so"
           ./linuxdeploy-x86_64.AppImage --appdir qbittorrent --plugin qt
-          rm qbittorrent/apprun-hooks/*
+          mkdir -p qbittorrent/apprun-hooks
+          rm -f qbittorrent/apprun-hooks/*
           cp .github/workflows/helper/appimage/export_vars.sh qbittorrent/apprun-hooks/export_vars.sh
           NO_APPSTREAM=1 \
             OUTPUT=upload/qbittorrent-CI_Ubuntu_x86_64.AppImage \


### PR DESCRIPTION
Upstream made some changes and it won't create the AppRun hook folder anymore, so we create it ourselves.
Upstream PR: https://github.com/linuxdeploy/linuxdeploy-plugin-qt/pull/206
