### PR TITLE
Cache tracker URL to hostname mapping

### DIFF
--- a/src/base/torrentfilter.cpp
+++ b/src/base/torrentfilter.cpp
@@ -47,12 +47,18 @@ const std::optional<TorrentAnnounceStatus> TorrentFilter::AnyAnnounceStatus;
 
 QString getTrackerHost(const QString &url)
 {
-    // We want the hostname.
-    if (const QString host = QUrl(url).host(); !host.isEmpty())
-        return host;
+    static QHash<QString, QString> cache;
 
+    if (const auto iter = cache.constFind(url); iter != cache.constEnd())
+        return iter.value();
+
+    // We want the hostname.
+    const QString host = QUrl(url).host();
     // If failed to parse the domain, original input should be returned
-    return url;
+    const QString result = !host.isEmpty() ? host : url;
+    cache[url] = result;
+
+    return result;
 }
 
 TorrentFilter::TorrentFilter(const Status status, const std::optional<TorrentIDSet> &idSet, const std::optional<QString> &category


### PR DESCRIPTION
Unfortunately, the filtering algorithm used since #23452 has a noticeable performance degradation with an increase in the number of trackers per torrent. This is noticeable when switching the tracker filter if you have many torrents (several thousand), each of which has many trackers (several dozen).
This PR is designed to partially improve filtering performance by caching tracker hostnames to avoid re-parsing tracker URLs.

P.S. It's still not as productive as it used to be, so in the future I'll try to add some kind of data indexing to fix this (if it really bothers users).