### PR TITLE
GHA CI: enable ccache by default on forked repository

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:
-          store_cache: ${{ github.ref == 'refs/heads/master' }}
+          store_cache: ${{ (github.repository != 'qbittorrent/qBittorrent') || (github.ref == 'refs/heads/master') }}
           update_packager_index: false
           ccache_options: |
             max_size=1G

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:
-          store_cache: ${{ github.ref == 'refs/heads/master' }}
+          store_cache: ${{ (github.repository != 'qbittorrent/qBittorrent') || (github.ref == 'refs/heads/master') }}
           update_packager_index: false
           ccache_options: |
             max_size=1G


### PR DESCRIPTION
This change only affects forked repository.

Previously ccache was only enabled on `master` branch regardless of the owner of the repository. This is not ideal for forked repository where the owner (mostly) wants to run the GHA CI to create binary for their own use and ccache couldn't be utilized. This change will enable ccache by default for all non-official repositories.
