### PR TITLE
Add country flags for external IP

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -32,6 +32,8 @@
 ## 2.15.4
 * [#24056](https://github.com/qbittorrent/qBittorrent/pull/24056)
   * Add `rss/cloneRule` endpoint with `sourceName` and `cloneName` as parameters for cloning an existing RSS auto-download rule
+* [#23731](https://github.com/qbittorrent/qBittorrent/pull/23731)
+  * Add country information for external IP addresses in `sync/maindata` endpoint. `server_state` now includes `last_external_address_v4_country_code`, `last_external_address_v4_country`, `last_external_address_v6_country_code`, and `last_external_address_v6_country` when peer country resolution is enabled
 
 ## 2.15.3
 * [#24043](https://github.com/qbittorrent/qBittorrent/pull/24043)

--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -28,12 +28,12 @@
 * [#24135](https://github.com/qbittorrent/qBittorrent/pull/24135)
   * Add `torrents/downloadFile` endpoint with `hash` and `file` as parameters allowing to download a completed file from torrent content
     * `file` accepts either file index or path relative to content root
+* [#23731](https://github.com/qbittorrent/qBittorrent/pull/23731)
+  * Add country information for external IP addresses in `sync/maindata` endpoint. `server_state` now includes `last_external_address_v4_country_code`, `last_external_address_v4_country`, `last_external_address_v6_country_code`, and `last_external_address_v6_country` when peer country resolution is enabled
 
 ## 2.15.4
 * [#24056](https://github.com/qbittorrent/qBittorrent/pull/24056)
   * Add `rss/cloneRule` endpoint with `sourceName` and `cloneName` as parameters for cloning an existing RSS auto-download rule
-* [#23731](https://github.com/qbittorrent/qBittorrent/pull/23731)
-  * Add country information for external IP addresses in `sync/maindata` endpoint. `server_state` now includes `last_external_address_v4_country_code`, `last_external_address_v4_country`, `last_external_address_v6_country_code`, and `last_external_address_v6_country` when peer country resolution is enabled
 
 ## 2.15.3
 * [#24043](https://github.com/qbittorrent/qBittorrent/pull/24043)

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -278,7 +278,7 @@ void StatusBar::updateExternalAddressesLabel()
         bool hasFlag = false;
         if (hasAddress && resolveCountries && geoIP)
         {
-            const QHostAddress hostAddr(address);
+            const QHostAddress hostAddr {address};
             if (!hostAddr.isNull())
             {
                 const QString countryCode = geoIP->lookup(hostAddr);

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -29,12 +29,15 @@
 #include "statusbar.h"
 
 #include <QFrame>
+#include <QHBoxLayout>
+#include <QHostAddress>
 #include <QLabel>
 #include <QPushButton>
 #include <QStyle>
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/sessionstatus.h"
+#include "base/net/geoipmanager.h"
 #include "base/preferences.h"
 #include "base/utils/misc.h"
 #include "speedlimitdialog.h"
@@ -97,8 +100,33 @@ StatusBar::StatusBar(QWidget *parent)
     m_freeDiskSpaceLbl->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
     m_freeDiskSpaceSeparator = createSeparator(this);
 
-    m_lastExternalIPsLbl = new QLabel(tr("External IP: N/A"));
-    m_lastExternalIPsLbl->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+    m_externalIPsWidget = new QWidget(this);
+    m_externalIPsWidget->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+    auto *externalIPsLayout = new QHBoxLayout(m_externalIPsWidget);
+    externalIPsLayout->setContentsMargins(0, 0, 0, 0);
+    externalIPsLayout->setSpacing(0);
+
+    m_externalIPPrefixLbl = new QLabel(tr("External IP: N/A"), m_externalIPsWidget);
+    m_ipv4FlagLbl = new QLabel(m_externalIPsWidget);
+    m_ipv4FlagLbl->setContentsMargins(0, 0, 3, 0);
+    m_ipv4FlagLbl->setVisible(false);
+    m_ipv4AddressLbl = new QLabel(m_externalIPsWidget);
+    m_ipv4AddressLbl->setVisible(false);
+    m_ipSeparatorLbl = new QLabel(u", "_s, m_externalIPsWidget);
+    m_ipSeparatorLbl->setVisible(false);
+    m_ipv6FlagLbl = new QLabel(m_externalIPsWidget);
+    m_ipv6FlagLbl->setContentsMargins(0, 0, 3, 0);
+    m_ipv6FlagLbl->setVisible(false);
+    m_ipv6AddressLbl = new QLabel(m_externalIPsWidget);
+    m_ipv6AddressLbl->setVisible(false);
+
+    externalIPsLayout->addWidget(m_externalIPPrefixLbl);
+    externalIPsLayout->addWidget(m_ipv4FlagLbl);
+    externalIPsLayout->addWidget(m_ipv4AddressLbl);
+    externalIPsLayout->addWidget(m_ipSeparatorLbl);
+    externalIPsLayout->addWidget(m_ipv6FlagLbl);
+    externalIPsLayout->addWidget(m_ipv6AddressLbl);
+
     m_lastExternalIPsSeparator = createSeparator(this);
 
     const bool isDHTVisible = session->isDHTEnabled();
@@ -127,7 +155,7 @@ StatusBar::StatusBar(QWidget *parent)
 
     addPermanentWidget(m_freeDiskSpaceLbl);
     addPermanentWidget(m_freeDiskSpaceSeparator);
-    addPermanentWidget(m_lastExternalIPsLbl);
+    addPermanentWidget(m_externalIPsWidget);
     addPermanentWidget(m_lastExternalIPsSeparator);
     addPermanentWidget(m_DHTLbl);
     addPermanentWidget(m_DHTSeparator);
@@ -226,23 +254,58 @@ void StatusBar::updateExternalAddressesLabel()
 {
     const QString lastExternalIPv4Address = BitTorrent::Session::instance()->lastExternalIPv4Address();
     const QString lastExternalIPv6Address = BitTorrent::Session::instance()->lastExternalIPv6Address();
-    QString addressText = tr("External IP: N/A");
+    const bool resolveCountries = Preferences::instance()->resolvePeerCountries();
+    Net::GeoIPManager *const geoIP = Net::GeoIPManager::instance();
 
     const bool hasIPv4Address = !lastExternalIPv4Address.isEmpty();
     const bool hasIPv6Address = !lastExternalIPv6Address.isEmpty();
 
-    if (hasIPv4Address && hasIPv6Address)
-        addressText = tr("External IPs: %1, %2").arg(lastExternalIPv4Address, lastExternalIPv6Address);
-    else if (hasIPv4Address || hasIPv6Address)
-        addressText = tr("External IP: %1%2").arg(lastExternalIPv4Address, lastExternalIPv6Address);
+    if (!hasIPv4Address && !hasIPv6Address)
+        m_externalIPPrefixLbl->setText(tr("External IP: N/A"));
+    else if (hasIPv4Address && hasIPv6Address)
+        m_externalIPPrefixLbl->setText(tr("External IPs: "));
+    else
+        m_externalIPPrefixLbl->setText(tr("External IP: "));
 
-    m_lastExternalIPsLbl->setText(addressText);
+    const auto updateIPWidgets = [resolveCountries, geoIP]
+            (const QString &address, QLabel *flagLbl, QLabel *addressLbl)
+    {
+        const bool hasAddress = !address.isEmpty();
+        addressLbl->setVisible(hasAddress);
+        if (hasAddress)
+            addressLbl->setText(address);
+
+        bool hasFlag = false;
+        if (hasAddress && resolveCountries && geoIP)
+        {
+            const QHostAddress hostAddr(address);
+            if (!hostAddr.isNull())
+            {
+                const QString countryCode = geoIP->lookup(hostAddr);
+                if (!countryCode.isEmpty())
+                {
+                    const QIcon flagIcon = UIThemeManager::instance()->getFlagIcon(countryCode.toLower());
+                    if (!flagIcon.isNull())
+                    {
+                        flagLbl->setPixmap(flagIcon.pixmap(Utils::Gui::smallIconSize()));
+                        flagLbl->setToolTip(Net::GeoIPManager::CountryName(countryCode));
+                        hasFlag = true;
+                    }
+                }
+            }
+        }
+        flagLbl->setVisible(hasFlag);
+    };
+
+    updateIPWidgets(lastExternalIPv4Address, m_ipv4FlagLbl, m_ipv4AddressLbl);
+    updateIPWidgets(lastExternalIPv6Address, m_ipv6FlagLbl, m_ipv6AddressLbl);
+    m_ipSeparatorLbl->setVisible(hasIPv4Address && hasIPv6Address);
 }
 
 void StatusBar::updateExternalAddressesVisibility()
 {
     const bool isVisible = Preferences::instance()->isStatusbarExternalIPDisplayed();
-    m_lastExternalIPsLbl->setVisible(isVisible);
+    m_externalIPsWidget->setVisible(isVisible);
     m_lastExternalIPsSeparator->setVisible(isVisible);
 }
 

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -102,29 +102,34 @@ StatusBar::StatusBar(QWidget *parent)
 
     m_externalIPsWidget = new QWidget(this);
     m_externalIPsWidget->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+
     auto *externalIPsLayout = new QHBoxLayout(m_externalIPsWidget);
     externalIPsLayout->setContentsMargins(0, 0, 0, 0);
     externalIPsLayout->setSpacing(0);
 
     m_externalIPPrefixLbl = new QLabel(tr("External IP: N/A"), m_externalIPsWidget);
+    externalIPsLayout->addWidget(m_externalIPPrefixLbl);
+
     m_ipv4FlagLbl = new QLabel(m_externalIPsWidget);
     m_ipv4FlagLbl->setContentsMargins(0, 0, 3, 0);
     m_ipv4FlagLbl->setVisible(false);
+    externalIPsLayout->addWidget(m_ipv4FlagLbl);
+
     m_ipv4AddressLbl = new QLabel(m_externalIPsWidget);
     m_ipv4AddressLbl->setVisible(false);
+    externalIPsLayout->addWidget(m_ipv4AddressLbl);
+
     m_ipSeparatorLbl = new QLabel(u", "_s, m_externalIPsWidget);
     m_ipSeparatorLbl->setVisible(false);
+    externalIPsLayout->addWidget(m_ipSeparatorLbl);
+
     m_ipv6FlagLbl = new QLabel(m_externalIPsWidget);
     m_ipv6FlagLbl->setContentsMargins(0, 0, 3, 0);
     m_ipv6FlagLbl->setVisible(false);
+    externalIPsLayout->addWidget(m_ipv6FlagLbl);
+
     m_ipv6AddressLbl = new QLabel(m_externalIPsWidget);
     m_ipv6AddressLbl->setVisible(false);
-
-    externalIPsLayout->addWidget(m_externalIPPrefixLbl);
-    externalIPsLayout->addWidget(m_ipv4FlagLbl);
-    externalIPsLayout->addWidget(m_ipv4AddressLbl);
-    externalIPsLayout->addWidget(m_ipSeparatorLbl);
-    externalIPsLayout->addWidget(m_ipv6FlagLbl);
     externalIPsLayout->addWidget(m_ipv6AddressLbl);
 
     m_lastExternalIPsSeparator = createSeparator(this);
@@ -255,7 +260,7 @@ void StatusBar::updateExternalAddressesLabel()
     const QString lastExternalIPv4Address = BitTorrent::Session::instance()->lastExternalIPv4Address();
     const QString lastExternalIPv6Address = BitTorrent::Session::instance()->lastExternalIPv6Address();
     const bool resolveCountries = Preferences::instance()->resolvePeerCountries();
-    Net::GeoIPManager *const geoIP = Net::GeoIPManager::instance();
+    const Net::GeoIPManager *geoIP = Net::GeoIPManager::instance();
 
     const bool hasIPv4Address = !lastExternalIPv4Address.isEmpty();
     const bool hasIPv6Address = !lastExternalIPv6Address.isEmpty();
@@ -268,31 +273,33 @@ void StatusBar::updateExternalAddressesLabel()
         m_externalIPPrefixLbl->setText(tr("External IP: "));
 
     const auto updateIPWidgets = [resolveCountries, geoIP]
-            (const QString &address, QLabel *flagLbl, QLabel *addressLbl)
+            (const QString &address, QLabel *flagLbl, QLabel *addressLbl) -> void
     {
         const bool hasAddress = !address.isEmpty();
         addressLbl->setVisible(hasAddress);
-        if (hasAddress)
-            addressLbl->setText(address);
+        if (!hasAddress)
+            return;
+
+        addressLbl->setText(address);
 
         bool hasFlag = false;
-        if (hasAddress && resolveCountries && geoIP)
+        if (resolveCountries && geoIP)
         {
             const QHostAddress hostAddr {address};
-            if (!hostAddr.isNull())
-            {
-                const QString countryCode = geoIP->lookup(hostAddr);
-                if (!countryCode.isEmpty())
-                {
-                    const QIcon flagIcon = UIThemeManager::instance()->getFlagIcon(countryCode.toLower());
-                    if (!flagIcon.isNull())
-                    {
-                        flagLbl->setPixmap(flagIcon.pixmap(Utils::Gui::smallIconSize()));
-                        flagLbl->setToolTip(Net::GeoIPManager::CountryName(countryCode));
-                        hasFlag = true;
-                    }
-                }
-            }
+            if (hostAddr.isNull())
+                return;
+
+            const QString countryCode = geoIP->lookup(hostAddr);
+            if (countryCode.isEmpty())
+                return;
+
+            const QIcon flagIcon = UIThemeManager::instance()->getFlagIcon(countryCode.toLower());
+            if (flagIcon.isNull())
+                return;
+
+            flagLbl->setPixmap(flagIcon.pixmap(Utils::Gui::smallIconSize()));
+            flagLbl->setToolTip(Net::GeoIPManager::CountryName(countryCode));
+            hasFlag = true;
         }
         flagLbl->setVisible(hasFlag);
     };

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -72,8 +72,14 @@ private:
     QPushButton *m_upSpeedLbl = nullptr;
     QLabel *m_freeDiskSpaceLbl = nullptr;
     QWidget *m_freeDiskSpaceSeparator = nullptr;
-    QLabel *m_lastExternalIPsLbl = nullptr;
+    QWidget *m_externalIPsWidget = nullptr;
     QWidget *m_lastExternalIPsSeparator = nullptr;
+    QLabel *m_externalIPPrefixLbl = nullptr;
+    QLabel *m_ipv4FlagLbl = nullptr;
+    QLabel *m_ipv4AddressLbl = nullptr;
+    QLabel *m_ipSeparatorLbl = nullptr;
+    QLabel *m_ipv6FlagLbl = nullptr;
+    QLabel *m_ipv6AddressLbl = nullptr;
     QLabel *m_DHTLbl = nullptr;
     QWidget *m_DHTSeparator = nullptr;
     QPushButton *m_connecStatusLblIcon = nullptr;

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -29,6 +29,7 @@
 #include "synccontroller.h"
 
 #include <QFuture>
+#include <QHostAddress>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QMetaObject>
@@ -91,6 +92,10 @@ namespace
     const QString KEY_TRANSFER_FREESPACEONDISK = u"free_space_on_disk"_s;
     const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4 = u"last_external_address_v4"_s;
     const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6 = u"last_external_address_v6"_s;
+    const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4_COUNTRY_CODE = u"last_external_address_v4_country_code"_s;
+    const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY_CODE = u"last_external_address_v6_country_code"_s;
+    const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4_COUNTRY = u"last_external_address_v4_country"_s;
+    const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY = u"last_external_address_v6_country"_s;
     const QString KEY_TRANSFER_UPDATA = u"up_info_data"_s;
     const QString KEY_TRANSFER_UPRATELIMIT = u"up_rate_limit"_s;
     const QString KEY_TRANSFER_UPSPEED = u"up_info_speed"_s;
@@ -190,8 +195,23 @@ namespace
         map[KEY_TRANSFER_TOTAL_QUEUED_SIZE] = cacheStatus.queuedBytes;
         map[KEY_TRANSFER_REQUEST_LATENCY] = cacheStatus.requestLatency;
 
-        map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4] = session->lastExternalIPv4Address();
-        map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6] = session->lastExternalIPv6Address();
+        const QString lastExternalIPv4Address = session->lastExternalIPv4Address();
+        const QString lastExternalIPv6Address = session->lastExternalIPv6Address();
+        map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4] = lastExternalIPv4Address;
+        map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6] = lastExternalIPv6Address;
+
+        const bool resolvePeerCountries = Preferences::instance()->resolvePeerCountries();
+        if (resolvePeerCountries)
+        {
+            const QString ip4CountryCode = Net::GeoIPManager::instance()->lookup(QHostAddress(lastExternalIPv4Address));
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4_COUNTRY_CODE] = ip4CountryCode.toLower();
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4_COUNTRY] = Net::GeoIPManager::CountryName(ip4CountryCode);
+
+            const QString ip6CountryCode = Net::GeoIPManager::instance()->lookup(QHostAddress(lastExternalIPv6Address));
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY_CODE] = ip6CountryCode.toLower();
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY] = Net::GeoIPManager::CountryName(ip6CountryCode);
+        }
+
         map[KEY_TRANSFER_DHT_NODES] = sessionStatus.dhtNodes;
         map[KEY_TRANSFER_CONNECTION_STATUS] = session->isListening()
             ? (sessionStatus.hasIncomingConnections ? u"connected"_s : u"firewalled"_s)

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -211,6 +211,13 @@ namespace
             map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY_CODE] = ip6CountryCode.toLower();
             map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY] = Net::GeoIPManager::CountryName(ip6CountryCode);
         }
