### PR TITLE
Migrate away from old libtorrent setting

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -387,8 +387,8 @@ namespace BitTorrent
         virtual void setOutgoingPortsMax(int max) = 0;
         virtual int UPnPLeaseDuration() const = 0;
         virtual void setUPnPLeaseDuration(int duration) = 0;
-        virtual int peerToS() const = 0;
-        virtual void setPeerToS(int value) = 0;
+        virtual int peerDSCP() const = 0;
+        virtual void setPeerDSCP(int value) = 0;
         virtual bool ignoreLimitsOnLAN() const = 0;
         virtual void setIgnoreLimitsOnLAN(bool ignore) = 0;
         virtual bool includeOverheadInLimits() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -484,7 +484,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_outgoingPortsMin(BITTORRENT_SESSION_KEY(u"OutgoingPortsMin"_s), 0)
     , m_outgoingPortsMax(BITTORRENT_SESSION_KEY(u"OutgoingPortsMax"_s), 0)
     , m_UPnPLeaseDuration(BITTORRENT_SESSION_KEY(u"UPnPLeaseDuration"_s), 0)
-    , m_peerToS(BITTORRENT_SESSION_KEY(u"PeerToS"_s), 0x04)
+    , m_peerDSCP(BITTORRENT_SESSION_KEY(u"PeerToS"_s), 0x01)
     , m_ignoreLimitsOnLAN(BITTORRENT_SESSION_KEY(u"IgnoreLimitsOnLAN"_s), false)
     , m_includeOverheadInLimits(BITTORRENT_SESSION_KEY(u"IncludeOverheadInLimits"_s), false)
     , m_announceIP(BITTORRENT_SESSION_KEY(u"AnnounceIP"_s))
@@ -2069,7 +2069,7 @@ lt::settings_pack SessionImpl::loadLTSettings() const
     // UPnP lease duration
     settingsPack.set_int(lt::settings_pack::upnp_lease_duration, UPnPLeaseDuration());
     // Type of service
-    settingsPack.set_int(lt::settings_pack::peer_tos, peerToS());
+    settingsPack.set_int(lt::settings_pack::peer_dscp, peerDSCP());
     // Include overhead in transfer limits
     settingsPack.set_bool(lt::settings_pack::rate_limit_ip_overhead, includeOverheadInLimits());
     // IP address to announce to trackers
@@ -4889,17 +4889,17 @@ void SessionImpl::setUPnPLeaseDuration(const int duration)
     }
 }
 
-int SessionImpl::peerToS() const
+int SessionImpl::peerDSCP() const
 {
-    return m_peerToS;
+    return m_peerDSCP;
 }
 
