### PR TITLE
Force UTF-8 support for Python

### DIFF
--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -44,6 +44,13 @@ from typing import Any, Optional, cast
 
 import socks
 
+# Ensure UTF-8 output (fixes UnicodeEncodeError on Windows for non-ASCII text)
+# This relies on the fact that this script is imported by nova2 and nova2dl
+if type(sys.stdout) is io.TextIOWrapper:
+    sys.stdout.reconfigure(encoding='utf-8')
+else:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
 
 def _getBrowserUserAgent() -> str:
     """ Disguise as browser to circumvent website blocking """

--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -106,7 +106,7 @@ def list_engines() -> list[EngineModuleName]:
         Return list of all engines' module name
     """
 
-    names = []
+    names: list[EngineModuleName] = []
 
     for engine_path in glob(path.join(path.dirname(__file__), 'engines', '*.py')):
         engine_module_name = path.basename(engine_path).split('.')[0].strip()


### PR DESCRIPTION
Superseded by: https://github.com/qbittorrent/qBittorrent/pull/23633

Related: https://github.com/qbittorrent/search-plugins/pull/402

On Windows, Python uses `cp1252` encoding by default unless Windows setting `Beta: Unicode UTF-8 for worldwide language support` is enabled in `Region Settings`. To avoid enforcing users to enable this feature to use search plugins, tell Python to use UTF-8 explicitly.

Oh, yeah, and fixed one type annotation...