### PR TITLE
Revert "NSIS: Create a mutex to ensure only one installer is running"

### DIFF
--- a/dist/windows/installer-translations/afrikaans.nsh
+++ b/dist/windows/installer-translations/afrikaans.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_AFRIKAANS} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_AFRIKAANS} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_AFRIKAANS} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_AFRIKAANS} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/albanian.nsh
+++ b/dist/windows/installer-translations/albanian.nsh
@@ -38,8 +38,7 @@ LangString inst_uninstall_link_description ${LANG_ALBANIAN} "Uninstall qBittorre
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ALBANIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ALBANIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ALBANIAN} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/arabic.nsh
+++ b/dist/windows/installer-translations/arabic.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_ARABIC} "Uninstall qBittorrent
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ARABIC} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ARABIC} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ARABIC} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/basque.nsh
+++ b/dist/windows/installer-translations/basque.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_BASQUE} "Uninstall qBittorrent
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BASQUE} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BASQUE} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_BASQUE} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/belarusian.nsh
+++ b/dist/windows/installer-translations/belarusian.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_BELARUSIAN} "Uninstall qBittor
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BELARUSIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BELARUSIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_BELARUSIAN} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/bosnian.nsh
+++ b/dist/windows/installer-translations/bosnian.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_BOSNIAN} "Uninstall qBittorren
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BOSNIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BOSNIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_BOSNIAN} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/breton.nsh
+++ b/dist/windows/installer-translations/breton.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_BRETON} "Uninstall qBittorrent
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BRETON} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BRETON} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_BRETON} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/bulgarian.nsh
+++ b/dist/windows/installer-translations/bulgarian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_BULGARIAN} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_BULGARIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_BULGARIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_BULGARIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/catalan.nsh
+++ b/dist/windows/installer-translations/catalan.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_CATALAN} "Desinstal·lar qBitt
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_CATALAN} "Aquesta versió x64 de qBittorrent no pot funcionar en sistemes ARM64. Siusplau, descarrega l'instal·lador ARM64."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_CATALAN} "Aquesta versió ARM64 de qBittorrent no pot funcionar en sistemes x64. Siusplau, descarrega l'instal·lador x64."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_CATALAN} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/croatian.nsh
+++ b/dist/windows/installer-translations/croatian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_CROATIAN} "Uninstall qBittorre
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_CROATIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_CROATIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_CROATIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/czech.nsh
+++ b/dist/windows/installer-translations/czech.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_CZECH} "Uninstall qBittorrent"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_CZECH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_CZECH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_CZECH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/danish.nsh
+++ b/dist/windows/installer-translations/danish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_DANISH} "Afinstaller qBittorre
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_DANISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_DANISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_DANISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/dutch.nsh
+++ b/dist/windows/installer-translations/dutch.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_DUTCH} "qBittorrent verwijdere
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_DUTCH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_DUTCH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_DUTCH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/english.nsh
+++ b/dist/windows/installer-translations/english.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_ENGLISH} "Uninstall qBittorren
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ENGLISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/esperanto.nsh
+++ b/dist/windows/installer-translations/esperanto.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_ESPERANTO} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ESPERANTO} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ESPERANTO} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ESPERANTO} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/estonian.nsh
+++ b/dist/windows/installer-translations/estonian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_ESTONIAN} "Desinstalli qBittor
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ESTONIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ESTONIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ESTONIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/farsi.nsh
+++ b/dist/windows/installer-translations/farsi.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_FARSI} "Uninstall qBittorrent"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_FARSI} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_FARSI} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_FARSI} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/finnish.nsh
+++ b/dist/windows/installer-translations/finnish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_FINNISH} "Uninstall qBittorren
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_FINNISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_FINNISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_FINNISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/french.nsh
+++ b/dist/windows/installer-translations/french.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_FRENCH} "Désinstaller qBittor
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_FRENCH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_FRENCH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_FRENCH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/galician.nsh
+++ b/dist/windows/installer-translations/galician.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_GALICIAN} "Uninstall qBittorre
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_GALICIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_GALICIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_GALICIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/german.nsh
+++ b/dist/windows/installer-translations/german.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_GERMAN} "qBittorrent deinstall
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_GERMAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_GERMAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_GERMAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/greek.nsh
+++ b/dist/windows/installer-translations/greek.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_GREEK} "Uninstall qBittorrent"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_GREEK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_GREEK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_GREEK} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/hebrew.nsh
+++ b/dist/windows/installer-translations/hebrew.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_HEBREW} "הסר את ההתק�
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_HEBREW} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_HEBREW} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_HEBREW} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/hungarian.nsh
+++ b/dist/windows/installer-translations/hungarian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_HUNGARIAN} "qBittorrent eltáv
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_HUNGARIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_HUNGARIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_HUNGARIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/icelandic.nsh
+++ b/dist/windows/installer-translations/icelandic.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_ICELANDIC} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ICELANDIC} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ICELANDIC} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ICELANDIC} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/indonesian.nsh
+++ b/dist/windows/installer-translations/indonesian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_INDONESIAN} "Hapus qBittorrent
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_INDONESIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_INDONESIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_INDONESIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/irish.nsh
+++ b/dist/windows/installer-translations/irish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_IRISH} "Uninstall qBittorrent"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_IRISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_IRISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_IRISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/italian.nsh
+++ b/dist/windows/installer-translations/italian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_ITALIAN} "Disinstalla qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ITALIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ITALIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ITALIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/japanese.nsh
+++ b/dist/windows/installer-translations/japanese.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_JAPANESE} "qBittorrent をア�
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_JAPANESE} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_JAPANESE} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_JAPANESE} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/korean.nsh
+++ b/dist/windows/installer-translations/korean.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_KOREAN} "qBittorrent 제거"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_KOREAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_KOREAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_KOREAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/kurdish.nsh
+++ b/dist/windows/installer-translations/kurdish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_KURDISH} "کیووبیتتۆر
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_KURDISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_KURDISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_KURDISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/latvian.nsh
+++ b/dist/windows/installer-translations/latvian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_LATVIAN} "Atinstalēt qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_LATVIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_LATVIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_LATVIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/lithuanian.nsh
+++ b/dist/windows/installer-translations/lithuanian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_LITHUANIAN} "Pašalinti qBitto
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_LITHUANIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_LITHUANIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_LITHUANIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/luxembourgish.nsh
+++ b/dist/windows/installer-translations/luxembourgish.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_LUXEMBOURGISH} "qBittorrent de
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_LUXEMBOURGISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_LUXEMBOURGISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_LUXEMBOURGISH} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/macedonian.nsh
+++ b/dist/windows/installer-translations/macedonian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_MACEDONIAN} "Uninstall qBittor
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_MACEDONIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_MACEDONIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_MACEDONIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/malay.nsh
+++ b/dist/windows/installer-translations/malay.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_MALAY} "Uninstall qBittorrent"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_MALAY} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_MALAY} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_MALAY} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/mongolian.nsh
+++ b/dist/windows/installer-translations/mongolian.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_MONGOLIAN} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_MONGOLIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_MONGOLIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_MONGOLIAN} "Another instance of the installer is already running."
+
 ;------------------------------------
 ;Uninstaller strings
 

