### PR TITLE
Fix more typos

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -305,15 +305,15 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
 
     if (!metadata.isEmpty())
     {
-        const lt::bdecode_node torentInfoRoot = lt::bdecode(metadata, ec
+        const lt::bdecode_node torrentInfoRoot = lt::bdecode(metadata, ec
                 , nullptr, pref->getBdecodeDepthLimit(), pref->getBdecodeTokenLimit());
         if (ec)
             return nonstd::make_unexpected(tr("Cannot parse torrent info: %1").arg(QString::fromStdString(ec.message())));
 
-        if (torentInfoRoot.type() != lt::bdecode_node::dict_t)
+        if (torrentInfoRoot.type() != lt::bdecode_node::dict_t)
             return nonstd::make_unexpected(tr("Cannot parse torrent info: invalid format"));
 
-        const auto torrentInfo = std::make_shared<lt::torrent_info>(torentInfoRoot, ec);
+        const auto torrentInfo = std::make_shared<lt::torrent_info>(torrentInfoRoot, ec);
         if (ec)
             return nonstd::make_unexpected(tr("Cannot parse torrent info: %1").arg(QString::fromStdString(ec.message())));
 

--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -680,12 +680,12 @@ LoadResumeDataResult DBResumeDataStorage::parseQueryResultRow(const QSqlQuery &q
     if (const QByteArray bencodedMetadata = query.value(DB_COLUMN_METADATA.name).toByteArray()
             ; !bencodedMetadata.isEmpty())
     {
-        const lt::bdecode_node torentInfoRoot = lt::bdecode(bencodedMetadata, ec
+        const lt::bdecode_node torrentInfoRoot = lt::bdecode(bencodedMetadata, ec
                 , nullptr, bdecodeDepthLimit, bdecodeTokenLimit);
         if (ec)
             return nonstd::make_unexpected(tr("Cannot parse torrent info: %1").arg(QString::fromStdString(ec.message())));
 
-        p.ti = std::make_shared<lt::torrent_info>(torentInfoRoot, ec);
+        p.ti = std::make_shared<lt::torrent_info>(torrentInfoRoot, ec);
         if (ec)
             return nonstd::make_unexpected(tr("Cannot parse torrent info: %1").arg(QString::fromStdString(ec.message())));
     }


### PR DESCRIPTION
* `torent` -> `torrent`

Xref.: https://github.com/qbittorrent/qBittorrent/pull/23706#issuecomment-3725042672