### PR TITLE
Check whether "getrandom" exists

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -247,6 +247,13 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         ${Carbon_LIBRARY}
         ${IOKit_LIBRARY}
     )
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    include(CheckSymbolExists)
+    check_symbol_exists(getrandom "sys/random.h" HAVE_GETRANDOM)
+
+    if (HAVE_GETRANDOM)
+        target_compile_definitions(qbt_base PUBLIC QBT_USES_GETRANDOM)
+    endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(qbt_base PRIVATE iphlpapi powrprof)
 endif()

--- a/src/base/utils/random.cpp
+++ b/src/base/utils/random.cpp
@@ -32,7 +32,7 @@
 
 #include <QtSystemDetection>
 
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) && defined(QBT_USES_GETRANDOM)
 #include "randomlayer_linux.cpp"
 #elif defined(Q_OS_WIN)
 #include "randomlayer_win.cpp"


### PR DESCRIPTION
Under some Linux environments (e.g. Termux) "getrandom" may not actually exist.