### PR TITLE
Raise 'torrent share ratio' maximum limit

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1126,6 +1126,8 @@ void OptionsDialog::loadBittorrentTabOptions()
     m_ui->spinUploadRateForSlowTorrents->setValue(session->uploadRateForSlowTorrents());
     m_ui->spinSlowTorrentsInactivityTimer->setValue(session->slowTorrentsInactivityTimer());
 
+    m_ui->spinMaxRatio->setMaximum(std::numeric_limits<int>::max());
+
     if (session->globalMaxRatio() >= 0.)
     {
         // Enable
@@ -1170,7 +1172,7 @@ void OptionsDialog::loadBittorrentTabOptions()
 
     const QHash<BitTorrent::ShareLimitAction, int> actIndex =
     {
-                                                               {BitTorrent::ShareLimitAction::Stop, 0},
+        {BitTorrent::ShareLimitAction::Stop, 0},
         {BitTorrent::ShareLimitAction::Remove, 1},
         {BitTorrent::ShareLimitAction::RemoveWithContent, 2},
         {BitTorrent::ShareLimitAction::EnableSuperSeeding, 3}

--- a/src/gui/torrentsharelimitswidget.cpp
+++ b/src/gui/torrentsharelimitswidget.cpp
@@ -28,6 +28,8 @@
 
 #include "torrentsharelimitswidget.h"
 
+#include <limits>
+
 #include "base/bittorrent/torrent.h"
 #include "ui_torrentsharelimitswidget.h"
 
@@ -59,6 +61,7 @@ TorrentShareLimitsWidget::TorrentShareLimitsWidget(QWidget *parent)
     m_ui->setupUi(this);
 
     m_ui->spinBoxRatioValue->setEnabled(false);
+    m_ui->spinBoxRatioValue->setMaximum(std::numeric_limits<int>::max());
     m_ui->spinBoxRatioValue->setSuffix({});
     m_ui->spinBoxRatioValue->clear();
     m_ui->spinBoxSeedingTimeValue->setEnabled(false);


### PR DESCRIPTION
The default from Qt was `99.99` which could be too small for some.
The new limit is `INT_MAX` (not `DOUBLE_MAX`) as to hide the rounding/approximation errors from the user.