--- a/dist/windows/installer-translations/norwegian.nsh
+++ b/dist/windows/installer-translations/norwegian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_NORWEGIAN} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_NORWEGIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_NORWEGIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_NORWEGIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/norwegiannynorsk.nsh
+++ b/dist/windows/installer-translations/norwegiannynorsk.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_NORWEGIANNYNORSK} "Uninstall q
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_NORWEGIANNYNORSK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_NORWEGIANNYNORSK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_NORWEGIANNYNORSK} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/polish.nsh
+++ b/dist/windows/installer-translations/polish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_POLISH} "Odinstaluj qBittorren
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_POLISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_POLISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_POLISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/portuguese.nsh
+++ b/dist/windows/installer-translations/portuguese.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_PORTUGUESE} "Desinstalar qBitt
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_PORTUGUESE} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_PORTUGUESE} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_PORTUGUESE} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/portugueseBR.nsh
+++ b/dist/windows/installer-translations/portugueseBR.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_PORTUGUESEBR} "Desinstalar o q
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_PORTUGUESEBR} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_PORTUGUESEBR} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_PORTUGUESEBR} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/romanian.nsh
+++ b/dist/windows/installer-translations/romanian.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_ROMANIAN} "Dezinstalați qBitt
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_ROMANIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ROMANIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_ROMANIAN} "Another instance of the installer is already running."
+
 ;------------------------------------
 ;Uninstaller strings
 

--- a/dist/windows/installer-translations/russian.nsh
+++ b/dist/windows/installer-translations/russian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_RUSSIAN} "Удалить qBitt
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_RUSSIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_RUSSIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_RUSSIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/serbian.nsh
+++ b/dist/windows/installer-translations/serbian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_SERBIAN} "Uninstall qBittorren
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SERBIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SERBIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SERBIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/serbianlatin.nsh
+++ b/dist/windows/installer-translations/serbianlatin.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_SERBIANLATIN} "Uninstall qBitt
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SERBIANLATIN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SERBIANLATIN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SERBIANLATIN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/simpchinese.nsh
+++ b/dist/windows/installer-translations/simpchinese.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_SIMPCHINESE} "卸载 qBittorre
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SIMPCHINESE} "X64 版本的 qBittorrent 不能运行在 ARM64 系统上。请下载 ARM64 安装程序。"
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SIMPCHINESE} "ARM64 版本的 qBittorrent 不能运行在 X64 系统上。请下载 X64 安装程序。"
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SIMPCHINESE} "另一个安装程序实例正在运行。"
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/slovak.nsh
+++ b/dist/windows/installer-translations/slovak.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_SLOVAK} "Odinštalovať qBitto
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SLOVAK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SLOVAK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SLOVAK} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/slovenian.nsh
+++ b/dist/windows/installer-translations/slovenian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_SLOVENIAN} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SLOVENIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SLOVENIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SLOVENIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/spanish.nsh
+++ b/dist/windows/installer-translations/spanish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_SPANISH} "Desinstalar qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SPANISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SPANISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SPANISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/spanishinternational.nsh
+++ b/dist/windows/installer-translations/spanishinternational.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_SPANISHINTERNATIONAL} "Desinst
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SPANISHINTERNATIONAL} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SPANISHINTERNATIONAL} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SPANISHINTERNATIONAL} "Another instance of the installer is already running."
+
 ;------------------------------------
 ;Uninstaller strings
 

