### PR TITLE
GHA CI: Bump `Qt` version

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         libt_version: ["2.0.11", "1.2.20"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
-        qt_version: ["6.9.1"]
+        qt_version: ["6.10.1"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: "6.9.1"
+          version: "6.10.1"
           arch: ${{ matrix.config.qt_arch }}
           archives: qtbase qtsvg qttools
           cache: true

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         libt_version: ["2.0.11"]
         qbt_gui: ["GUI=ON"]
-        qt_version: ["6.9.1"]
+        qt_version: ["6.10.1"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"


### PR DESCRIPTION
* Bump `Qt` version to `6.10.1` for (Windows, macOS, coverity-scan)