### PR TITLE
WebUI: Do not hide context menu if the click target has submenu

### DIFF
--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -217,9 +217,8 @@ window.qBittorrent.ContextMenu ??= (() => {
                 if ((parentNode !== null) && (parentNode.tagName.toLowerCase() === "li")) {
                     const grandParentNode = parentNode.parentNode;
                     if ((grandParentNode !== null) && (grandParentNode.classList.contains("contextMenu"))) {
-                        const submenuItem = parentNode.getElementsByTagName("ul");
-                        // if the menu item has a submenu, the context menu
-                        if (submenuItem.length > 0)
+                        const submenuNodes = parentNode.getElementsByTagName("ul");
+                        if (submenuNodes.length > 0)
                             return;
                     }
                 }


### PR DESCRIPTION
Closes #23532.

Add check if the click event occurs in the menu item and if the menu item has a submenu, do not close the context menu.