--- a/dist/windows/installer-translations/swedish.nsh
+++ b/dist/windows/installer-translations/swedish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_SWEDISH} "Avinstallera qBittor
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_SWEDISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_SWEDISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_SWEDISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/thai.nsh
+++ b/dist/windows/installer-translations/thai.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_THAI} "Uninstall qBittorrent"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_THAI} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_THAI} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_THAI} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/tradchinese.nsh
+++ b/dist/windows/installer-translations/tradchinese.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_TRADCHINESE} "移除 qBittorre
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_TRADCHINESE} "X64 版本的 qBittorrent 無法在 ARM64 系統上執行。請下載 ARM64 安裝程式。"
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_TRADCHINESE} "ARM64 版本的 qBittorrent 無法在 X64 系統上執行。請下載 X64 安裝程式。"
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_TRADCHINESE} "另一個安裝程式實例正在運行。"
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/turkish.nsh
+++ b/dist/windows/installer-translations/turkish.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_TURKISH} "qBittorrent'i kaldı
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_TURKISH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_TURKISH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_TURKISH} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/ukrainian.nsh
+++ b/dist/windows/installer-translations/ukrainian.nsh
@@ -36,8 +36,6 @@ LangString inst_uninstall_link_description ${LANG_UKRAINIAN} "Uninstall qBittorr
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_UKRAINIAN} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_UKRAINIAN} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_UKRAINIAN} "Another instance of the installer is already running."
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/uzbek.nsh
+++ b/dist/windows/installer-translations/uzbek.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_UZBEK} "qBittorrent oʻchirils
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_UZBEK} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_UZBEK} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_UZBEK} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer-translations/welsh.nsh
+++ b/dist/windows/installer-translations/welsh.nsh
@@ -36,8 +36,7 @@ LangString inst_uninstall_link_description ${LANG_WELSH} "Uninstall qBittorrent"
 LangString inst_arch_mismatch_x64_on_arm64 ${LANG_WELSH} "This x64 version of qBittorrent cannot run on ARM64 systems. Please download the ARM64 installer."
 ;LangString inst_arch_mismatch_arm64_on_x64 ${LANG_ENGLISH} "Error: This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
 LangString inst_arch_mismatch_arm64_on_x64 ${LANG_WELSH} "This ARM64 version of qBittorrent cannot run on x64 systems. Please download the x64 installer."
-;LangString inst_already_running ${LANG_ENGLISH} "Another instance of the installer is already running."
-LangString inst_already_running ${LANG_WELSH} "Another instance of the installer is already running."
+
 
 ;------------------------------------
 ;Uninstaller strings

--- a/dist/windows/installer.nsh
+++ b/dist/windows/installer.nsh
@@ -112,18 +112,6 @@ SectionEnd
 ;--------------------------------
 
 Function .onInit
-  ; create a mutex to ensure only one installer is running
-  System::Call 'kernel32::CreateMutex(p 0, b 0, t "qbt_installer") p . r1 ?e'
-  Var /GLOBAL CreateMutexResult
-  Pop $CreateMutexResult
-  IntCmpU $CreateMutexResult 183 isDuplicateInstance isUniqueInstance isUniqueInstance
-
-  isDuplicateInstance:
-    MessageBox MB_OK|MB_ICONEXCLAMATION $(inst_already_running) /SD IDOK
-    SetErrorLevel 183 # WinError.h: `ERROR_ALREADY_EXISTS`
-    Abort
-
-  isUniqueInstance:
 
   !insertmacro Init "installer"
   !insertmacro MUI_LANGDLL_DISPLAY


### PR DESCRIPTION
This reverts commit 530c7d1bbd1fb460bb4b7ac7b52d02dfba0c9402. The installer uses the `UAC` plugin which creates two instances of the installer when launched. One runs with admin privileges while the other with user privileges. Creating a mutex in the first instance stops the other one from continuing.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
