### PR TITLE
Use View type to partition string

### DIFF
--- a/src/base/utils/password.cpp
+++ b/src/base/utils/password.cpp
@@ -34,8 +34,10 @@
 #include <openssl/evp.h>
 
 #include <QByteArray>
+#include <QByteArrayView>
 #include <QList>
 #include <QString>
+#include <QStringView>
 
 #include "base/global.h"
 #include "bytearray.h"
@@ -55,14 +57,14 @@ namespace Utils
 
 // Implements constant-time comparison to protect against timing attacks
 // Taken from https://crackstation.net/hashing-security.htm
-bool Utils::Password::slowEquals(const QByteArray &a, const QByteArray &b)
+bool Utils::Password::slowEquals(const QByteArrayView left, const QByteArrayView right)
 {
-    const qsizetype lengthA = a.length();
-    const qsizetype lengthB = b.length();
+    const qsizetype lengthLeft = left.length();
+    const qsizetype lengthRight = right.length();
 
-    qsizetype diff = lengthA ^ lengthB;
-    for (qsizetype i = 0; (i < lengthA) && (i < lengthB); ++i)
-        diff |= a[i] ^ b[i];
+    qsizetype diff = lengthLeft ^ lengthRight;
+    for (qsizetype i = 0; (i < lengthLeft) && (i < lengthRight); ++i)
+        diff |= left[i] ^ right[i];
 
     return (diff == 0);
 }
@@ -109,7 +111,7 @@ QByteArray Utils::Password::PBKDF2::generate(const QByteArray &password)
     return (saltView.toBase64() + ':' + outBufView.toBase64());
 }
 
-bool Utils::Password::PBKDF2::verify(const QByteArray &secret, const QString &password)
+bool Utils::Password::PBKDF2::verify(const QByteArray &secret, const QStringView password)
 {
     return verify(secret, password.toUtf8());
 }

--- a/src/base/utils/password.h
+++ b/src/base/utils/password.h
@@ -30,13 +30,15 @@
 #pragma once
 
 class QByteArray;
+class QByteArrayView;
 class QString;
+class QStringView;
 
 namespace Utils::Password
 {
     // Implements constant-time comparison to protect against timing attacks
     // Taken from https://crackstation.net/hashing-security.htm
-    bool slowEquals(const QByteArray &a, const QByteArray &b);
+    bool slowEquals(QByteArrayView left, QByteArrayView right);
 
     QString generate(int passwordLength);
 
@@ -45,7 +47,7 @@ namespace Utils::Password
         QByteArray generate(const QString &password);
         QByteArray generate(const QByteArray &password);
 
-        bool verify(const QByteArray &secret, const QString &password);
+        bool verify(const QByteArray &secret, QStringView password);
         bool verify(const QByteArray &secret, const QByteArray &password);
     }
 }

--- a/src/webui/api/isessionmanager.h
+++ b/src/webui/api/isessionmanager.h
@@ -28,9 +28,8 @@
 
 #pragma once
 
-#include <QVariant>
-
 class QString;
+class QStringView;
 
 struct ISession
 {
@@ -44,5 +43,5 @@ struct ISessionManager
     virtual ISession *session() = 0;
     virtual void sessionStart() = 0;
     virtual void sessionEnd() = 0;
-    virtual bool validateCredentials(const QString &username, const QString &password) const = 0;
+    virtual bool validateCredentials(QStringView username, QStringView password) const = 0;
 };

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -139,8 +139,8 @@ private:
     bool isCrossSiteRequest(const Http::Request &request) const;
     bool validateHostHeader(const QStringList &domains) const;
 
-    bool validateCredentials(const QString &username, const QString &password) const override;
-    bool validateBasicAuth(const QString &credentials) const;
+    bool validateCredentials(QStringView username, QStringView password) const override;
+    bool validateBasicAuth(QStringView credentials) const;
     bool isBanned() const;
     int failedAttemptsCount() const;
     void increaseFailedAttempts() const;


### PR DESCRIPTION
And avoid redundant string copies. This applies to `validateBasicAuth()` and `parseAuthorizationHeader()`.