### PR TITLE
Fix embedded tracker peerId string conversion

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -458,7 +458,7 @@ void Tracker::prepareAnnounceResponse(const TrackerAnnounceRequest &announceReq)
                 };
 
                 if (!announceReq.noPeerId)
-                    peerDict[ANNOUNCE_RESPONSE_PEERS_PEER_ID] = std::string(peer.peerId.constData(), peer.peerId.size());
+                    peerDict[ANNOUNCE_RESPONSE_PEERS_PEER_ID] = lt::entry::string_type(peer.peerId.constData(), peer.peerId.size());
 
                 peerList.emplace_back(peerDict);
             }


### PR DESCRIPTION
When type `char *` is assigned to the `peerDict` it is converted to `std::string` via a conversion for C-style strings which are terminated by null character. Thus a peerId containing a null-byte gets truncated from the end.
Fix is to explicitly do the conversion and specify length of the byte array.