-void SessionImpl::setPeerToS(const int value)
+void SessionImpl::setPeerDSCP(const int value)
 {
-    if (value == m_peerToS)
+    if (value == m_peerDSCP)
         return;
 
-    m_peerToS = value;
+    m_peerDSCP = value;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -361,8 +361,8 @@ namespace BitTorrent
         void setOutgoingPortsMax(int max) override;
         int UPnPLeaseDuration() const override;
         void setUPnPLeaseDuration(int duration) override;
-        int peerToS() const override;
-        void setPeerToS(int value) override;
+        int peerDSCP() const override;
+        void setPeerDSCP(int value) override;
         bool ignoreLimitsOnLAN() const override;
         void setIgnoreLimitsOnLAN(bool ignore) override;
         bool includeOverheadInLimits() const override;
@@ -692,7 +692,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_outgoingPortsMin;
         CachedSettingValue<int> m_outgoingPortsMax;
         CachedSettingValue<int> m_UPnPLeaseDuration;
-        CachedSettingValue<int> m_peerToS;
+        CachedSettingValue<int> m_peerDSCP;
         CachedSettingValue<bool> m_ignoreLimitsOnLAN;
         CachedSettingValue<bool> m_includeOverheadInLimits;
         CachedSettingValue<QString> m_announceIP;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -149,7 +149,7 @@ namespace
         OUTGOING_PORT_MIN,
         OUTGOING_PORT_MAX,
         UPNP_LEASE_DURATION,
-        PEER_TOS,
+        PEER_DSCP,
         UTP_MIX_MODE,
         HOSTNAME_CACHE_TTL,
         IDN_SUPPORT,
@@ -276,7 +276,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     // UPnP lease duration
     session->setUPnPLeaseDuration(m_spinBoxUPnPLeaseDuration.value());
     // Type of service
-    session->setPeerToS(m_spinBoxPeerToS.value());
+    session->setPeerDSCP(m_spinBoxPeerDSCP.value());
     // uTP-TCP mixed mode
     session->setUtpMixedMode(m_comboBoxUtpMixedMode.currentData().value<BitTorrent::MixedModeAlgorithm>());
     // Hostname resolver cache TTL
@@ -723,11 +723,11 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(UPNP_LEASE_DURATION, (tr("UPnP lease duration [0: permanent lease]") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration", u"(?)"))
         , &m_spinBoxUPnPLeaseDuration);
     // Type of service
-    m_spinBoxPeerToS.setMinimum(0);
-    m_spinBoxPeerToS.setMaximum(255);
-    m_spinBoxPeerToS.setValue(session->peerToS());
-    addRow(PEER_TOS, (tr("Type of service (ToS) for connections to peers") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#peer_tos", u"(?)"))
-        , &m_spinBoxPeerToS);
+    m_spinBoxPeerDSCP.setMinimum(0);
+    m_spinBoxPeerDSCP.setMaximum(255);
+    m_spinBoxPeerDSCP.setValue(session->peerDSCP());
+    addRow(PEER_DSCP, (tr("Differentiated Services Code Point (DSCP) for connections to peers") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#peer_dscp", u"(?)"))
+        , &m_spinBoxPeerDSCP);
     // uTP-TCP mixed mode
     m_comboBoxUtpMixedMode.addItem(tr("Prefer TCP"), QVariant::fromValue(BitTorrent::MixedModeAlgorithm::TCP));
     m_comboBoxUtpMixedMode.addItem(tr("Peer proportional (throttles TCP)"), QVariant::fromValue(BitTorrent::MixedModeAlgorithm::Proportional));

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -70,7 +70,7 @@ private:
 
     QSpinBox m_spinBoxSaveResumeDataInterval, m_spinBoxSaveStatisticsInterval, m_spinBoxTorrentFileSizeLimit, m_spinBoxBdecodeDepthLimit, m_spinBoxBdecodeTokenLimit,
              m_spinBoxAsyncIOThreads, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage, m_spinBoxDiskQueueSize,
-             m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration, m_spinBoxPeerToS, m_spinBoxHostnameCacheTTL,
+             m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration, m_spinBoxPeerDSCP, m_spinBoxHostnameCacheTTL,
              m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxConnectionSpeed, m_spinBoxSocketSendBufferSize, m_spinBoxSocketReceiveBufferSize, m_spinBoxSocketBacklogSize,
              m_spinBoxAnnouncePort, m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout, m_spinBoxSessionShutdownTimeout,

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -461,7 +461,7 @@ void AppController::preferencesAction()
     // UPnP lease duration
     data[u"upnp_lease_duration"_s] = session->UPnPLeaseDuration();
     // Type of service
-    data[u"peer_tos"_s] = session->peerToS();
+    data[u"peer_tos"_s] = session->peerDSCP();
     // uTP-TCP mixed mode
     data[u"utp_tcp_mixed_mode"_s] = static_cast<int>(session->utpMixedMode());
     // Hostname resolver cache TTL
@@ -1114,7 +1114,7 @@ void AppController::setPreferencesAction()
         session->setUPnPLeaseDuration(it.value().toInt());
     // Type of service
     if (hasKey(u"peer_tos"_s))
-        session->setPeerToS(it.value().toInt());
+        session->setPeerDSCP(it.value().toInt());
     // uTP-TCP mixed mode
     if (hasKey(u"utp_tcp_mixed_mode"_s))
         session->setUtpMixedMode(static_cast<BitTorrent::MixedModeAlgorithm>(it.value().toInt()));

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1561,10 +1561,10 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 </tr>
                 <tr>
                     <td>
-                        <label for="peerToS">QBT_TR(Type of service (ToS) for connections to peers)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_tos" target="_blank">(?)</a></label>
+                        <label for="peerDSCP">QBT_TR(Differentiated Services Code Point (DSCP) for connections to peers)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_dscp" target="_blank">(?)</a></label>
                     </td>
                     <td>
-                        <input type="text" id="peerToS" style="width: 15em;">
+                        <input type="text" id="peerDSCP" style="width: 15em;">
                     </td>
                 </tr>
                 <tr>
@@ -2668,7 +2668,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("outgoingPortsMin").value = pref.outgoing_ports_min;
                     document.getElementById("outgoingPortsMax").value = pref.outgoing_ports_max;
                     document.getElementById("UPnPLeaseDuration").value = pref.upnp_lease_duration;
-                    document.getElementById("peerToS").value = pref.peer_tos;
+                    document.getElementById("peerDSCP").value = pref.peer_tos;
                     document.getElementById("utpTCPMixedModeAlgorithm").value = pref.utp_tcp_mixed_mode;
                     document.getElementById("hostnameCacheTTL").value = pref.hostname_cache_ttl;
                     document.getElementById("IDNSupportCheckbox").checked = pref.idn_support_enabled;
@@ -3156,12 +3156,12 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["outgoing_ports_max"] = Number(document.getElementById("outgoingPortsMax").value);
             settings["upnp_lease_duration"] = Number(document.getElementById("UPnPLeaseDuration").value);
 
-            const peerToS = Number(document.getElementById("peerToS").value);
-            if (Number.isNaN(peerToS) || (peerToS < 0) || (peerToS > 255)) {
-                alert("QBT_TR(Peer ToS must be between 0 and 255.)QBT_TR[CONTEXT=HttpServer]");
+            const peerDSCP = Number(document.getElementById("peerDSCP").value);
+            if (Number.isNaN(peerDSCP) || (peerDSCP < 0) || (peerDSCP > 255)) {
+                alert("QBT_TR(Peer DSCP must be between 0 and 255.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings["peer_tos"] = peerToS;
+            settings["peer_tos"] = peerDSCP;
 
             settings["utp_tcp_mixed_mode"] = Number(document.getElementById("utpTCPMixedModeAlgorithm").value);
             settings["hostname_cache_ttl"] = Number(document.getElementById("hostnameCacheTTL").value);


### PR DESCRIPTION
The setting has been renamed from `peer_tos` to `peer_dscp` and the default value has changed from `0x04` to `0x01`.
Note that in WebAPI and qbt config, the previous name is retained to avoid disruption to user.

Upstream PR:
https://github.com/arvidn/libtorrent/pull/6822
https://github.com/arvidn/libtorrent/pull/8072

~~This PR should be merged after https://github.com/arvidn/libtorrent/pull/8072 is merged upstream.~~
https://github.com/arvidn/libtorrent/pull/8072 is merged.