### PR TITLE
Temporarily lower Qt version deprecation

### DIFF
--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -20,7 +20,7 @@ target_compile_features(qbt_common_cfg INTERFACE
 )
 
 target_compile_definitions(qbt_common_cfg INTERFACE
-    QT_DISABLE_DEPRECATED_UP_TO=0x060600
+    QT_DISABLE_DEPRECATED_UP_TO=0x060500
     QT_NO_CAST_FROM_ASCII
     QT_NO_CAST_TO_ASCII
     QT_NO_CAST_FROM_BYTEARRAY


### PR DESCRIPTION
Static builds of Qt fail when deprecating up to 6.6
[QTBUG-141994](https://bugreports.qt.io/browse/QTBUG-141994)

Once a Qt version with a fix has been release we can raise it again.
Otherwise, I can't do a beta release on Windows.