### PR TITLE
Docs: Fix loop counter in for-loop example

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -92,7 +92,7 @@ if (condition)
     // code
 }
 
-for (int a = 0; a < b; ++b)
+for (int a = 0; a < b; ++a)
 {
     // code
 }


### PR DESCRIPTION
## Summary
Fixes a bug in the CODING_GUIDELINES.md example code.

## Changes
The example for-loop on line 100 was incrementing the wrong variable:
- Before: `for (int a = 0; a < b; ++b)`
- After: `for (int a = 0; a < b; ++a)`

## Motivation
The example was incrementing `b` (the limit) instead of `a` (the loop counter), which would cause an infinite loop. This could mislead new contributors following the coding guidelines.

While this is just example code in documentation, having correct examples is important for a coding guidelines document.

## Type
- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
