### PR TITLE
Add CTRL+W search tab close functionality

### DIFF
--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -431,6 +431,14 @@ SearchWidget::SearchWidget(IGUIApplication *app, QWidget *parent)
     const auto *focusSearchHotkeyAlternative = new QShortcut((Qt::CTRL | Qt::Key_E), this);
     connect(focusSearchHotkeyAlternative, &QShortcut::activated, this, &SearchWidget::toggleFocusBetweenLineEdits);
 
+    const auto *closeTabHotkey = new QShortcut(QKeySequence::Close, this);
+    connect(closeTabHotkey, &QShortcut::activated, this, [this]()
+    {
+        const int currentIndex = m_ui->tabWidget->currentIndex();
+        if (currentIndex >= 0)
+            closeTab(currentIndex);
+    });
+
     m_historyLength = Preferences::instance()->searchHistoryLength();
     m_storeOpenedTabs = Preferences::instance()->storeOpenedSearchTabs();
     m_storeOpenedTabsResults = Preferences::instance()->storeOpenedSearchTabResults();


### PR DESCRIPTION
This commit adds basic changes to src/gui/searchwidget.cpp file, with the goal of common browser keyboard shortcut of closing search tab with ctrl-w for the sake of easier mouseless navigation.

Tested and built (v5.2.0beta1) on Debian Trixie, everything works as intended.