### PR TITLE
GHA CI: Use `ubuntu-slim` runner image for low priority tasks

### DIFF
--- a/.github/workflows/ci_file_health.yaml
+++ b/.github/workflows/ci_file_health.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   ci:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/ci_webui.yaml
+++ b/.github/workflows/ci_webui.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   ci:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       security-events: write
 

--- a/.github/workflows/stale_bot.yaml
+++ b/.github/workflows/stale_bot.yaml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
As mentioned briefly in https://github.com/qbittorrent/qBittorrent/pull/23631#issuecomment-3677881954 & https://github.com/qbittorrent/qBittorrent/pull/23631#issuecomment-3677940316

* Make use of `ubuntu-slim` runner images in our `CI` where applicable/practical.

- [x] `ci_file_health.yaml`
-  [x] `ci_webui.yaml`
- [x] `stale_bot.yaml`
- [ ] `ci_python.yaml`  **Excluded** (Fails!)

From https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners :
>This type of runner is optimized for automation tasks, issue operations and short-running jobs. They are not suitable for typical heavyweight CI/CD builds.

* https://github.com/actions/runner-images?tab=readme-ov-file#available-images
* https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md
* https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
____

**Expected:**
~Python build to fail - discussion on what we can do here, exclude it from this PR etc.~ Resolved, will exclude!