### PR TITLE
Store WebUI search tabs between app restarts and across sessions

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,5 +1,10 @@
 # WebAPI Changelog
 
+## 2.16.1
+
+* [#23784](https://github.com/qbittorrent/qBittorrent/pull/23784)
+  * `search/status` endpoint now includes `pattern`, `category`, and `plugins` fields for each search job
+
 ## 2.16.0
 
 * [#24724](https://github.com/qbittorrent/qBittorrent/pull/24724)

--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -4,6 +4,7 @@
 
 * [#23784](https://github.com/qbittorrent/qBittorrent/pull/23784)
   * `search/status` endpoint now includes `pattern`, `category`, and `plugins` fields for each search job
+  * `app/preferences` endpoint now supports `store_search_jobs` and `store_search_job_results` preference keys
 
 ## 2.16.0
 

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -48,7 +48,7 @@ using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
-    const int MIGRATION_VERSION = 11;
+    const int MIGRATION_VERSION = 12;
     const QString MIGRATION_VERSION_KEY = u"Meta/MigrationVersion"_s;
 
     void exportWebUIHttpsFiles()
@@ -616,6 +616,27 @@ namespace
         doMigrate(u"Preferences/WebUI/ReverseProxySupportEnabled"_s, u"WebUI/ReverseProxySupportEnabled"_s);
         doMigrate(u"Preferences/WebUI/TrustedReverseProxiesList"_s, u"WebUI/TrustedReverseProxiesList"_s);
     }
+
+    void migrateSearchSettingKeys()
+    {
+        auto *settingsStorage = SettingsStorage::instance();
+
+        const auto oldKey1 = u"Search/StoreOpenedSearchTabs"_s;
+        const auto newKey1 = u"Search/StoreSearchJobs"_s;
+        if (settingsStorage->hasKey(oldKey1))
+        {
+            settingsStorage->storeValue(newKey1, settingsStorage->loadValue<bool>(oldKey1));
+            settingsStorage->removeValue(oldKey1);
+        }
+
+        const auto oldKey2 = u"Search/StoreOpenedSearchTabResults"_s;
+        const auto newKey2 = u"Search/StoreSearchJobResults"_s;
+        if (settingsStorage->hasKey(oldKey2))
+        {
+            settingsStorage->storeValue(newKey2, settingsStorage->loadValue<bool>(oldKey2));
+            settingsStorage->removeValue(oldKey2);
+        }
+    }
 }
 
 bool upgrade()
@@ -673,6 +694,9 @@ bool upgrade()
             migrateTorrentExportFolderSettings();
             migrateWebUISettings();
         }
+
+        if (version < 12)
+            migrateSearchSettingKeys();
 
         version = MIGRATION_VERSION;
     }

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -727,30 +727,30 @@ void Preferences::setSearchHistoryLength(const int length)
     setValue(u"Search/HistoryLength"_s, clampedLength);
 }
 
-bool Preferences::storeOpenedSearchTabs() const
+bool Preferences::storeSearchJobs() const
 {
-    return value(u"Search/StoreOpenedSearchTabs"_s, false);
+    return value(u"Search/StoreSearchJobs"_s, false);
 }
 
-void Preferences::setStoreOpenedSearchTabs(const bool enabled)
+void Preferences::setStoreSearchJobs(const bool enabled)
 {
-    if (enabled == storeOpenedSearchTabs())
+    if (enabled == storeSearchJobs())
         return;
 
-    setValue(u"Search/StoreOpenedSearchTabs"_s, enabled);
+    setValue(u"Search/StoreSearchJobs"_s, enabled);
 }
 
-bool Preferences::storeOpenedSearchTabResults() const
+bool Preferences::storeSearchJobResults() const
 {
-    return value(u"Search/StoreOpenedSearchTabResults"_s, false);
+    return value(u"Search/StoreSearchJobResults"_s, false);
 }
 
-void Preferences::setStoreOpenedSearchTabResults(const bool enabled)
+void Preferences::setStoreSearchJobResults(const bool enabled)
 {
-    if (enabled == storeOpenedSearchTabResults())
+    if (enabled == storeSearchJobResults())
         return;
 
-    setValue(u"Search/StoreOpenedSearchTabResults"_s, enabled);
+    setValue(u"Search/StoreSearchJobResults"_s, enabled);
 }
 
 bool Preferences::isWebUIEnabled() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -171,10 +171,10 @@ public:
     // Search UI
     int searchHistoryLength() const;
     void setSearchHistoryLength(int length);
-    bool storeOpenedSearchTabs() const;
-    void setStoreOpenedSearchTabs(bool enabled);
-    bool storeOpenedSearchTabResults() const;
-    void setStoreOpenedSearchTabResults(bool enabled);
+    bool storeSearchJobs() const;
+    void setStoreSearchJobs(bool enabled);
+    bool storeSearchJobResults() const;
+    void setStoreSearchJobResults(bool enabled);
 
     // HTTP Server
     bool isWebUIEnabled() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1384,12 +1384,12 @@ void OptionsDialog::loadSearchTabOptions()
 {
     const auto *pref = Preferences::instance();
 
-    m_ui->groupStoreOpenedTabs->setChecked(pref->storeOpenedSearchTabs());
-    m_ui->checkStoreTabsSearchResults->setChecked(pref->storeOpenedSearchTabResults());
+    m_ui->groupStoreSearchJobs->setChecked(pref->storeSearchJobs());
+    m_ui->checkStoreSearchJobResults->setChecked(pref->storeSearchJobResults());
     m_ui->searchHistoryLengthSpinBox->setValue(pref->searchHistoryLength());
 
-    connect(m_ui->groupStoreOpenedTabs, &QGroupBox::toggled, this, &OptionsDialog::enableApplyButton);
-    connect(m_ui->checkStoreTabsSearchResults, &QCheckBox::toggled, this, &OptionsDialog::enableApplyButton);
+    connect(m_ui->groupStoreSearchJobs, &QGroupBox::toggled, this, &OptionsDialog::enableApplyButton);
+    connect(m_ui->checkStoreSearchJobResults, &QCheckBox::toggled, this, &OptionsDialog::enableApplyButton);
     connect(m_ui->searchHistoryLengthSpinBox, qSpinBoxValueChanged, this, &OptionsDialog::enableApplyButton);
 }
 
@@ -1397,8 +1397,8 @@ void OptionsDialog::saveSearchTabOptions() const
 {
     auto *pref = Preferences::instance();
 
-    pref->setStoreOpenedSearchTabs(m_ui->groupStoreOpenedTabs->isChecked());
-    pref->setStoreOpenedSearchTabResults(m_ui->checkStoreTabsSearchResults->isChecked());
+    pref->setStoreSearchJobs(m_ui->groupStoreSearchJobs->isChecked());
+    pref->setStoreSearchJobResults(m_ui->checkStoreSearchJobResults->isChecked());
     pref->setSearchHistoryLength(m_ui->searchHistoryLengthSpinBox->value());
 }
 

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3427,7 +3427,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
               </property>
               <layout class="QVBoxLayout" name="groupSearchUILayout">
                <item>
