### PR TITLE
Calculate torrent pieces asynchronously

### DIFF
--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -64,6 +64,7 @@ private slots:
 private:
     void dropEvent(QDropEvent *event) override;
     void dragEnterEvent(QDragEnterEvent *event) override;
+    void setPiecesCount(int count);
 
     void saveSettings();
     void loadSettings();


### PR DESCRIPTION
Implement asynchronous calculation of torrent pieces to improve UI responsiveness during the process. This change introduces a new `PiecesCountCalculator` class that runs in a separate thread, allowing the main UI to remain interactive.

