### PR TITLE
WebAPI/WebUI: Add support for downloading completed torrent files

### DIFF
--- a/src/base/http/connection.h
+++ b/src/base/http/connection.h
@@ -56,7 +56,8 @@ namespace Http
     private:
         static bool acceptsGzipEncoding(QString codings);
         void read();
-        void sendResponse(const Response &response) const;
+        void sendResponse(const Response &response);
+        void sendStreamingResponse(const Response &response);
 
         QTcpSocket *m_socket = nullptr;
         IRequestHandler *m_requestHandler = nullptr;

--- a/src/base/http/responsebuilder.cpp
+++ b/src/base/http/responsebuilder.cpp
@@ -60,6 +60,11 @@ Response ResponseBuilder::response() const
     return m_response;
 }
 
+Response &ResponseBuilder::responseRef()
+{
+    return m_response;
+}
+
 void ResponseBuilder::print_impl(const QByteArray &data, const QString &type)
 {
     if (!m_response.headers.contains(HEADER_CONTENT_TYPE))

--- a/src/base/http/responsebuilder.h
+++ b/src/base/http/responsebuilder.h
@@ -46,6 +46,9 @@ namespace Http
 
         Response response() const;
 
+    protected:
+        Response &responseRef();
+
     private:
         void print_impl(const QByteArray &data, const QString &type);
 

--- a/src/base/http/responsegenerator.h
+++ b/src/base/http/responsegenerator.h
@@ -38,6 +38,7 @@ namespace Http
     struct Response;
 
     QByteArray toByteArray(Response response);
+    QByteArray generateResponseHeaders(const Response &response);
     QString httpDate();
     void compressContent(Response &response);
 }

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QByteArray>
 #include <QHash>
 #include <QHostAddress>
@@ -37,9 +39,20 @@
 #include <QString>
 
 #include "base/global.h"
+#include "base/path.h"
 
 namespace Http
 {
+    struct RangeRequest
+    {
+        bool isValid = false;       // Whether a valid range was parsed
+        qint64 start = 0;           // Start byte offset
+        qint64 end = -1;            // End byte offset (inclusive)
+        qint64 length = -1;         // Length to serve (end - start + 1)
+    };
+
+    RangeRequest parseRangeHeader(const QString &rangeHeader, qint64 fileSize);
+
     inline const QString METHOD_GET = u"GET"_s;
     inline const QString METHOD_POST = u"POST"_s;
 
@@ -65,6 +78,9 @@ namespace Http
     inline const QString HEADER_X_FORWARDED_PROTO = u"x-forwarded-proto"_s;
     inline const QString HEADER_X_FRAME_OPTIONS = u"x-frame-options"_s;
     inline const QString HEADER_X_XSS_PROTECTION = u"x-xss-protection"_s;
+    inline const QString HEADER_ACCEPT_RANGES = u"accept-ranges"_s;
+    inline const QString HEADER_CONTENT_RANGE = u"content-range"_s;
+    inline const QString HEADER_RANGE = u"range"_s;
 
     inline const QString HEADER_REQUEST_METHOD_GET = u"GET"_s;
     inline const QString HEADER_REQUEST_METHOD_HEAD = u"HEAD"_s;
@@ -124,11 +140,20 @@ namespace Http
         QString text;
     };
 
+    struct StreamingInfo
+    {
+        Path filePath;
+        qint64 offset = 0;
+        qint64 size = 0;
+        qint64 totalSize = 0;
+    };
+
     struct Response
     {
         ResponseStatus status;
         HeaderMap headers;
         QByteArray content;
+        std::optional<StreamingInfo> streaming;
 
         Response(uint code = 200, const QString &text = u"OK"_s)
             : status {code, text}

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -44,6 +44,7 @@ void APIResult::clear()
     mimeType.clear();
     filename.clear();
     status = APIStatus::Ok;
+    streaming.reset();
 }
 
 APIController::APIController(IApplication *app, QObject *parent)
@@ -107,6 +108,16 @@ void APIController::setResult(const QJsonObject &result)
 void APIController::setResult(const QByteArray &result, const QString &mimeType, const QString &filename)
 {
     m_result.data = result;
+    m_result.mimeType = mimeType;
+    m_result.filename = filename;
+}
+
+void APIController::setStreamingResult(const Path &filePath, const qint64 fileSize, const QString &mimeType, const QString &filename)
+{
+    m_result.streaming = APIStreamingInfo {
+        .filePath = filePath,
+        .totalSize = fileSize
+    };
     m_result.mimeType = mimeType;
     m_result.filename = filename;
 }

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -28,16 +28,25 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QtContainerFwd>
 #include <QObject>
 #include <QString>
 #include <QVariant>
 
 #include "base/applicationcomponent.h"
+#include "base/path.h"
 #include "apistatus.h"
 
 using DataMap = QHash<QString, QByteArray>;
 using StringMap = QHash<QString, QString>;