-                <widget class="QGroupBox" name="groupStoreOpenedTabs">
+                <widget class="QGroupBox" name="groupStoreSearchJobs">
                  <property name="title">
                   <string>Store opened tabs</string>
                  </property>
@@ -3437,9 +3437,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  <property name="checked">
                   <bool>false</bool>
                  </property>
-                 <layout class="QVBoxLayout" name="groupStoreOpenedTabsLayout">
+                 <layout class="QVBoxLayout" name="groupStoreSearchJobsLayout">
                   <item>
-                   <widget class="QCheckBox" name="checkStoreTabsSearchResults">
+                   <widget class="QCheckBox" name="checkStoreSearchJobResults">
                     <property name="text">
                      <string>Also store search results</string>
                     </property>

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -440,8 +440,8 @@ SearchWidget::SearchWidget(IGUIApplication *app, QWidget *parent)
     });
 
     m_historyLength = Preferences::instance()->searchHistoryLength();
-    m_storeOpenedTabs = Preferences::instance()->storeOpenedSearchTabs();
-    m_storeOpenedTabsResults = Preferences::instance()->storeOpenedSearchTabResults();
+    m_storeOpenedTabs = Preferences::instance()->storeSearchJobs();
+    m_storeOpenedTabsResults = Preferences::instance()->storeSearchJobResults();
     connect(Preferences::instance(), &Preferences::changed, this, &SearchWidget::onPreferencesChanged);
 
     m_dataStorage->moveToThread(m_ioThread.get());
@@ -488,7 +488,7 @@ void SearchWidget::onPreferencesChanged()
 {
     const auto *pref = Preferences::instance();
 
-    const bool storeOpenedTabs = pref->storeOpenedSearchTabs();
+    const bool storeOpenedTabs = pref->storeSearchJobs();
     const bool isStoreOpenedTabsChanged = storeOpenedTabs != m_storeOpenedTabs;
     if (isStoreOpenedTabsChanged)
     {
@@ -504,7 +504,7 @@ void SearchWidget::onPreferencesChanged()
     }
 
 
-    const bool storeOpenedTabsResults = pref->storeOpenedSearchTabResults();
+    const bool storeOpenedTabsResults = pref->storeSearchJobResults();
     const bool isStoreOpenedTabsResultsChanged = storeOpenedTabsResults != m_storeOpenedTabsResults;
     if (isStoreOpenedTabsResultsChanged)
         m_storeOpenedTabsResults = storeOpenedTabsResults;

--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(qbt_webui STATIC
     api/transfercontroller.h
     api/serialize/serialize_torrent.h
     clientdatastorage.h
+    searchjobmanager.h
     webapplication.h
     websession.h
     webui.h
@@ -35,6 +36,7 @@ add_library(qbt_webui STATIC
     api/transfercontroller.cpp
     api/serialize/serialize_torrent.cpp
     clientdatastorage.cpp
+    searchjobmanager.cpp
     webapplication.cpp
     websession.cpp
     webui.cpp

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -156,6 +156,9 @@ void AppController::preferencesAction()
     data[u"status_bar_external_ip"_s] = pref->isStatusbarExternalIPDisplayed();
     // Transfer List
     data[u"confirm_torrent_deletion"_s] = pref->confirmTorrentDeletion();
+    // Search
+    data[u"store_search_jobs"_s] = pref->storeSearchJobs();
+    data[u"store_search_job_results"_s] = pref->storeSearchJobResults();
     // Log file
     data[u"file_log_enabled"_s] = app()->isFileLoggerEnabled();
     data[u"file_log_path"_s] = app()->fileLoggerPath().toString();
@@ -553,6 +556,11 @@ void AppController::setPreferencesAction()
     // Transfer List
     if (hasKey(u"confirm_torrent_deletion"_s))
         pref->setConfirmTorrentDeletion(it.value().toBool());
+    // Search
+    if (hasKey(u"store_search_jobs"_s))
+        pref->setStoreSearchJobs(it.value().toBool());
+    if (hasKey(u"store_search_job_results"_s))
+        pref->setStoreSearchJobResults(it.value().toBool());
     // Log file
     if (hasKey(u"file_log_enabled"_s))
         app()->setFileLoggerEnabled(it.value().toBool());

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -29,13 +29,10 @@
 
 #include "searchcontroller.h"
 
-#include <limits>
-
 #include <QHash>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QList>
-#include <QSharedPointer>
 
 #include "base/addtorrentmanager.h"
 #include "base/global.h"
@@ -45,10 +42,10 @@
 #include "base/search/searchhandler.h"
 #include "base/utils/datetime.h"
 #include "base/utils/foreignapps.h"
-#include "base/utils/random.h"
 #include "base/utils/string.h"
 #include "apierror.h"
 #include "isessionmanager.h"
+#include "webui/searchjobmanager.h"
 
 namespace
 {
@@ -80,6 +77,24 @@ namespace
 
         return categoriesInfo;
     }
+
+    QJsonObject jobInfoToJSON(const SearchJobManager::JobInfo &jobInfo)
+    {
+        return {
+            {u"id"_s, jobInfo.id},
+            {u"status"_s, jobInfo.active ? u"Running"_s : u"Stopped"_s},
+            {u"pattern"_s, jobInfo.pattern},
+            {u"category"_s, jobInfo.category},
+            {u"plugins"_s, QJsonArray::fromStringList(jobInfo.plugins)},
+            {u"total"_s, jobInfo.results.size()}
+        };
+    }
+}
+
+SearchController::SearchController(SearchJobManager *searchJobManager, IApplication *app, QObject *parent)
+    : APIController(app, parent)
+    , m_searchJobManager {searchJobManager}
+{
 }
 
 void SearchController::startAction()
@@ -109,19 +124,11 @@ void SearchController::startAction()
         pluginsToUse << plugins;
     }
 
-    if (m_activeSearches.size() >= MAX_CONCURRENT_SEARCHES)
-        throw APIError(APIErrorType::Conflict, tr("Unable to create more than %1 concurrent searches.").arg(MAX_CONCURRENT_SEARCHES));
+    const auto startSearchResult = m_searchJobManager->startSearch(pattern, category, pluginsToUse);
+    if (!startSearchResult)
+        throw APIError(APIErrorType::Conflict, startSearchResult.error());
 
-    const auto id = generateSearchId();
-    const std::shared_ptr<SearchHandler> searchHandler {SearchPluginManager::instance()->startSearch(pattern, category, pluginsToUse)};
-    connect(searchHandler.get(), &SearchHandler::searchFinished, this, [this, id] { m_activeSearches.remove(id); });
-    connect(searchHandler.get(), &SearchHandler::searchFailed, this, [this, id]([[maybe_unused]] const QString &errorMessage) { m_activeSearches.remove(id); });
-
-    m_searchHandlers.insert(id, searchHandler);
-
-    m_activeSearches.insert(id);
-
-    const QJsonObject result = {{u"id"_s, id}};
+    const QJsonObject result = {{u"id"_s, *startSearchResult}};
     setResult(result);
 }
 
