### PR TITLE
WebUI: Add option to increase display density

### DIFF
--- a/src/webui/www/private/css/dynamicTable.css
+++ b/src/webui/www/private/css/dynamicTable.css
@@ -12,6 +12,17 @@
     padding: 2px;
 }
 
+:root.compact .dynamicTable td {
+    padding-bottom: 4px;
+    padding-top: 4px;
+}
+
+:root.compact #torrentFilesTableDiv .dynamicTable td,
+:root.compact #bulkRenameFilesTableDiv .dynamicTable td {
+    padding-bottom: 2px;
+    padding-top: 2px;
+}
+
 .dynamicTableDiv table.dynamicTable tbody tr.selected {
     background-color: var(--color-background-blue);
     color: var(--color-text-white);

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -159,6 +159,12 @@ body {
     text-align: left;
 }
 
+:root.compact body {
+    --icon-size: 13px;
+
+    line-height: 1.2;
+}
+
 /* targets dialog windows loaded via iframes */
 body:not(:has(#desktop)) {
     background-color: var(--color-background-popup);

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -66,6 +66,7 @@ window.qBittorrent.Client ??= (() => {
             "dblclick_complete",
             "dblclick_download",
             "dblclick_filter",
+            "display_density",
             "full_url_tracker_column",
             "hide_zero_status_filters",
             "qbt_selected_log_levels",
@@ -299,6 +300,7 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 
     await window.qBittorrent.Client.initializeClientData();
     window.qBittorrent.ColorScheme.update();
+    document.documentElement.classList.toggle("compact", clientData.get("display_density") === "compact");
 
     useAutoHideZeroStatusFilters = clientData.get("hide_zero_status_filters") === true;
     displayFullURLTrackerColumn = clientData.get("full_url_tracker_column") === true;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -80,7 +80,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.hiddenTableHeader = this.dynamicTableDiv.querySelector("thead tr");
             this.table = this.dynamicTableDiv.querySelector("table");
             this.tableBody = this.dynamicTableDiv.querySelector("tbody");
-            this.rowHeight = 26;
+            this.rowHeight = (clientData.get("display_density") === "compact") ? 22 : 26;
             this.rows = new Map();
             this.cachedElements = [];
             this.selectedRows = [];
@@ -1100,7 +1100,7 @@ window.qBittorrent.DynamicTable ??= (() => {
     class TorrentsTable extends DynamicTable {
         setupVirtualList() {
             super.setupVirtualList();
-            this.rowHeight = 22;
+            this.rowHeight = (clientData.get("display_density") === "compact") ? 18 : 22;
         }
 
         initColumns() {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -9,12 +9,21 @@
 
     <fieldset class="settings">
         <legend>QBT_TR(Interface)QBT_TR[CONTEXT=OptionsDialog]</legend>
-        <label for="colorSchemeSelect">QBT_TR(Color scheme:)QBT_TR[CONTEXT=OptionsDialog]</label>
-        <select id="colorSchemeSelect">
-            <option value="0">QBT_TR(Auto)QBT_TR[CONTEXT=OptionsDialog]</option>
-            <option value="1">QBT_TR(Light)QBT_TR[CONTEXT=OptionsDialog]</option>
-            <option value="2">QBT_TR(Dark)QBT_TR[CONTEXT=OptionsDialog]</option>
-        </select>
+        <div class="formRow" style="margin-bottom: 3px;">
+            <label for="colorSchemeSelect">QBT_TR(Color scheme:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <select id="colorSchemeSelect">
+                <option value="0">QBT_TR(Auto)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="1">QBT_TR(Light)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="2">QBT_TR(Dark)QBT_TR[CONTEXT=OptionsDialog]</option>
+            </select>
+        </div>
+        <div class="formRow">
+            <label for="displayDensitySelect">QBT_TR(Display density:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <select id="displayDensitySelect">
+                <option value="default">QBT_TR(Default)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="compact">QBT_TR(Compact)QBT_TR[CONTEXT=OptionsDialog]</option>
+            </select>
+        </div>
     </fieldset>
 
     <fieldset class="settings">
@@ -2262,6 +2271,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 .then((pref) => {
                     const clientData = window.parent.qBittorrent.ClientData;
                     const colorScheme = clientData.get("color_scheme");
+                    const displayDensity = clientData.get("display_density") ?? "default";
                     const fullUrlTrackerColumn = clientData.get("full_url_tracker_column");
                     const useVirtualList = clientData.get("use_virtual_list");
                     const hideZeroStatusFilters = clientData.get("hide_zero_status_filters");
@@ -2274,6 +2284,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     // Language
                     updateWebuiLocaleSelect(pref.locale);
                     updateColoSchemeSelect(colorScheme);
+                    document.getElementById("displayDensitySelect").value = displayDensity;
 
                     document.getElementById("statusBarExternalIP").checked = pref.status_bar_external_ip;
                     document.getElementById("performanceWarning").checked = pref.performance_warning;
@@ -2721,6 +2732,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 clientData.color_scheme = "light";
             else
                 clientData.color_scheme = "dark";
+            const displayDensity = document.getElementById("displayDensitySelect").value;
+            clientData.display_density = (displayDensity === "default") ? null : displayDensity;
             settings["status_bar_external_ip"] = document.getElementById("statusBarExternalIP").checked;
             settings["performance_warning"] = document.getElementById("performanceWarning").checked;
             clientData.full_url_tracker_column = document.getElementById("displayFullURLTrackerColumn").checked;


### PR DESCRIPTION
This adds a WebUI option to allow displaying more information on screen. The information density of the WebUI was decreased in v5 (see #21743) and this allows users to achieve the previous behavior.

Closes #21743.

Default density:
![Screenshot 2026-01-04 at 22 39 31](https://github.com/user-attachments/assets/134ca10d-408d-44e7-b692-5780cf4639d2)

Compact density:
![Screenshot 2026-01-04 at 22 39 41](https://github.com/user-attachments/assets/68b15710-18ac-4156-bf1d-8cdb71d35482)

