### PR TITLE
Enforce Python to run in UTF-8 mode

### DIFF
--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -54,6 +54,7 @@ SearchDownloadHandler::SearchDownloadHandler(const QString &pluginName, const QS
     const QStringList params
     {
         Utils::ForeignApps::PYTHON_ISOLATE_MODE_FLAG,
+        Utils::ForeignApps::PYTHON_UTF8_MODE_FLAG,
         (SearchPluginManager::engineLocation() / Path(u"nova2dl.py"_s)).toString(),
         pluginName,
         url

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -102,6 +102,7 @@ SearchHandler::SearchHandler(const QString &pattern, const QString &category, co
     const QStringList params
     {
         Utils::ForeignApps::PYTHON_ISOLATE_MODE_FLAG,
+        Utils::ForeignApps::PYTHON_UTF8_MODE_FLAG,
         (SearchPluginManager::engineLocation() / Path(u"nova2.py"_s)).toString(),
         m_usedPlugins.join(u','),
         m_category

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -554,6 +554,7 @@ void SearchPluginManager::update()
     const QStringList params
     {
         Utils::ForeignApps::PYTHON_ISOLATE_MODE_FLAG,
+        Utils::ForeignApps::PYTHON_UTF8_MODE_FLAG,
         (engineLocation() / Path(u"/nova2.py"_s)).toString(),
         u"--capabilities"_s
     };

--- a/src/base/utils/foreignapps.h
+++ b/src/base/utils/foreignapps.h
@@ -38,6 +38,7 @@
 namespace Utils::ForeignApps
 {
     inline const QString PYTHON_ISOLATE_MODE_FLAG = u"-I"_s;
+    inline const QString PYTHON_UTF8_MODE_FLAG = u"-Xutf8=1"_s;
 
     struct PythonInfo
     {


### PR DESCRIPTION
When running Python via QProcess on Windows, the output code page will be set to the system default instead of UTF-8.
This commit enforces that UTF-8 will be used unconditionally.

Supersedes #23629.