@@ -131,17 +138,8 @@ void SearchController::stopAction()
 
     const int id = params()[u"id"_s].toInt();
 
-    const auto iter = m_searchHandlers.constFind(id);
-    if (iter == m_searchHandlers.cend())
+    if (!m_searchJobManager->stopSearch(id))
         throw APIError(APIErrorType::NotFound);
-
-    const std::shared_ptr<SearchHandler> &searchHandler = iter.value();
-
-    if (searchHandler->isActive())
-    {
-        searchHandler->cancelSearch();
-        m_activeSearches.remove(id);
-    }
 
     setResult(QString());
 }
@@ -150,22 +148,20 @@ void SearchController::statusAction()
 {
     const int id = params()[u"id"_s].toInt();
 
-    if ((id != 0) && !m_searchHandlers.contains(id))
-        throw APIError(APIErrorType::NotFound);
+    if (id != 0)
+    {
+        const auto jobInfo = m_searchJobManager->getJobInfo(id);
+        if (!jobInfo)
+            throw APIError(APIErrorType::NotFound);
+
+        const QJsonArray statusArray {jobInfoToJSON(*jobInfo)};
+        setResult(statusArray);
+        return;
+    }
 
     QJsonArray statusArray;
-    const QList<int> searchIds {(id == 0) ? m_searchHandlers.keys() : QList<int> {id}};
-
-    for (const int searchId : searchIds)
-    {
-        const std::shared_ptr<SearchHandler> &searchHandler = m_searchHandlers[searchId];
-        statusArray << QJsonObject
-        {
-            {u"id"_s, searchId},
-            {u"status"_s, searchHandler->isActive() ? u"Running"_s : u"Stopped"_s},
-            {u"total"_s, searchHandler->results().size()}
-        };
-    }
+    for (const auto &jobInfo : asConst(m_searchJobManager->getAllJobInfos()))
+        statusArray << jobInfoToJSON(jobInfo);
 
     setResult(statusArray);
 }
@@ -178,12 +174,11 @@ void SearchController::resultsAction()
     int limit = params()[u"limit"_s].toInt();
     int offset = params()[u"offset"_s].toInt();
 
-    const auto iter = m_searchHandlers.constFind(id);
-    if (iter == m_searchHandlers.cend())
+    const auto jobInfo = m_searchJobManager->getJobInfo(id);
+    if (!jobInfo)
         throw APIError(APIErrorType::NotFound);
 
-    const std::shared_ptr<SearchHandler> &searchHandler = iter.value();
-    const QList<SearchResult> searchResults = searchHandler->results();
+    const QList<SearchResult> &searchResults = jobInfo->results;
     const qsizetype size = searchResults.size();
 
     if (offset > size)
@@ -198,9 +193,9 @@ void SearchController::resultsAction()
         limit = -1;
 
     if ((limit > 0) || (offset > 0))
-        setResult(getResults(searchResults.mid(offset, limit), searchHandler->isActive(), size));
+        setResult(getResults(searchResults.mid(offset, limit), jobInfo->active, size));
     else
-        setResult(getResults(searchResults, searchHandler->isActive(), size));
+        setResult(getResults(searchResults, jobInfo->active, size));
 }
 
 void SearchController::deleteAction()
@@ -209,14 +204,8 @@ void SearchController::deleteAction()
 
     const int id = params()[u"id"_s].toInt();
 
-    const auto iter = m_searchHandlers.constFind(id);
-    if (iter == m_searchHandlers.cend())
+    if (!m_searchJobManager->deleteSearch(id))
         throw APIError(APIErrorType::NotFound);
-
-    const std::shared_ptr<SearchHandler> &searchHandler = iter.value();
-    searchHandler->cancelSearch();
-    m_activeSearches.remove(id);
-    m_searchHandlers.erase(iter);
 
     setResult(QString());
 }
