### PR TITLE
Calculate torrent pieces asynchronously

### DIFF
--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -33,9 +33,14 @@
 #include <QDialog>
 #include <QThreadPool>
 
-#include "base/bittorrent/torrentcreator.h"
 #include "base/path.h"
 #include "base/settingvalue.h"
+
+namespace BitTorrent
+{
+    enum class TorrentFormat;
+    struct TorrentCreatorResult;
+}
 
 namespace Ui
 {
@@ -54,7 +59,7 @@ public:
 
 private slots:
     void updateProgressBar(int progress);
-    void updatePiecesCount();
+    void onCalculatePiecesButtonClicked();
     void onCreateButtonClicked();
     void onAddFileButtonClicked();
     void onAddFolderButtonClicked();


### PR DESCRIPTION
So the GUI won't hang when the calculation took a long time. Note that it is not possible to cancel the calculation so it will always run until finish in the background.

Supersedes #23497.
