### PR TITLE
fix build with libtorrent 2.1.0

### DIFF
--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -163,7 +163,17 @@ void CustomDiskIOThread::async_rename_file(lt::storage_index_t storage, lt::file
             , [=, this, handler = std::move(handler)](const std::string &name, lt::file_index_t index, const lt::storage_error &error)
     {
         if (!error)
+        {
+            #if LIBTORRENT_VERSION_NUM < 20100
+            // libtorrent < 2.1.0
             m_storageData[storage].files.rename_file(index, name);
+            #else
+            // libtorrent >= 2.1.0
+            // FIXME rename_file is deprecated since libtorrent 77eb55f31e53f798d9b88c946d434b8076310d00
+            // https://github.com/arvidn/libtorrent/pull/7983
+            m_storageData[storage].files.rename_file(index, name);
+            #endif
+        }
         handler(name, index, error);
     });
 }


### PR DESCRIPTION
tested with https://github.com/arvidn/libtorrent/commit/a01469c8d1f88dd83bed458ffccffab2727b9d2a

libtorrent fails to announce to https trackers with

> CERTIFICATE_VERIFY_FAILED (SSL routines, OPENSSL_internal)

... but this may be an [issue with nixos linux](https://discourse.nixos.org/t/fix-ssl-sslcertverificationerror-with-uvs-standalone-python/71138)

also i cannot login to the webinterface

related: #23953 