+        else
+        {
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4_COUNTRY_CODE] = {};
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4_COUNTRY] = {};
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY_CODE] = {};
+            map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6_COUNTRY] = {};
+        }
 
         map[KEY_TRANSFER_DHT_NODES] = sessionStatus.dhtNodes;
         map[KEY_TRANSFER_CONNECTION_STATUS] = session->isListening()

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -800,6 +800,12 @@ td.statusBarSeparator {
     width: 24px;
 }
 
+span.flags {
+    background: left center / contain no-repeat;
+    margin-left: 2px;
+    padding-left: 25px;
+}
+
 /* Statistics window */
 #statisticsContent {
     & table {

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1238,16 +1238,73 @@ window.addEventListener("DOMContentLoaded", async (event) => {
         if (window.qBittorrent.Cache.preferences.get().status_bar_external_ip) {
             const lastExternalAddressV4 = serverState.last_external_address_v4;
             const lastExternalAddressV6 = serverState.last_external_address_v6;
+            const lastExternalAddressV4CountryCode = serverState.last_external_address_v4_country_code;
+            const lastExternalAddressV6CountryCode = serverState.last_external_address_v6_country_code;
+            const lastExternalAddressV4Country = serverState.last_external_address_v4_country;
+            const lastExternalAddressV6Country = serverState.last_external_address_v6_country;
             const hasIPv4Address = lastExternalAddressV4 !== "";
             const hasIPv6Address = lastExternalAddressV6 !== "";
-            let lastExternalAddressLabel = "QBT_TR(External IP: N/A)QBT_TR[CONTEXT=HttpServer]";
+
+            // Clear previous content
+            externalIPsElement.textContent = "";
+
+            let labelPrefix = "QBT_TR(External IP: N/A)QBT_TR[CONTEXT=HttpServer]";
             if (hasIPv4Address && hasIPv6Address)
-                lastExternalAddressLabel = "QBT_TR(External IPs: %1, %2)QBT_TR[CONTEXT=HttpServer]";
+                labelPrefix = "QBT_TR(External IPs: )QBT_TR[CONTEXT=HttpServer]";
             else if (hasIPv4Address || hasIPv6Address)
-                lastExternalAddressLabel = "QBT_TR(External IP: %1%2)QBT_TR[CONTEXT=HttpServer]";
-            // https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses_(with_zone_index)
-            lastExternalAddressLabel = lastExternalAddressLabel.replace("%1", lastExternalAddressV4).replace("%2", lastExternalAddressV6);
-            externalIPsElement.textContent = lastExternalAddressLabel;
+                labelPrefix = "QBT_TR(External IP: )QBT_TR[CONTEXT=HttpServer]";
+
+            if (hasIPv4Address || hasIPv6Address) {
+                // Add label prefix
+                const labelSpan = document.createElement("span");
+                labelSpan.textContent = labelPrefix;
+                externalIPsElement.append(labelSpan);
+
+                // Add IPv4 with flag if available
+                if (hasIPv4Address) {
+                    if (lastExternalAddressV4CountryCode) {
+                        const flagSpan = document.createElement("span");
+                        flagSpan.classList.add("flags");
+                        flagSpan.style.backgroundImage = `url('images/flags/${lastExternalAddressV4CountryCode || "xx"}.svg')`;
+                        flagSpan.textContent = lastExternalAddressV4;
+                        flagSpan.title = lastExternalAddressV4Country || lastExternalAddressV4;
+                        externalIPsElement.appendChild(flagSpan);
+                    }
+                    else {
+                        const ipSpan = document.createElement("span");
+                        ipSpan.textContent = lastExternalAddressV4;
+                        externalIPsElement.appendChild(ipSpan);
+                    }
+
+                    // Add separator if both addresses exist
+                    if (hasIPv6Address) {
+                        const separatorSpan = document.createElement("span");
+                        separatorSpan.textContent = ", ";
+                        externalIPsElement.appendChild(separatorSpan);
+                    }
+                }
+
+                // Add IPv6 with flag if available
+                if (hasIPv6Address) {
+                    if (lastExternalAddressV6CountryCode) {
+                        const flagSpan = document.createElement("span");
+                        flagSpan.classList.add("flags");
+                        flagSpan.style.backgroundImage = `url('images/flags/${lastExternalAddressV6CountryCode || "xx"}.svg')`;
+                        flagSpan.textContent = lastExternalAddressV6;
+                        flagSpan.title = lastExternalAddressV6Country || lastExternalAddressV6;
+                        externalIPsElement.appendChild(flagSpan);
+                    }
+                    else {
+                        const ipSpan = document.createElement("span");
+                        ipSpan.textContent = lastExternalAddressV6;
+                        externalIPsElement.appendChild(ipSpan);
+                    }
+                }
+            }
+            else {
+                externalIPsElement.textContent = labelPrefix;
+            }
+
             externalIPsElement.classList.remove("invisible");
             externalIPsElement.previousElementSibling.classList.remove("invisible");
         }

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1235,75 +1235,67 @@ window.addEventListener("DOMContentLoaded", async (event) => {
         document.getElementById("freeSpaceOnDisk").textContent = "QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]".replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.free_space_on_disk));
 
         const externalIPsElement = document.getElementById("externalIPs");
-        if (window.qBittorrent.Cache.preferences.get().status_bar_external_ip) {
+        const preferences = window.qBittorrent.Cache.preferences.get();
+        if (preferences.status_bar_external_ip) {
             const lastExternalAddressV4 = serverState.last_external_address_v4;
             const lastExternalAddressV6 = serverState.last_external_address_v6;
             const lastExternalAddressV4CountryCode = serverState.last_external_address_v4_country_code;
             const lastExternalAddressV6CountryCode = serverState.last_external_address_v6_country_code;
             const lastExternalAddressV4Country = serverState.last_external_address_v4_country;
             const lastExternalAddressV6Country = serverState.last_external_address_v6_country;
-            const hasIPv4Address = lastExternalAddressV4 !== "";
-            const hasIPv6Address = lastExternalAddressV6 !== "";
+            const hasIPv4Address = (lastExternalAddressV4 !== "");
+            const hasIPv6Address = (lastExternalAddressV6 !== "");
+            const resolveCountries = preferences.resolve_peer_countries;
 
-            // Clear previous content
-            externalIPsElement.textContent = "";
-
-            let labelPrefix = "QBT_TR(External IP: N/A)QBT_TR[CONTEXT=HttpServer]";
-            if (hasIPv4Address && hasIPv6Address)
-                labelPrefix = "QBT_TR(External IPs: )QBT_TR[CONTEXT=HttpServer]";
-            else if (hasIPv4Address || hasIPv6Address)
-                labelPrefix = "QBT_TR(External IP: )QBT_TR[CONTEXT=HttpServer]";
-
-            if (hasIPv4Address || hasIPv6Address) {
-                // Add label prefix
-                const labelSpan = document.createElement("span");
-                labelSpan.textContent = labelPrefix;
-                externalIPsElement.append(labelSpan);
-
-                // Add IPv4 with flag if available
-                if (hasIPv4Address) {
-                    if (lastExternalAddressV4CountryCode) {
-                        const flagSpan = document.createElement("span");
-                        flagSpan.classList.add("flags");
-                        flagSpan.style.backgroundImage = `url('images/flags/${lastExternalAddressV4CountryCode || "xx"}.svg')`;
-                        flagSpan.textContent = lastExternalAddressV4;
-                        flagSpan.title = lastExternalAddressV4Country || lastExternalAddressV4;
-                        externalIPsElement.appendChild(flagSpan);
-                    }
-                    else {
-                        const ipSpan = document.createElement("span");
-                        ipSpan.textContent = lastExternalAddressV4;
-                        externalIPsElement.appendChild(ipSpan);
-                    }
-
-                    // Add separator if both addresses exist
-                    if (hasIPv6Address) {
-                        const separatorSpan = document.createElement("span");
-                        separatorSpan.textContent = ", ";
-                        externalIPsElement.appendChild(separatorSpan);
-                    }
+            const ensureSpan = (className) => {
+                let span = externalIPsElement.querySelector(`.${className}`);
+                let isNew = false;
+                if (!span) {
+                    span = document.createElement("span");
+                    span.classList.add(className);
+                    isNew = true;
                 }
+                return { span, isNew };
+            };
 
-                // Add IPv6 with flag if available
-                if (hasIPv6Address) {
-                    if (lastExternalAddressV6CountryCode) {
-                        const flagSpan = document.createElement("span");
-                        flagSpan.classList.add("flags");
-                        flagSpan.style.backgroundImage = `url('images/flags/${lastExternalAddressV6CountryCode || "xx"}.svg')`;
-                        flagSpan.textContent = lastExternalAddressV6;
-                        flagSpan.title = lastExternalAddressV6Country || lastExternalAddressV6;
-                        externalIPsElement.appendChild(flagSpan);
-                    }
-                    else {
-                        const ipSpan = document.createElement("span");
-                        ipSpan.textContent = lastExternalAddressV6;
-                        externalIPsElement.appendChild(ipSpan);
-                    }
+            const prefixSpanRef = ensureSpan("external-ips-prefix");
+            const ipv4SpanRef = ensureSpan("external-ipv4");
+            const separatorSpanRef = ensureSpan("external-ips-separator");
+            const ipv6SpanRef = ensureSpan("external-ipv6");
+            if (prefixSpanRef.isNew || ipv4SpanRef.isNew || separatorSpanRef.isNew || ipv6SpanRef.isNew)
+                externalIPsElement.append(prefixSpanRef.span, ipv4SpanRef.span, separatorSpanRef.span, ipv6SpanRef.span);
+
+            const updateIPSpan = (span, address, countryCode, country) => {
+                const hasAddress = (address !== "");
+                span.classList.toggle("invisible", !hasAddress);
+                if (!hasAddress)
+                    return;
+
+                span.textContent = address;
+
+                if (resolveCountries && countryCode) {
+                    span.classList.add("flags");
+                    span.style.backgroundImage = `url('images/flags/${countryCode}.svg')`;
+                    span.title = country || address;
                 }
-            }
-            else {
-                externalIPsElement.textContent = labelPrefix;
-            }
+                else {
+                    span.classList.remove("flags");
+                    span.style.backgroundImage = "";
+                    span.title = "";
+                }
+            };
+
+            if (!hasIPv4Address && !hasIPv6Address)
+                prefixSpanRef.span.textContent = "QBT_TR(External IP: N/A)QBT_TR[CONTEXT=HttpServer]";
+            else if (hasIPv4Address && hasIPv6Address)
+                prefixSpanRef.span.textContent = "QBT_TR(External IPs: )QBT_TR[CONTEXT=HttpServer]";
+            else
+                prefixSpanRef.span.textContent = "QBT_TR(External IP: )QBT_TR[CONTEXT=HttpServer]";
+
+            updateIPSpan(ipv4SpanRef.span, lastExternalAddressV4, lastExternalAddressV4CountryCode, lastExternalAddressV4Country);
+            updateIPSpan(ipv6SpanRef.span, lastExternalAddressV6, lastExternalAddressV6CountryCode, lastExternalAddressV6Country);
+            separatorSpanRef.span.textContent = ", ";
+            separatorSpanRef.span.classList.toggle("invisible", !(hasIPv4Address && hasIPv6Address));
 
             externalIPsElement.classList.remove("invisible");
             externalIPsElement.previousElementSibling.classList.remove("invisible");

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1249,11 +1249,10 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 
             const ensureSpan = (className) => {
                 let span = externalIPsElement.querySelector(`.${className}`);
-                let isNew = false;
-                if (!span) {
+                const isNew = span === null;
+                if (isNew) {
                     span = document.createElement("span");
                     span.classList.add(className);
-                    isNew = true;
                 }
                 return { span, isNew };
             };


### PR DESCRIPTION
# Motivation

Currently, the WebUI and DesktopGUI displays the external IP address in the status bar, but unlike peer IPs, it doesn't show the associated country flag. This feature request adds visual consistency by displaying country flags for external IPs using the same method as peer IPs. Very cool when you use a VPN

## What it does

This PR adds country flag display for external IP addresses (both IPv4 and IPv6) in the status bar. The flags are shown next to the IP addresses, matching the behavior already implemented for peer IPs in the peers table.

### Changes

**Backend (C++ - WebUI):**
- Modified `src/webui/api/synccontroller.cpp`:
  - Added `QHostAddress` include
  - Added country code and country name keys for external IPs (IPv4 and IPv6)
  - Enhanced `getTransferInfo()` to resolve country codes using `GeoIPManager` when peer country resolution is enabled
  - Simplified IPv6 country lookup to match IPv4 pattern (removed redundant nesting and error handling)

**Frontend (JavaScript - WebUI):**
- Modified `src/webui/www/private/scripts/client.js`:
  - Updated `processServerState()` to display flags for external IPs
  - Creates `<span>` elements with `flags` class and background images pointing to flag SVG files
  - Handles both IPv4 and IPv6 addresses with their respective flags
  - Falls back to plain text if country code is not available

**CSS (WebUI):**
- Modified `src/webui/www/private/css/style.css`:
  - Added global `span.flags` style for status bar (matching the style used in dynamic tables)

**Desktop GUI:**
- Modified `src/gui/statusbar.h`:
  - Replaced `QLabel *m_lastExternalIPsLbl` with `QWidget *m_externalIPsContainer` to support a richer layout
- Modified `src/gui/statusbar.cpp`:
  - Added `QHostAddress` and `GeoIPManager` includes
  - Replaced the single `QLabel` with a `QWidget` container using `QHBoxLayout` for flexible content
  - `updateExternalAddressesLabel()` now dynamically builds the IP display: clears existing widgets, adds a prefix label, then for each IP adds an optional flag icon (`UIThemeManager::getFlagIcon()`) with country name tooltip followed by the IP address
  - Handles IPv4 only, IPv6 only, both (with comma separator), or N/A
  - Country resolution is conditional on `Preferences::resolvePeerCountries()` (same as peers)


### Behavior

- Country flags are only displayed when "Resolve peer countries" is enabled in preferences (same as for peers)
- Works with IPv4-only, IPv6-only, or both addresses simultaneously
- Displays appropriate flag for each IP address
- Shows country name in tooltip on hover
- Gracefully falls back to plain IP display if country resolution fails or is disabled

### Testing

To test this feature:
1. Enable "Resolve peer countries" in Options → Behavior → BitTorrent
2. Enable "Show external IP in status bar" in Options → Interface → Interface
3. Access the WebUI and check the status bar at the bottom
4. Verify that flags appear next to external IP addresses
5. Verify tooltip shows country name on hover

## Screenshots
WebUI : 
<img width="947" height="152" alt="Capture d’écran 2026-01-11 à 19 27 50" src="https://github.com/user-attachments/assets/01b4beb0-2b02-432c-89fb-7526a2085d4b" />
(Ip Hidden)

Desktop GUI (Mac) : 
<img width="1275" height="65" alt="image" src="https://github.com/user-attachments/assets/5331b4d2-e3e7-453c-b9a4-f48db450216a" />
(Ip Hidden)



## Related

This feature uses the same GeoIP resolution system and flag display method as the existing peer country feature, ensuring consistency across the application.

