### PR TITLE
Bump (qBittorrent-nox) release metainfo to v5.2.0beta1

### DIFF
--- a/dist/unix/org.qbittorrent.qBittorrent-nox.metainfo.xml
+++ b/dist/unix/org.qbittorrent.qBittorrent-nox.metainfo.xml
@@ -52,6 +52,6 @@
   <url type="contribute">https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md</url>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="5.2.0~alpha1" date="2025-02-11"/>
+    <release version="5.2.0~beta1" date="2025-12-31"/>
   </releases>
 </component>


### PR DESCRIPTION
* Fix a slight oversight from https://github.com/qbittorrent/qBittorrent/commit/9d5a8270cf8fb72775c6e5e1a96925a7c1ab2773