### PR TITLE
Adds onFinished callback for SessionImpl::updateTrackersFromURL

### DIFF
--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -647,7 +647,7 @@ namespace BitTorrent
         void handleRemovedTorrent(const TorrentID &torrentID, const QString &partfileRemoveError = {});
 
         void setAdditionalTrackersFromURL(const QString &trackers);
-        void updateTrackersFromURL();
+        void updateTrackersFromURL(const std::function<void()> &onFinished = {});
 
         CachedSettingValue<QString> m_DHTBootstrapNodes;
         CachedSettingValue<bool> m_isDHTEnabled;


### PR DESCRIPTION
Fixes #23508.

This PR adds `onFinished` param callback for `SessionImpl::updateTrackersFromURL`  function.

The  `onFinished` call back is called when `setAdditionalTrackersFromURL` is called or when the download of the tracker list failed.

This fixes the async issue when qBittorent is launched via CLI with the following conditions:

1. `--skip-dialog=true`
2. a torrent file or magnet url is specified to be downloaded
3. user has `Automatically append trackers from URL to new downloads:` set 

In `master`, on app launch, an async task is started to download the url set in `AdditionalTrackersURL`. Meanwhile, the application would process the CLI params and immediately start the download of the  torrent file or magnet url specified in the CLI param even before the download task finishes. This bug makes the  `Automatically append trackers from URL to new downloads:` feature not work properly if the torrent download was triggered via CLI and if add torrent dialog is skipped.

With this PR, if the `AdditionalTrackersURL` is set, we wait for the download task to finish before starting up the session.

### caveats
- if the url set in `AdditionalTrackersURL` is invalid, it would take 30 seconds for the app to startup since the default timeout for the http request is 30 seconds

https://github.com/qbittorrent/qBittorrent/blob/46cc3a358e165e04e01a671d006cde363495afad/src/base/net/downloadmanager.cpp#L336

- it would be nice to only do 
```
updateTrackersFromURL([this]()
        {
            prepareStartup();
        });
```

if the CLI param has `--skip-dialog=true` and has a `url` param, but the `sessionimpl` class has no access to CLI params