+
+struct APIStreamingInfo
+{
+    Path filePath;
+    qint64 totalSize = 0;
+};
 
 struct APIResult
 {
@@ -45,6 +54,7 @@ struct APIResult
     QString mimeType;
     QString filename;
     APIStatus status = APIStatus::Ok;
+    std::optional<APIStreamingInfo> streaming;
 
     void clear();
 };
@@ -68,6 +78,7 @@ protected:
     void setResult(const QJsonArray &result);
     void setResult(const QJsonObject &result);
     void setResult(const QByteArray &result, const QString &mimeType = {}, const QString &filename = {});
+    void setStreamingResult(const Path &filePath, qint64 fileSize, const QString &mimeType, const QString &filename);
 
     void setStatus(APIStatus status);
 

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -117,6 +117,7 @@ private slots:
     void fetchMetadataAction();
     void parseMetadataAction();
     void saveMetadataAction();
+    void downloadFileAction();
 
 private:
     void onDownloadFinished(const Net::DownloadResult &result);

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -278,6 +278,8 @@
     </ul>
     <ul id="torrentFilesMenu" class="contextMenu">
         <li><a href="#Rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#Download"><img src="images/download.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#CopyURL"><img src="images/edit-copy.svg" alt="QBT_TR(Copy URL)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy URL)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li class="separator">
             <a href="#FilePrio" class="arrow-right"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Priority)QBT_TR[CONTEXT=PropertiesWidget]</a>
             <ul>

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -46,6 +46,7 @@ window.qBittorrent.Misc ??= (() => {
             containsAllTerms: containsAllTerms,
             sleep: sleep,
             downloadFile: downloadFile,
+            downloadFileStream: downloadFileStream,
             // variables
             FILTER_INPUT_DELAY: 400,
             MAX_ETA: 8640000
@@ -296,6 +297,26 @@ window.qBittorrent.Misc ??= (() => {
             link.download = fileName;
             link.click();
             link.remove();
+        }
+        catch (error) {
+            alert(errorMessage);
+        }
+    };
+
+    const downloadFileStream = async (url, errorMessage = "QBT_TR(Unable to download file)QBT_TR[CONTEXT=HttpServer]") => {
+        try {
+            // Pre-flight HEAD request to check for errors before triggering download
+            // This avoids navigating to an error page on failure
+            const response = await fetch(url, { method: "HEAD" });
+            if (!response.ok) {
+                alert(errorMessage);
+                return;
+            }
+
+            // Trigger native browser download
+            const link = document.createElement("a");
+            link.href = url;
+            link.click();
         }
         catch (error) {
             alert(errorMessage);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(testFiles
     testconceptsexplicitlyconvertibleto.cpp
     testconceptsstringable.cpp
     testglobal.cpp
+    testhttprangeparser.cpp
     testorderedset.cpp
     testpath.cpp
     testutilsbytearray.cpp

--- a/test/testhttprangeparser.cpp
+++ b/test/testhttprangeparser.cpp
@@ -1,0 +1,279 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2025  Thomas Piccirello <thomas@piccirello.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QObject>
+#include <QTest>
+
+#include "base/global.h"
+#include "base/http/types.h"
+
+class TestHttpRangeParser final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestHttpRangeParser)
+
+public:
+    TestHttpRangeParser() = default;
+
+private slots:
+    // Valid range formats
+    void testSimpleRange() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=0-499"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 0);
+        QCOMPARE(result.end, 499);
+        QCOMPARE(result.length, 500);
+    }
+
+    void testMiddleRange() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=500-999"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 500);
+        QCOMPARE(result.end, 999);
+        QCOMPARE(result.length, 500);
+    }
+
+    void testOpenEndedRange() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=500-"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 500);
+        QCOMPARE(result.end, 999);
+        QCOMPARE(result.length, 500);
+    }
+
+    void testSuffixRange() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=-500"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 500);
+        QCOMPARE(result.end, 999);
+        QCOMPARE(result.length, 500);
+    }
+
+    void testSingleByte() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=0-0"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 0);
+        QCOMPARE(result.end, 0);
+        QCOMPARE(result.length, 1);
+    }
+
+    void testLastByte() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=-1"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 999);
+        QCOMPARE(result.end, 999);
+        QCOMPARE(result.length, 1);
+    }
+
+    void testEntireFileViaRange() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=0-999"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 0);
+        QCOMPARE(result.end, 999);
+        QCOMPARE(result.length, 1000);
+    }
+
+    // Boundary conditions - clamping
+    void testRangeExceedsFileSize() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=0-2000"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 0);
+        QCOMPARE(result.end, 999);  // Clamped to file size
+        QCOMPARE(result.length, 1000);
+    }
+
+    void testStartAtLastByte() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=999-"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 999);
+        QCOMPARE(result.end, 999);
+        QCOMPARE(result.length, 1);
+    }
+
+    void testSuffixLargerThanFile() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=-2000"_s, 1000);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 0);  // Clamps to start of file
+        QCOMPARE(result.end, 999);
+        QCOMPARE(result.length, 1000);
+    }
+
+    // Invalid/malformed ranges - should return isValid=false
+    void testNoRangeHeader() const
+    {
+        const auto result = Http::parseRangeHeader(QString(), 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testEmptyRangeHeader() const
+    {
+        const auto result = Http::parseRangeHeader(u""_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testMissingEquals() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes 0-499"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testWrongUnit() const
+    {
+        const auto result = Http::parseRangeHeader(u"items=0-499"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testNoDash() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=500"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testStartGreaterThanEnd() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=500-100"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testStartAtFileSize() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=1000-"_s, 1000);
+        QVERIFY(!result.isValid);  // Start at 1000 is out of bounds for size 1000
+    }
+
+    void testStartBeyondFileSize() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=1500-"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testNonNumericStart() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=abc-500"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testNonNumericEnd() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=0-def"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testEmptyDash() const
+    {
+        // "bytes=-" with nothing after is invalid
+        const auto result = Http::parseRangeHeader(u"bytes=-"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    void testNegativeStart() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=-10-500"_s, 1000);
+        QVERIFY(!result.isValid);  // This is actually parsed as suffix range "-10-500" which is invalid
+    }
+
+    void testZeroSuffix() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=-0"_s, 1000);
+        QVERIFY(!result.isValid);  // Zero-length suffix is invalid
+    }
+
+    void testNegativeSuffix() const
+    {
+        // Note: "-" followed by negative number like "bytes=--5"
+        // The parser sees startStr="" and endStr="-5" which is invalid as a suffix length
+        const auto result = Http::parseRangeHeader(u"bytes=--5"_s, 1000);
+        QVERIFY(!result.isValid);
+    }
+
+    // Large file tests (multi-GB)
+    void testLargeFileRange() const
+    {
+        const qint64 fileSize = Q_INT64_C(10737418240);  // 10 GB
+        const auto result = Http::parseRangeHeader(u"bytes=5368709120-"_s, fileSize);  // Start at 5GB
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, Q_INT64_C(5368709120));
+        QCOMPARE(result.end, Q_INT64_C(10737418239));
+        QCOMPARE(result.length, Q_INT64_C(5368709120));
+    }
+
+    void testLargeFileSuffix() const
+    {
+        const qint64 fileSize = Q_INT64_C(10737418240);  // 10 GB
+        const auto result = Http::parseRangeHeader(u"bytes=-1073741824"_s, fileSize);  // Last 1GB
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, Q_INT64_C(9663676416));  // 10GB - 1GB
+        QCOMPARE(result.end, Q_INT64_C(10737418239));
+        QCOMPARE(result.length, Q_INT64_C(1073741824));
+    }
+
+    // Edge case: file size of 1
+    void testSingleByteFile() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=0-0"_s, 1);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 0);
+        QCOMPARE(result.end, 0);
+        QCOMPARE(result.length, 1);
+    }
+
+    void testSingleByteFileSuffix() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=-1"_s, 1);
+        QVERIFY(result.isValid);
+        QCOMPARE(result.start, 0);
+        QCOMPARE(result.end, 0);
+        QCOMPARE(result.length, 1);
+    }
+
+    // Edge case: file size of 0 (should all be invalid)
+    void testEmptyFile() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=0-0"_s, 0);
+        QVERIFY(!result.isValid);
+    }
+
+    void testEmptyFileSuffix() const
+    {
+        const auto result = Http::parseRangeHeader(u"bytes=-1"_s, 0);
+        QVERIFY(!result.isValid);
+    }
+};
+
+QTEST_APPLESS_MAIN(TestHttpRangeParser)
+#include "testhttprangeparser.moc"


### PR DESCRIPTION
This PR adds a new WebAPI endpoint for downloading individual torrent files directly from the WebUI. This allows users to retrieve completed files without needing a separate file server/access mechanism. It also supports streaming files directly to a media player, like VLC.

qBittorrent's HTTP server doesn't currently support the concept of streaming. Any data must be fully loaded into memory before it can be sent to the client. But this approach is impractical for large files. Now, qBittorrent's HTTP server additionally supports thread-based streaming. When a download is requested, the HTTP headers are sent on the main thread. The `QTcpSocket` is then moved to a dedicated worker thread that handles the file streaming synchronously, to avoid blocking. Once the download completes, the worker thread is cleaned up. This approach allows for a relatively simple implementation and reliable flow control via `waitForBytesWritten()`. (I also explored implementing this with async streaming but the code was much more complicated and I couldn't get flow control working correctly)

To keep memory usage low, file data is read in 256KB chunks with a 512KB socket buffer limit. The streaming thread blocks when the buffer is full, ensuring memory usage stays constant regardless of file size or transfer rate. We currently limit the server to 3 concurrent file downloads to bound total resource usage, but this is just an arbitrary limit.

Closes #15561.
Closes #15729.