### PR TITLE
Add "Created On" column to transfer list

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -171,6 +171,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_ETA: return tr("ETA", "i.e: Estimated Time of Arrival / Time left");
             case TR_CATEGORY: return tr("Category");
             case TR_TAGS: return tr("Tags");
+			case TR_CREATE_DATE: return tr("Created On", "Torrent was initially created on 01/01/2010 08:00");
             case TR_ADD_DATE: return tr("Added On", "Torrent was added to transfer list on 01/01/2010 08:00");
             case TR_SEED_DATE: return tr("Completed On", "Torrent was completed on 01/01/2010 08:00");
             case TR_TRACKER: return tr("Tracker");
@@ -399,6 +400,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return torrent->category();
     case TR_TAGS:
         return Utils::String::joinIntoString(torrent->tags(), u", "_s);
+    case TR_CREATE_DATE:
+        return QLocale().toString(torrent->creationDate().toLocalTime(), QLocale::ShortFormat);
     case TR_ADD_DATE:
         return QLocale().toString(torrent->addedTime().toLocalTime(), QLocale::ShortFormat);
     case TR_SEED_DATE:
@@ -480,6 +483,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->category();
     case TR_TAGS:
         return QVariant::fromValue(torrent->tags());
+    case TR_CREATE_DATE:
+        return torrent->creationDate();
     case TR_ADD_DATE:
         return torrent->addedTime();
     case TR_SEED_DATE:

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -65,6 +65,7 @@ public:
         TR_POPULARITY,
         TR_CATEGORY,
         TR_TAGS,
+		TR_CREATE_DATE,
         TR_ADD_DATE,
         TR_SEED_DATE,
         TR_TRACKER,

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -65,7 +65,6 @@ public:
         TR_POPULARITY,
         TR_CATEGORY,
         TR_TAGS,
-		TR_CREATE_DATE,
         TR_ADD_DATE,
         TR_SEED_DATE,
         TR_TRACKER,
@@ -88,6 +87,7 @@ public:
         TR_INFOHASH_V2,
         TR_REANNOUNCE,
         TR_PRIVATE,
+        TR_CREATE_DATE,
 
         NB_COLUMNS
     };

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -256,6 +256,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_STATUS:
         return threeWayCompare(leftValue.toInt(), rightValue.toInt());
 
+    case TransferListModel::TR_CREATE_DATE:
     case TransferListModel::TR_ADD_DATE:
     case TransferListModel::TR_SEED_DATE:
     case TransferListModel::TR_SEEN_COMPLETE_DATE:

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -155,6 +155,7 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
     // Default hidden columns
     if (!columnLoaded)
     {
+        setColumnHidden(TransferListModel::TR_CREATE_DATE, true);
         setColumnHidden(TransferListModel::TR_ADD_DATE, true);
         setColumnHidden(TransferListModel::TR_SEED_DATE, true);
         setColumnHidden(TransferListModel::TR_UPLIMIT, true);


### PR DESCRIPTION
Makes the torrent's "Created On" date/time available (but hidden by default) in the main transfer list for sorting and better visibility.

Unlike the "Added On" column (which shows when a torrent was added to the client's list), this shows the date the torrent file was originally created. This is something that can help prioritize which torrents to seed. I have a long list of torrents and looking at each one's properties for the "Created On" date isn't feasible. With the addition of this column, I can just sort by it and bring the oldest torrents to the top of the list. Similarly, I can sort by the number of seeders to find which torrents could use some help the most, then glance at the "Created On" column (ex. I'd rather seed torrents from 10+ years ago that are struggling due to age/availability vs. ones from a few weeks ago that have been replaced by newer/better options). This column could also help with cleaning up your list of torrents by making them easier to work with based on their actual age (and not date added/completed).

I should also maybe mention that this is my first submission here, so hopefully I've followed all the guidelines correctly. I added this column using other similar columns as an example and everything seems to be working fine, but if I missed anything less obvious, please let me know!

Screenshot for reference:
<img width="1496" height="723" alt="image" src="https://github.com/user-attachments/assets/e009692c-73b2-4ed9-bfe1-2e939a541f97" />