@@ -321,16 +310,6 @@ void SearchController::checkForUpdatesFinished(const QHash<QString, SearchPlugin
 void SearchController::checkForUpdatesFailed(const QString &reason)
 {
     LogMsg(tr("Failed to check for plugin updates: %1").arg(reason), Log::INFO);
-}
-
-int SearchController::generateSearchId() const
-{
-    while (true)
-    {
-        const int id = Utils::Random::rand(1, std::numeric_limits<int>::max());
-        if (!m_searchHandlers.contains(id))
-            return id;
-    }
 }
 
 /**

--- a/src/webui/searchjobmanager.cpp
+++ b/src/webui/searchjobmanager.cpp
@@ -31,19 +31,102 @@
 
 #include <limits>
 
+#include <QDateTime>
+#include <QDir>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QString>
 #include <QStringList>
 
 #include "base/global.h"
+#include "base/logger.h"
+#include "base/path.h"
+#include "base/preferences.h"
+#include "base/profile.h"
 #include "base/search/searchhandler.h"
 #include "base/search/searchpluginmanager.h"
+#include "base/utils/fs.h"
+#include "base/utils/io.h"
 #include "base/utils/random.h"
 
+const Path DATA_FOLDER {u"WebUI/Search"_s};
+const QString SESSION_FILE_NAME = u"Session.json"_s;
+const int SESSION_FILE_MAX_SIZE = 1024 * 1024; // 1 MiB
+const int RESULTS_FILE_MAX_SIZE = 10 * 1024 * 1024; // 10 MiB
 const int MAX_CONCURRENT_SEARCHES = 5;
+
+const QString KEY_JOBS = u"Jobs"_s;
+const QString KEY_JOB_ID = u"ID"_s;
+const QString KEY_JOB_SEARCH_PATTERN = u"SearchPattern"_s;
+const QString KEY_JOB_CATEGORY = u"Category"_s;
+const QString KEY_JOB_PLUGINS = u"Plugins"_s;
+
+const QString KEY_RESULT_FILE_NAME = u"FileName"_s;
+const QString KEY_RESULT_FILE_URL = u"FileURL"_s;
+const QString KEY_RESULT_FILE_SIZE = u"FileSize"_s;
+const QString KEY_RESULT_SEEDERS_COUNT = u"SeedersCount"_s;
+const QString KEY_RESULT_LEECHERS_COUNT = u"LeechersCount"_s;
+const QString KEY_RESULT_ENGINE_NAME = u"EngineName"_s;
+const QString KEY_RESULT_SITE_URL = u"SiteURL"_s;
+const QString KEY_RESULT_DESCR_LINK = u"DescrLink"_s;
+const QString KEY_RESULT_PUB_DATE = u"PubDate"_s;
+
+namespace
+{
+    Path makeDataFilePath(const QString &fileName)
+    {
+        return specialFolderLocation(SpecialFolder::Data) / DATA_FOLDER / Path(fileName);
+    }
+
+    Path makeResultsFilePath(const int searchId)
+    {
+        return makeDataFilePath(QString::number(searchId).rightJustified(4, u'0') + u".json"_s);
+    }
+
+    QList<SearchResult> loadSearchResults(const int searchId)
+    {
+        const Path resultsFilePath = makeResultsFilePath(searchId);
+        const auto readResult = Utils::IO::readFile(resultsFilePath, RESULTS_FILE_MAX_SIZE);
+        if (!readResult)
+            return {};
+
+        QJsonParseError jsonError;
+        const QJsonDocument jsonDoc = QJsonDocument::fromJson(readResult.value(), &jsonError);
+        if ((jsonError.error != QJsonParseError::NoError) || !jsonDoc.isArray())
+            return {};
+
+        const QJsonArray resultsArray = jsonDoc.array();
+        QList<SearchResult> results;
+        results.reserve(resultsArray.size());
+        for (const QJsonValue &resultValue : resultsArray)
+        {
+            const QJsonObject resultObj = resultValue.toObject();
+            const SearchResult result {
+                .fileName = resultObj[KEY_RESULT_FILE_NAME].toString(),
+                .fileUrl = resultObj[KEY_RESULT_FILE_URL].toString(),
+                .fileSize = resultObj[KEY_RESULT_FILE_SIZE].toInteger(),
+                .nbSeeders = resultObj[KEY_RESULT_SEEDERS_COUNT].toInteger(),
+                .nbLeechers = resultObj[KEY_RESULT_LEECHERS_COUNT].toInteger(),
+                .engineName = resultObj[KEY_RESULT_ENGINE_NAME].toString(),
+                .siteUrl = resultObj[KEY_RESULT_SITE_URL].toString(),
+                .descrLink = resultObj[KEY_RESULT_DESCR_LINK].toString(),
+                .pubDate = QDateTime::fromSecsSinceEpoch(resultObj[KEY_RESULT_PUB_DATE].toInteger())
+            };
+            results.append(result);
+        }
+
+        return results;
+    }
+}
 
 SearchJobManager::SearchJobManager(QObject *parent)
     : QObject(parent)
+    , m_storeSearchJobs {Preferences::instance()->storeSearchJobs()}
+    , m_storeSearchJobResults {Preferences::instance()->storeSearchJobResults()}
 {
+    connect(Preferences::instance(), &Preferences::changed, this, &SearchJobManager::onPreferencesChanged);
+    loadSession();
 }
 
 nonstd::expected<int, QString> SearchJobManager::startSearch(const QString &pattern, const QString &category, const QStringList &plugins)
@@ -54,23 +137,15 @@ nonstd::expected<int, QString> SearchJobManager::startSearch(const QString &patt
     const int id = generateSearchId();
     const std::shared_ptr<SearchHandler> searchHandler = std::shared_ptr<SearchHandler>(SearchPluginManager::instance()->startSearch(pattern, category, plugins));
 
-    connect(searchHandler.get(), &SearchHandler::searchFinished, this, [this, id]
+    connect(searchHandler.get(), &SearchHandler::searchFinished, this, [this, id] { onSearchStopped(id); });
+    connect(searchHandler.get(), &SearchHandler::searchFailed, this, [this, id] { onSearchStopped(id); });
+    connect(searchHandler.get(), &SearchHandler::newSearchResults, this, [this, id, handler = searchHandler.get()]
     {
         const auto jobIter = m_jobs.find(id);
         if (jobIter == m_jobs.end())
             return;
 
-        jobIter->active = false;
-        m_searchHandlers.remove(id);
-    });
-    connect(searchHandler.get(), &SearchHandler::searchFailed, this, [this, id]([[maybe_unused]] const QString &errorMessage)
-    {
-        const auto jobIter = m_jobs.find(id);
-        if (jobIter == m_jobs.end())
-            return;
-
-        jobIter->active = false;
-        m_searchHandlers.remove(id);
+        jobIter->results = handler->results();
     });
 
     m_searchHandlers.insert(id, searchHandler);
@@ -82,6 +157,8 @@ nonstd::expected<int, QString> SearchJobManager::startSearch(const QString &patt
         .active = true,
         .results = {}});
     m_searchOrder.append(id);
+
+    saveSession();
 
     return id;
 }
@@ -107,6 +184,8 @@ bool SearchJobManager::deleteSearch(const int id)
         searchHandler->cancelSearch();
 
     m_searchOrder.removeOne(id);
+    removeSearchResults(id);
+    saveSession();
 
     return true;
 }
@@ -134,6 +213,19 @@ QList<SearchJobManager::JobInfo> SearchJobManager::getAllJobInfos() const
     return result;
 }
 
+void SearchJobManager::onSearchStopped(const int id)
+{
+    const auto jobIter = m_jobs.find(id);
+    if (jobIter == m_jobs.end())
+        return;
+
+    jobIter->active = false;
+    m_searchHandlers.remove(id);
+
+    if (m_storeSearchJobs && m_storeSearchJobResults)
+        saveSearchResults(id);
+}
+
 int SearchJobManager::generateSearchId() const
 {
     while (true)
@@ -141,5 +233,192 @@ int SearchJobManager::generateSearchId() const
         const int id = Utils::Random::rand(1, std::numeric_limits<int>::max());
         if (!m_jobs.contains(id))
             return id;
+    }
+}
+
+void SearchJobManager::loadSession()
+{
+    if (!m_storeSearchJobs)
+        return;
+
+    const Path sessionFilePath = makeDataFilePath(SESSION_FILE_NAME);
+    const auto readResult = Utils::IO::readFile(sessionFilePath, SESSION_FILE_MAX_SIZE);
+    if (!readResult)
+    {
+        if (readResult.error().status != Utils::IO::ReadError::NotExist)
+        {
+            LogMsg(tr("Failed to load WebUI search session. File: \"%1\". Error: \"%2\"")
+                    .arg(sessionFilePath.toString(), readResult.error().message), Log::WARNING);
+        }
+        return;
+    }
+
+    QJsonParseError jsonError;
+    const QJsonDocument jsonDoc = QJsonDocument::fromJson(readResult.value(), &jsonError);
+    if (jsonError.error != QJsonParseError::NoError)
+    {
+        LogMsg(tr("Failed to parse WebUI search session. File: \"%1\". Error: \"%2\"")
+                .arg(sessionFilePath.toString(), jsonError.errorString()), Log::WARNING);
+        return;
+    }
+
+    const QJsonObject jsonObj = jsonDoc.object();
+    const QJsonArray jobsArray = jsonObj[KEY_JOBS].toArray();
+
+    for (const QJsonValue &jobValue : jobsArray)
+    {
+        const QJsonObject jobObj = jobValue.toObject();
+        const int jobId = jobObj[KEY_JOB_ID].toInt();
+        const QString searchPattern = jobObj[KEY_JOB_SEARCH_PATTERN].toString();
+
+        if ((jobId <= 0) || searchPattern.isEmpty())
+            continue;
+
+        JobInfo jobInfo;
+        jobInfo.id = jobId;
+        jobInfo.pattern = searchPattern;
+        jobInfo.category = jobObj[KEY_JOB_CATEGORY].toString();
+        for (const QJsonValue &pluginValue : jobObj[KEY_JOB_PLUGINS].toArray())
+            jobInfo.plugins.append(pluginValue.toString());
+
+        if (m_storeSearchJobResults)
+            jobInfo.results = loadSearchResults(jobId);
+
+        m_jobs.insert(jobId, jobInfo);
+        m_searchOrder.append(jobId);
+    }
+}
+
+void SearchJobManager::saveSession() const
+{
+    if (!m_storeSearchJobs)
+    {
+        removeAllData();
+        return;
+    }
+
+    QJsonArray jobsArray;
+
+    // Save searches in chronological order (oldest first)
+    for (const int searchId : asConst(m_searchOrder))
+    {
+        const auto jobInfo = getJobInfo(searchId);
+        Q_ASSERT(jobInfo);
+        if (!jobInfo) [[unlikely]]
+            continue;
+
+        jobsArray.append(QJsonObject {
+            {KEY_JOB_ID, searchId},
+            {KEY_JOB_SEARCH_PATTERN, jobInfo->pattern},
+            {KEY_JOB_CATEGORY, jobInfo->category},
+            {KEY_JOB_PLUGINS, QJsonArray::fromStringList(jobInfo->plugins)}
+        });
+    }
+
+    const QJsonObject sessionObj {
+        {KEY_JOBS, jobsArray}
+    };
+
+    const Path sessionFilePath = makeDataFilePath(SESSION_FILE_NAME);
+
+    // Ensure directory exists
+    Utils::Fs::mkpath(sessionFilePath.parentPath());
+
+    const auto saveResult = Utils::IO::saveToFile(sessionFilePath, QJsonDocument(sessionObj).toJson());
+    if (!saveResult)
+    {
+        LogMsg(tr("Failed to save WebUI search session. File: \"%1\". Error: \"%2\"")
+                .arg(sessionFilePath.toString(), saveResult.error()), Log::WARNING);
+    }
+}
+
+void SearchJobManager::saveSearchResults(const int searchId) const
+{
+    const auto jobInfo = getJobInfo(searchId);
+    Q_ASSERT(jobInfo);
+    if (!jobInfo) [[unlikely]]
+        return;
+
+    QJsonArray resultsArray;
+    for (const SearchResult &result : jobInfo->results)
+    {
+        resultsArray.append(QJsonObject {
+            {KEY_RESULT_FILE_NAME, result.fileName},
+            {KEY_RESULT_FILE_URL, result.fileUrl},
+            {KEY_RESULT_FILE_SIZE, result.fileSize},
+            {KEY_RESULT_SEEDERS_COUNT, result.nbSeeders},
+            {KEY_RESULT_LEECHERS_COUNT, result.nbLeechers},
+            {KEY_RESULT_ENGINE_NAME, result.engineName},
+            {KEY_RESULT_SITE_URL, result.siteUrl},
+            {KEY_RESULT_DESCR_LINK, result.descrLink},
+            {KEY_RESULT_PUB_DATE, result.pubDate.toSecsSinceEpoch()}
+        });
+    }
+
+    const Path resultsFilePath = makeResultsFilePath(searchId);
+
+    // Ensure directory exists
+    Utils::Fs::mkpath(resultsFilePath.parentPath());
+
+    const auto saveResult = Utils::IO::saveToFile(resultsFilePath, QJsonDocument(resultsArray).toJson());
+    if (!saveResult)
+    {
+        LogMsg(tr("Failed to save WebUI search results. File: \"%1\". Error: \"%2\"")
+                .arg(resultsFilePath.toString(), saveResult.error()), Log::WARNING);
+    }
+}
+
+void SearchJobManager::removeSearchResults(const int searchId) const
+{
+    const Path resultsFilePath = makeResultsFilePath(searchId);
+    std::ignore = Utils::Fs::removeFile(resultsFilePath);
+}
+
+void SearchJobManager::removeAllData() const
+{
+    const Path dataFolderPath = specialFolderLocation(SpecialFolder::Data) / DATA_FOLDER;
+    Utils::Fs::removeDirRecursively(dataFolderPath);
+}
+
+void SearchJobManager::removeAllResultFiles() const
+{
+    const Path dataFolderPath = specialFolderLocation(SpecialFolder::Data) / DATA_FOLDER;
+    // Remove all .json files except Session.json
+    const QStringList entries = QDir(dataFolderPath.data()).entryList({u"*.json"_s}, QDir::Files);
+    for (const QString &entry : entries)
+    {
+        if (entry != SESSION_FILE_NAME)
+            std::ignore = Utils::Fs::removeFile(dataFolderPath / Path(entry));
+    }
+}
+
+void SearchJobManager::onPreferencesChanged()
+{
+    const auto *pref = Preferences::instance();
+
+    const bool storeSearchJobs = pref->storeSearchJobs();
+    if (storeSearchJobs != m_storeSearchJobs)
+    {
+        m_storeSearchJobs = storeSearchJobs;
+        saveSession();
+    }
+
+    const bool storeSearchJobResults = pref->storeSearchJobResults();
+    if (storeSearchJobResults != m_storeSearchJobResults)
+    {
+        m_storeSearchJobResults = storeSearchJobResults;
+        if (m_storeSearchJobResults && m_storeSearchJobs)
+        {
+            // Save results for all completed searches
+            for (const JobInfo &job : asConst(m_jobs))
+            {
+                if (!job.active)
+                    saveSearchResults(job.id);
+            }
+        }
+        else
+        {
+            removeAllResultFiles();
+        }
     }
 }

--- a/src/webui/searchjobmanager.cpp
+++ b/src/webui/searchjobmanager.cpp
@@ -1,0 +1,145 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018, 2026  Thomas Piccirello <thomas@piccirello.com>
+ * Copyright (C) 2024  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "searchjobmanager.h"
+
+#include <limits>
+
+#include <QString>
+#include <QStringList>
+
+#include "base/global.h"
+#include "base/search/searchhandler.h"
+#include "base/search/searchpluginmanager.h"
+#include "base/utils/random.h"
+
+const int MAX_CONCURRENT_SEARCHES = 5;
+
+SearchJobManager::SearchJobManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+nonstd::expected<int, QString> SearchJobManager::startSearch(const QString &pattern, const QString &category, const QStringList &plugins)
+{
+    if (m_searchHandlers.size() >= MAX_CONCURRENT_SEARCHES)
+        return nonstd::make_unexpected(tr("Unable to create more than %1 concurrent searches.").arg(MAX_CONCURRENT_SEARCHES));
+
+    const int id = generateSearchId();
+    const std::shared_ptr<SearchHandler> searchHandler = std::shared_ptr<SearchHandler>(SearchPluginManager::instance()->startSearch(pattern, category, plugins));
+
+    connect(searchHandler.get(), &SearchHandler::searchFinished, this, [this, id]
+    {
+        const auto jobIter = m_jobs.find(id);
+        if (jobIter == m_jobs.end())
+            return;
+
+        jobIter->active = false;
+        m_searchHandlers.remove(id);
+    });
+    connect(searchHandler.get(), &SearchHandler::searchFailed, this, [this, id]([[maybe_unused]] const QString &errorMessage)
+    {
+        const auto jobIter = m_jobs.find(id);
+        if (jobIter == m_jobs.end())
+            return;
+
+        jobIter->active = false;
+        m_searchHandlers.remove(id);
+    });
+
+    m_searchHandlers.insert(id, searchHandler);
+    m_jobs.insert(id, {
+        .id = id,
+        .pattern = pattern,
+        .category = category,
+        .plugins = plugins,
+        .active = true,
+        .results = {}});
+    m_searchOrder.append(id);
+
+    return id;
+}
+
+bool SearchJobManager::stopSearch(const int id)
+{
+    if (!m_jobs.contains(id))
+        return false;
+
+    const std::shared_ptr<SearchHandler> searchHandler = m_searchHandlers.value(id);
+    if (searchHandler && searchHandler->isActive())
+        searchHandler->cancelSearch();
+
+    return true;
+}
+
+bool SearchJobManager::deleteSearch(const int id)
+{
+    if (!m_jobs.remove(id))
+        return false;
+
+    if (const std::shared_ptr<SearchHandler> searchHandler = m_searchHandlers.take(id))
+        searchHandler->cancelSearch();
+
+    m_searchOrder.removeOne(id);
+
+    return true;
+}
+
+std::optional<SearchJobManager::JobInfo> SearchJobManager::getJobInfo(const int id) const
+{
+    const auto iter = m_jobs.constFind(id);
+    if (iter == m_jobs.cend())
+        return std::nullopt;
+
+    return *iter;
+}
+
+QList<SearchJobManager::JobInfo> SearchJobManager::getAllJobInfos() const
+{
+    QList<JobInfo> result;
+    result.reserve(m_searchOrder.size());
+    for (const int id : asConst(m_searchOrder))
+    {
+        const auto info = getJobInfo(id);
+        Q_ASSERT(info);
+        if (info) [[likely]]
+            result.append(*info);
+    }
+    return result;
+}
+
+int SearchJobManager::generateSearchId() const
+{
+    while (true)
+    {
+        const int id = Utils::Random::rand(1, std::numeric_limits<int>::max());
+        if (!m_jobs.contains(id))
+            return id;
+    }
+}

--- a/src/webui/searchjobmanager.h
+++ b/src/webui/searchjobmanager.h
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018, 2026  Thomas Piccirello <thomas@piccirello.com>
  * Copyright (C) 2024  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2018  Thomas Piccirello <thomas@piccirello.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,43 +29,45 @@
 
 #pragma once
 
-#include <QtContainerFwd>
+#include <memory>
+#include <optional>
 
-#include "base/search/searchpluginmanager.h"
-#include "apicontroller.h"
+#include <QHash>
+#include <QObject>
 
-class QJsonArray;
-class QJsonObject;
+#include "base/3rdparty/expected.hpp"
+#include "base/search/searchhandler.h"
 
-class SearchJobManager;
-struct SearchResult;
-
-class SearchController : public APIController
+class SearchJobManager final : public QObject
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(SearchController)
+    Q_DISABLE_COPY_MOVE(SearchJobManager)
 
 public:
-    SearchController(SearchJobManager *searchJobManager, IApplication *app, QObject *parent = nullptr);
+    struct JobInfo
+    {
+        int id = 0;
+        QString pattern;
+        QString category;
+        QStringList plugins;
+        bool active = false;
+        QList<SearchResult> results;
+    };
 
-private slots:
-    void startAction();
-    void stopAction();
-    void statusAction();
-    void resultsAction();
-    void deleteAction();
-    void downloadTorrentAction();
-    void pluginsAction();
-    void installPluginAction();
-    void uninstallPluginAction();
-    void enablePluginAction();
-    void updatePluginsAction();
+    explicit SearchJobManager(QObject *parent = nullptr);
+
+    nonstd::expected<int, QString> startSearch(const QString &pattern, const QString &category, const QStringList &plugins);
+    bool stopSearch(int id);
+    bool deleteSearch(int id);
+
+    std::optional<JobInfo> getJobInfo(int id) const;
+    QList<JobInfo> getAllJobInfos() const;
 
 private:
-    void checkForUpdatesFinished(const QHash<QString, SearchPluginVersion> &updateInfo);
-    void checkForUpdatesFailed(const QString &reason);
-    QJsonObject getResults(const QList<SearchResult> &searchResults, bool isSearchActive, int totalResults) const;
-    QJsonArray getPluginsInfo(const QStringList &plugins) const;
+    int generateSearchId() const;
 
-    SearchJobManager *m_searchJobManager = nullptr;
+    QHash<int, std::shared_ptr<SearchHandler>> m_searchHandlers;
+    // TODO: use Boost.MultiIndex to provide both lookup by ID and insertion order
+    QHash<int, JobInfo> m_jobs;
+    QList<int> m_searchOrder;  // Tracks insertion order (oldest first)
 };

--- a/src/webui/searchjobmanager.h
+++ b/src/webui/searchjobmanager.h
@@ -63,8 +63,21 @@ public:
     std::optional<JobInfo> getJobInfo(int id) const;
     QList<JobInfo> getAllJobInfos() const;
 
+private slots:
+    void onPreferencesChanged();
+
 private:
+    void onSearchStopped(int id);
     int generateSearchId() const;
+    void loadSession();
+    void saveSession() const;
+    void saveSearchResults(int searchId) const;
+    void removeSearchResults(int searchId) const;
+    void removeAllResultFiles() const;
+    void removeAllData() const;
+
+    bool m_storeSearchJobs = false;
+    bool m_storeSearchJobResults = false;
 
     QHash<int, std::shared_ptr<SearchHandler>> m_searchHandlers;
     // TODO: use Boost.MultiIndex to provide both lookup by ID and insertion order

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -70,6 +70,7 @@
 #include "api/torrentscontroller.h"
 #include "api/transfercontroller.h"
 #include "clientdatastorage.h"
+#include "searchjobmanager.h"
 #include "websession.h"
 
 const int MAX_ALLOWED_FILESIZE = 10 * 1024 * 1024;
@@ -174,6 +175,7 @@ WebApplication::WebApplication(IApplication *app, QObject *parent)
     , m_trRegex {u"QBT_TR\\((([^\\)]|\\)(?!QBT_TR))+)\\)QBT_TR\\[CONTEXT=([a-zA-Z_][a-zA-Z0-9_]*)\\]"_s}
     , m_authController {new AuthController(this, app, this)}
     , m_torrentCreationManager {new BitTorrent::TorrentCreationManager(app, this)}
+    , m_searchJobManager {new SearchJobManager(this)}
     , m_clientDataStorage {new ClientDataStorage(this)}
 {
     declarePublicAPI(u"auth/login"_s);
@@ -913,7 +915,6 @@ void WebApplication::sessionStartImpl(const QString &sessionId, const WebSession
     m_currentSession->registerAPIController(u"app"_s, [app = app(), parent = m_currentSession] { return new AppController(app, parent); });
     m_currentSession->registerAPIController(u"log"_s, [app = app(), parent = m_currentSession] { return new LogController(app, parent); });
     m_currentSession->registerAPIController(u"rss"_s, [app = app(), parent = m_currentSession] { return new RSSController(app, parent); });
-    m_currentSession->registerAPIController(u"search"_s, [app = app(), parent = m_currentSession] { return new SearchController(app, parent); });
     m_currentSession->registerAPIController(u"torrents"_s, [app = app(), parent = m_currentSession] { return new TorrentsController(app, parent); });
     m_currentSession->registerAPIController(u"transfer"_s, [app = app(), parent = m_currentSession] { return new TransferController(app, parent); });
     m_currentSession->registerAPIController(u"clientdata"_s
@@ -925,6 +926,11 @@ void WebApplication::sessionStartImpl(const QString &sessionId, const WebSession
             , [app = app(), parent = m_currentSession, torrentCreationManager = m_torrentCreationManager]
     {
         return new TorrentCreatorController(torrentCreationManager, app, parent);
+    });
+    m_currentSession->registerAPIController(u"search"_s
+            , [app = app(), parent = m_currentSession, searchJobManager = m_searchJobManager]
+    {
+        return new SearchController(searchJobManager, app, parent);
     });
     m_currentSession->registerAPIController(u"sync"_s
             , [app = app(), parent = m_currentSession, btSession = BitTorrent::Session::instance()]

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -58,13 +58,14 @@
 using namespace std::chrono_literals;
 using namespace Qt::Literals::StringLiterals;
 
-inline const Utils::Version<3, 2> API_VERSION {2, 16, 0};
+inline const Utils::Version<3, 2> API_VERSION {2, 16, 1};
 
 class QNetworkCookie;
 
 class APIController;
 class AuthController;
 class ClientDataStorage;
+class SearchJobManager;
 class WebSession;
 
 enum class WebSessionType : qint8;
@@ -274,6 +275,7 @@ private:
     Http::HeaderMap m_prebuiltHeaders;
 
     BitTorrent::TorrentCreationManager *m_torrentCreationManager = nullptr;
+    SearchJobManager *m_searchJobManager = nullptr;
     ClientDataStorage *m_clientDataStorage = nullptr;
 
     struct FailedLogin

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -42,11 +42,8 @@ window.qBittorrent.Search ??= (() => {
             searchSeedsFilterChanged: searchSeedsFilterChanged,
             searchSizeFilterChanged: searchSizeFilterChanged,
             searchSizeFilterPrefixChanged: searchSizeFilterPrefixChanged,
-            closeSearchTab: closeSearchTab,
         };
     };
-
-    const localPreferences = new window.qBittorrent.LocalPreferences.LocalPreferences();
 
     const searchTabIdPrefix = "Search-";
     let loadSearchPluginsTimer = -1;
@@ -59,6 +56,8 @@ window.qBittorrent.Search ??= (() => {
     let searchResultsTable;
     /** @type Map<number, {
      * searchPattern: string,
+     * category: string,
+     * plugins: string,
      * filterPattern: string,
      * seedsFilter: {min: number, max: number},
      * sizeFilter: {min: number, minUnit: number, max: number, maxUnit: number},
@@ -195,10 +194,25 @@ window.qBittorrent.Search ??= (() => {
             }
         });
 
-        // restore search tabs
-        const searchJobs = JSON.parse(localPreferences.get("search_jobs", "[]"));
-        for (const { id, pattern, category, plugins } of searchJobs)
-            createSearchTab(id, pattern, category, plugins);
+        restoreSearchJobs();
+    };
+
+    const restoreSearchJobs = () => {
+        fetch("api/v2/search/status", {
+                method: "GET",
+                cache: "no-store"
+            })
+            .then(async (response) => {
+                if (!response.ok)
+                    return;
+
+                const serverJobs = await response.json();
+
+                for (const job of serverJobs) {
+                    if (!document.getElementById(`${searchTabIdPrefix}${job.id}`))
+                        createSearchTab(job.id, job.pattern, job.category, job.plugins);
+                }
+            });
     };
 
     const numSearchTabs = () => {
@@ -273,7 +287,7 @@ window.qBittorrent.Search ??= (() => {
         searchState.set(searchId, {
             searchPattern: pattern,
             category: category,
-            plugins: plugins,
+            plugins: Array.isArray(plugins) ? plugins.join("|") : plugins,
             filterPattern: searchText.filterPattern,
             seedsFilter: { min: searchSeedsFilter.min, max: searchSeedsFilter.max },
             sizeFilter: { min: searchSizeFilter.min, minUnit: searchSizeFilter.minUnit, max: searchSizeFilter.max, maxUnit: searchSizeFilter.maxUnit },
@@ -286,6 +300,7 @@ window.qBittorrent.Search ??= (() => {
             sort: { column: searchResultsTable.sortedColumn, reverse: searchResultsTable.reverseSort },
             lastSeenCount: 0,
         });
+        searchText.pattern = pattern;
         updateSearchResultsData(searchId);
     };
 
@@ -296,13 +311,6 @@ window.qBittorrent.Search ??= (() => {
                 id: oldSearchId
             })
         });
-
-        const searchJobs = JSON.parse(localPreferences.get("search_jobs", "[]"));
-        const jobIndex = searchJobs.findIndex((job) => job.id === oldSearchId);
-        if (jobIndex >= 0) {
-            searchJobs[jobIndex].id = searchId;
-            localPreferences.set("search_jobs", JSON.stringify(searchJobs));
-        }
 
         // update existing tab w/ new search id
         const tab = document.getElementById(`${searchTabIdPrefix}${oldSearchId}`);
@@ -350,13 +358,6 @@ window.qBittorrent.Search ??= (() => {
                 id: searchId
             })
         });
-
-        const searchJobs = JSON.parse(localPreferences.get("search_jobs", "[]"));
-        const jobIndex = searchJobs.findIndex((job) => job.id === searchId);
-        if (jobIndex >= 0) {
-            searchJobs.splice(jobIndex, 1);
-            localPreferences.set("search_jobs", JSON.stringify(searchJobs));
-        }
 
         searchState.delete(searchId);
 
@@ -504,10 +505,6 @@ window.qBittorrent.Search ??= (() => {
                 const responseJSON = await response.json();
                 const searchId = responseJSON.id;
                 createSearchTab(searchId, pattern, category, plugins);
-
-                const searchJobs = JSON.parse(localPreferences.get("search_jobs", "[]"));
-                searchJobs.push({ id: searchId, pattern: pattern, category: category, plugins: plugins });
-                localPreferences.set("search_jobs", JSON.stringify(searchJobs));
                 updateSearchButtonState();
             });
     };
@@ -525,8 +522,8 @@ window.qBittorrent.Search ??= (() => {
                 method: "POST",
                 body: new URLSearchParams({
                     pattern: state.searchPattern,
-                    category: state.category ?? document.getElementById("categorySelect").value,
-                    plugins: state.plugins ?? document.getElementById("pluginsSelect").value
+                    category: state.category,
+                    plugins: state.plugins
                 })
             })
             .then(async (response) => {
@@ -951,6 +948,11 @@ window.qBittorrent.Search ??= (() => {
                         // bad params. search id is invalid
                         resetSearchState(searchId);
                         updateStatusIconElement(searchId, "QBT_TR(An error occurred during search...)QBT_TR[CONTEXT=SearchJobWidget]", "images/error.svg");
+                    }
+                    else if (response.status === 409) {
+                        // offset out of range, the server no longer has the results
+                        updateStatusIconElement(searchId, "QBT_TR(Search results are no longer available)QBT_TR[CONTEXT=SearchJobWidget]", "images/error.svg");
+                        resetSearchState(searchId);
                     }
                     else if (state) {
                         clearTimeout(state.loadResultsTimer);

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -101,6 +101,18 @@
     </fieldset>
 
     <fieldset class="settings">
+        <legend>QBT_TR(Search)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <div class="formRow" style="margin-bottom: 3px;">
+            <input type="checkbox" id="storeSearchJobs" onclick="qBittorrent.Preferences.updateStoreSearchJobsEnabled();">
+            <label for="storeSearchJobs">QBT_TR(Save search tabs)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow" style="margin-bottom: 3px; margin-left: 30px;">
+            <input type="checkbox" id="storeSearchJobResults">
+            <label for="storeSearchJobResults">QBT_TR(Also save search results)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+    </fieldset>
+
+    <fieldset class="settings">
         <legend>
             <input type="checkbox" id="filelog_checkbox" onclick="qBittorrent.Preferences.updateFileLogEnabled();">
             <label for="filelog_checkbox">QBT_TR(Log Files)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -1896,6 +1908,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateFileLogEnabled: updateFileLogEnabled,
                 updateFileLogBackupEnabled: updateFileLogBackupEnabled,
                 updateFileLogDeleteEnabled: updateFileLogDeleteEnabled,
+                updateStoreSearchJobsEnabled: updateStoreSearchJobsEnabled,
                 updateTempDirEnabled: updateTempDirEnabled,
                 updateTorrentBackupControls: updateTorrentBackupControls,
                 updateFinishedTorrentBackupControls: updateFinishedTorrentBackupControls,
@@ -1969,6 +1982,11 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const pros = document.getElementById("filelog_delete_old_checkbox").getProperties("disabled", "checked");
             document.getElementById("filelog_age_input").disabled = pros.disabled || !pros.checked;
             document.getElementById("filelog_age_type_select").disabled = pros.disabled || !pros.checked;
+        };
+
+        const updateStoreSearchJobsEnabled = () => {
+            const enabled = document.getElementById("storeSearchJobs").checked;
+            document.getElementById("storeSearchJobResults").disabled = !enabled;
         };
 
         // Downloads tab
@@ -2423,6 +2441,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("dblclickCompleteSelect").value = dblclickComplete;
                     document.getElementById("dblclickFiltersSelect").value = dblclickFilter;
                     document.getElementById("confirmTorrentDeletion").checked = pref.confirm_torrent_deletion;
+                    document.getElementById("storeSearchJobs").checked = pref.store_search_jobs;
+                    document.getElementById("storeSearchJobResults").checked = pref.store_search_job_results;
+                    qBittorrent.Preferences.updateStoreSearchJobsEnabled();
                     document.getElementById("useAltRowColorsInput").checked = useAltRowColors === true;
                     document.getElementById("filelog_checkbox").checked = pref.file_log_enabled;
                     document.getElementById("filelog_save_path_input").value = pref.file_log_path;
@@ -2866,6 +2887,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             clientData.dblclick_complete = document.getElementById("dblclickCompleteSelect").value;
             clientData.dblclick_filter = document.getElementById("dblclickFiltersSelect").value;
             settings["confirm_torrent_deletion"] = document.getElementById("confirmTorrentDeletion").checked;
+            settings["store_search_jobs"] = document.getElementById("storeSearchJobs").checked;
+            settings["store_search_job_results"] = document.getElementById("storeSearchJobResults").checked;
             clientData.use_alt_row_colors = document.getElementById("useAltRowColorsInput").checked;
             settings["file_log_enabled"] = document.getElementById("filelog_checkbox").checked;
             settings["file_log_path"] = document.getElementById("filelog_save_path_input").value;


### PR DESCRIPTION
This PR makes two major improvements to WebAPI/WebUI searches:

- Searches and their results are now persisted across qBittorrent restarts. This mimics the same behavior available in the GUI.
- All searches are now available to and shared among all WebAPI sessions. This makes sense given that qBittorrent's WebAPI is single user.