### PR TITLE
WebUI: remove invalid `for` attribute

### DIFF
--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -333,7 +333,7 @@
                         <tbody>
                             <tr>
                                 <td class="noWrap">
-                                    <label for="size">QBT_TR(Size:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                                    <label>QBT_TR(Size:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                                 </td>
                                 <td class="fullWidth">
                                     <span id="size">QBT_TR(Not available)QBT_TR[CONTEXT=AddNewTorrentDialog]</span>
@@ -341,7 +341,7 @@
                             </tr>
                             <tr>
                                 <td class="noWrap">
-                                    <label for="createdDate">QBT_TR(Date:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                                    <label>QBT_TR(Date:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                                 </td>
                                 <td class="fullWidth">
                                     <span id="createdDate">QBT_TR(Not available)QBT_TR[CONTEXT=AddNewTorrentDialog]</span>
@@ -349,7 +349,7 @@
                             </tr>
                             <tr>
                                 <td class="noWrap">
-                                    <label for="infoHashV1">QBT_TR(Info hash v1:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                                    <label>QBT_TR(Info hash v1:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                                 </td>
                                 <td class="fullWidth">
                                     <span id="infoHashV1">QBT_TR(Not available)QBT_TR[CONTEXT=AddNewTorrentDialog]</span>
@@ -357,7 +357,7 @@
                             </tr>
                             <tr>
                                 <td class="noWrap">
-                                    <label for="infoHashV2">QBT_TR(Info hash v2:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                                    <label>QBT_TR(Info hash v2:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                                 </td>
                                 <td class="fullWidth">
                                     <span id="infoHashV2">QBT_TR(Not available)QBT_TR[CONTEXT=AddNewTorrentDialog]</span>


### PR DESCRIPTION
The `for` attribute can only reference a small set of elements and `span` is not one of them.
See: https://html.spec.whatwg.org/multipage/forms.html#category-label

ps. this PR addresses the recent CI - WebUI failures.