### PR TITLE
Revert "Temporarily lower Qt version deprecation"

### DIFF
--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -20,7 +20,7 @@ target_compile_features(qbt_common_cfg INTERFACE
 )
 
 target_compile_definitions(qbt_common_cfg INTERFACE
-    QT_DISABLE_DEPRECATED_UP_TO=0x060500
+    QT_DISABLE_DEPRECATED_UP_TO=0x060600
     QT_NO_CAST_FROM_ASCII
     QT_NO_CAST_TO_ASCII
     QT_NO_CAST_FROM_BYTEARRAY


### PR DESCRIPTION
This reverts 5df4df1308f2c6b54f950350dfc232407498c1d8 introduced in PR #23499 as upstream fix for [QTBUG-141994](https://bugreports.qt.io/browse/QTBUG-141994) has been publicly released.

* Upstream fixed in `Qt 6.8.6 / Qt 6.10.2 / Qt 6.11.0 Beta3+`

* [Qt 6.10.2 Release Announcement](https://www.qt.io/blog/qt-6.10.2-released)
* [Release Notes](https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.10.2/release-note.md)
____

>Once a Qt version with a fix has been release we can raise it again.
Otherwise, I can't do a beta release on Windows.

https://github.com/qbittorrent/qBittorrent/pull/23499#issue-3629355276