### PR TITLE
use constexpr instead of const

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -113,16 +113,16 @@ namespace
 #define NOTIFICATIONS_SETTINGS_KEY(name) (SETTINGS_KEY(u"GUI/Notifications/"_s) name)
 
     const QString LOG_FOLDER = u"logs"_s;
-    const QChar PARAMS_SEPARATOR = u'|';
+    constexpr QChar PARAMS_SEPARATOR = u'|';
 
     const Path DEFAULT_PORTABLE_MODE_PROFILE_DIR {u"profile"_s};
 
-    const int MIN_FILELOG_SIZE = 1024; // 1KiB
-    const int MAX_FILELOG_SIZE = 1000 * 1024 * 1024; // 1000MiB
-    const int DEFAULT_FILELOG_SIZE = 65 * 1024; // 65KiB
+    constexpr int MIN_FILELOG_SIZE = 1024; // 1KiB
+    constexpr int MAX_FILELOG_SIZE = 1000 * 1024 * 1024; // 1000MiB
+    constexpr int DEFAULT_FILELOG_SIZE = 65 * 1024; // 65KiB
 
 #ifndef DISABLE_GUI
-    const int PIXMAP_CACHE_SIZE = 64 * 1024 * 1024;  // 64MiB
+    constexpr int PIXMAP_CACHE_SIZE = 64 * 1024 * 1024;  // 64MiB
 #endif
 
     const QString PARAM_ADDSTOPPED = u"@addStopped"_s;
@@ -1215,7 +1215,7 @@ void Application::shutdownCleanup([[maybe_unused]] QSessionManager &manager)
 #if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_LINUX) && !defined(Q_OS_MACOS)
 void Application::applyMemoryWorkingSetLimit() const
 {
-    const size_t MiB = 1024 * 1024;
+    constexpr size_t MiB = 1024 * 1024;
     const QString logMessage = tr("Failed to set physical memory (RAM) usage limit. Error code: %1. Error message: \"%2\"");
 
 #ifdef Q_OS_WIN

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -53,9 +53,9 @@
 
 namespace
 {
-    const int USAGE_INDENTATION = 4;
-    const int USAGE_TEXT_COLUMN = 31;
-    const int WRAP_AT_COLUMN = 80;
+    constexpr int USAGE_INDENTATION = 4;
+    constexpr int USAGE_TEXT_COLUMN = 31;
+    constexpr int WRAP_AT_COLUMN = 80;
 
     // Base option class. Encapsulates name operations.
     class Option

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -46,7 +46,7 @@
 
 namespace
 {
-    const int MIGRATION_VERSION = 8;
+    constexpr int MIGRATION_VERSION = 8;
     const QString MIGRATION_VERSION_KEY = u"Meta/MigrationVersion"_s;
 
     void exportWebUIHttpsFiles()

--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -177,7 +177,7 @@ void BitTorrent::BencodeResumeDataStorage::doLoadAll() const
 
 void BitTorrent::BencodeResumeDataStorage::loadQueue(const Path &queueFilename)
 {
-    const int lineMaxLength = 48;
+    constexpr int lineMaxLength = 48;
 
     QFile queueFile {queueFilename.data()};
     if (!queueFile.exists())

--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -67,7 +67,7 @@ namespace
 {
     const QString DB_CONNECTION_NAME = u"ResumeDataStorage"_s;
 
-    const int DB_VERSION = 9;
+    constexpr int DB_VERSION = 9;
 
     const QString DB_TABLE_META = u"meta"_s;
     const QString DB_TABLE_TORRENTS = u"torrents"_s;

--- a/src/base/bittorrent/filterparserthread.cpp
+++ b/src/base/bittorrent/filterparserthread.cpp
@@ -105,8 +105,8 @@ namespace
         return !ec;
     }
 
-    const int BUFFER_SIZE = 2 * 1024 * 1024; // 2 MiB
-    const int MAX_LOGGED_ERRORS = 5;
+    constexpr int BUFFER_SIZE = 2 * 1024 * 1024; // 2 MiB
+    constexpr int MAX_LOGGED_ERRORS = 5;
 }
 
 FilterParserThread::FilterParserThread(QObject *parent)

--- a/src/base/bittorrent/ltqbitarray.cpp
+++ b/src/base/bittorrent/ltqbitarray.cpp
@@ -56,7 +56,7 @@ namespace BitTorrent::LT
 {
     QBitArray toQBitArray(const lt::bitfield &bits)
     {
-        const int STACK_ALLOC_SIZE = 10 * 1024;
+        constexpr int STACK_ALLOC_SIZE = 10 * 1024;
 
         const char *bitsData = bits.data();
         const int dataLength = (bits.size() + 7) / 8;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -119,8 +119,8 @@ using namespace BitTorrent;
 
 const Path CATEGORIES_FILE_NAME {u"categories.json"_s};
 const Path ADDITIONAL_TRACKERS_FROM_URL_FILE_NAME {u"additional_trackers_from_url.txt"_s};
-const int MAX_PROCESSING_RESUMEDATA_COUNT = 50;
-const std::chrono::seconds FREEDISKSPACE_CHECK_TIMEOUT = 30s;
+constexpr int MAX_PROCESSING_RESUMEDATA_COUNT = 50;
+constexpr std::chrono::seconds FREEDISKSPACE_CHECK_TIMEOUT = 30s;
 
 namespace
 {
@@ -5566,7 +5566,7 @@ void SessionImpl::loadCategories()
 //        return;
     }
 
-    const int fileMaxSize = 1024 * 1024;
+    constexpr int fileMaxSize = 1024 * 1024;
     const auto readResult = Utils::IO::readFile(path, fileMaxSize);
     if (!readResult)
     {
@@ -6633,7 +6633,7 @@ void SessionImpl::handleRemovedTorrent(const TorrentID &torrentID, const QString
 
 void SessionImpl::updateTrackersFromFile()
 {
-    const qint64 fileMaxSize = 1024 * 1024;
+    constexpr qint64 fileMaxSize = 1024 * 1024;
     const Path path = specialFolderLocation(SpecialFolder::Data) / Path(ADDITIONAL_TRACKERS_FROM_URL_FILE_NAME);
 
     const auto readResult = Utils::IO::readFile(path, fileMaxSize);

--- a/src/base/bittorrent/speedmonitor.h
+++ b/src/base/bittorrent/speedmonitor.h
@@ -77,7 +77,7 @@ public:
     void reset();
 
 private:
-    static const int MAX_SAMPLES = 30;
+    static constexpr int MAX_SAMPLES = 30;
     boost::circular_buffer<SpeedSample> m_speedSamples;
     SpeedSample m_sum;
 };

--- a/src/base/bittorrent/torrent.cpp
+++ b/src/base/bittorrent/torrent.cpp
@@ -44,7 +44,7 @@ namespace BitTorrent
 
     // Torrent
 
-    const qreal Torrent::MAX_RATIO = std::numeric_limits<qreal>::infinity();
+    constexpr qreal Torrent::MAX_RATIO = std::numeric_limits<qreal>::infinity();
 
     TorrentID Torrent::id() const
     {

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -46,12 +46,12 @@
 namespace
 {
     // static limits
-    const int MAX_TORRENTS = 10000;
-    const int MAX_PEERS_PER_TORRENT = 200;
-    const int ANNOUNCE_INTERVAL = 1800;  // 30min
+    constexpr int MAX_TORRENTS = 10000;
+    constexpr int MAX_PEERS_PER_TORRENT = 200;
+    constexpr int ANNOUNCE_INTERVAL = 1800;  // 30min
 
     // constants
-    const int PEER_ID_SIZE = 20;
+    constexpr int PEER_ID_SIZE = 20;
 
     const QString ANNOUNCE_REQUEST_PATH = u"/announce"_s;
 

--- a/src/base/http/requestparser.h
+++ b/src/base/http/requestparser.h
@@ -55,7 +55,7 @@ namespace Http
 
         static ParseResult parse(const QByteArray &data);
 
-        static const long MAX_CONTENT_SIZE = 64 * 1024 * 1024;  // 64 MB
+        static constexpr long MAX_CONTENT_SIZE = 64 * 1024 * 1024;  // 64 MB
 
     private:
         RequestParser() = default;

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -53,9 +53,9 @@ using namespace std::chrono_literals;
 
 namespace
 {
-    const int KEEP_ALIVE_DURATION = std::chrono::milliseconds(7s).count();
-    const int CONNECTIONS_LIMIT = 500;
-    const std::chrono::seconds CONNECTIONS_SCAN_INTERVAL {2};
+    constexpr int KEEP_ALIVE_DURATION = std::chrono::milliseconds(7s).count();
+    constexpr int CONNECTIONS_LIMIT = 500;
+    constexpr std::chrono::seconds CONNECTIONS_SCAN_INTERVAL {2};
 
     QList<QSslCipher> safeCipherList()
     {

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -40,7 +40,7 @@
 using namespace std::chrono_literals;
 using namespace Net;
 
-const std::chrono::seconds IP_CHECK_INTERVAL = 30min;
+constexpr std::chrono::seconds IP_CHECK_INTERVAL = 30min;
 
 DNSUpdater::DNSUpdater(QObject *parent)
     : QObject(parent)

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -46,7 +46,7 @@
 #include "base/utils/os.h"
 #endif // Q_OS_MACOS || Q_OS_WIN
 
-const int MAX_REDIRECTIONS = 20;  // the common value for web browsers
+constexpr int MAX_REDIRECTIONS = 20;  // the common value for web browsers
 
 Net::DownloadHandlerImpl::DownloadHandlerImpl(DownloadManager *manager
         , const DownloadRequest &downloadRequest, const bool useProxy)

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -65,8 +65,8 @@ namespace
         static QByteArray ret;
         if (ret.isEmpty())
         {
-            const std::chrono::time_point baseDate = std::chrono::sys_days(2024y / 04 / 16);
-            const int baseVersion = 125;
+            constexpr std::chrono::time_point baseDate = std::chrono::sys_days(2024y / 04 / 16);
+            constexpr int baseVersion = 125;
 
             const std::chrono::time_point nowDate = std::chrono::system_clock::now();
             const int nowVersion = baseVersion + std::chrono::duration_cast<std::chrono::months>(nowDate - baseDate).count();

--- a/src/base/net/geoipdatabase.cpp
+++ b/src/base/net/geoipdatabase.cpp
@@ -40,8 +40,8 @@
 
 namespace
 {
-    const qint32 MAX_FILE_SIZE = 67108864; // 64MB
-    const quint32 MAX_METADATA_SIZE = 131072; // 128KB
+    constexpr qint32 MAX_FILE_SIZE = 64 * 1024 * 1024; // 64MB
+    constexpr quint32 MAX_METADATA_SIZE = 128 * 1024; // 128KB
     const QByteArray METADATA_BEGIN_MARK = QByteArrayLiteral("\xab\xcd\xefMaxMind.com");
     const char DATA_SECTION_SEPARATOR[16] = {0};
 

--- a/src/base/net/reverseresolution.cpp
+++ b/src/base/net/reverseresolution.cpp
@@ -31,7 +31,7 @@
 #include <QHostInfo>
 #include <QString>
 
-const int CACHE_SIZE = 2048;
+constexpr int CACHE_SIZE = 2048;
 
 using namespace Net;
 

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -51,14 +51,14 @@
 
 namespace
 {
-    const short DEFAULT_PORT = 25;
+    constexpr short DEFAULT_PORT = 25;
 #ifndef QT_NO_OPENSSL
-    const short DEFAULT_PORT_SSL = 465;
+    constexpr short DEFAULT_PORT_SSL = 465;
 #endif
 
     QByteArray hmacMD5(QByteArray key, const QByteArray &msg)
     {
-        const int blockSize = 64; // HMAC-MD5 block size
+        constexpr int blockSize = 64; // HMAC-MD5 block size
         if (key.length() > blockSize)   // if key is longer than block size (64), reduce key length with MD5 compression
             key = QCryptographicHash::hash(key, QCryptographicHash::Md5);
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -757,9 +757,9 @@ void Preferences::setStoreOpenedSearchTabResults(const bool enabled)
 bool Preferences::isWebUIEnabled() const
 {
 #ifdef DISABLE_GUI
-    const bool defaultValue = true;
+    constexpr bool defaultValue = true;
 #else
-    const bool defaultValue = false;
+    constexpr bool defaultValue = false;
 #endif
     return value(u"Preferences/WebUI/Enabled"_s, defaultValue);
 }
@@ -2135,7 +2135,7 @@ void Preferences::setAddNewTorrentDialogTopLevel(const bool value)
 
 int Preferences::addNewTorrentDialogSavePathHistoryLength() const
 {
-    const int defaultHistoryLength = 8;
+    constexpr int defaultHistoryLength = 8;
 
     const int val = value(u"AddNewTorrentDialog/SavePathHistoryLength"_s, defaultHistoryLength);
     return std::clamp(val, 0, 99);

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -513,7 +513,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
 
 void AutoDownloader::load()
 {
-    const qint64 maxFileSize = 10 * 1024 * 1024;
+    constexpr qint64 maxFileSize = 10 * 1024 * 1024;
     const auto readResult = Utils::IO::readFile((m_fileStorage->storageDir() / Path(RULES_FILE_NAME)), maxFileSize);
     if (!readResult)
     {

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -271,7 +271,7 @@ Item *Session::itemByPath(const QString &path) const
 
 void Session::load()
 {
-    const int fileMaxSize = 10 * 1024 * 1024;
+    constexpr int fileMaxSize = 10 * 1024 * 1024;
     const Path path = m_confFileStorage->storageDir() / Path(FEEDS_FILE_NAME);
 
     const auto readResult = Utils::IO::readFile(path, fileMaxSize);

--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -60,7 +60,7 @@
 using namespace std::chrono_literals;
 
 const std::chrono::seconds WATCH_INTERVAL {10};
-const int MAX_FAILED_RETRIES = 5;
+constexpr int MAX_FAILED_RETRIES = 5;
 const QString CONF_FILE_NAME = u"watched_folders.json"_s;
 
 const QString OPTION_ADDTORRENTPARAMS = u"add_torrent_params"_s;
@@ -154,7 +154,7 @@ TorrentFilesWatcher::TorrentFilesWatcher(QObject *parent)
 
 void TorrentFilesWatcher::load()
 {
-    const int fileMaxSize = 10 * 1024 * 1024;
+    constexpr int fileMaxSize = 10 * 1024 * 1024;
     const Path path = specialFolderLocation(SpecialFolder::Config) / Path(CONF_FILE_NAME);
 
     const auto readResult = Utils::IO::readFile(path, fileMaxSize);

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -30,7 +30,7 @@
 
 #include <QtContainerFwd>
 
-const qlonglong MAX_ETA = 8640000;
+constexpr qlonglong MAX_ETA = 8640000;
 
 enum class ShutdownDialogAction
 {

--- a/src/base/utils/apikey.cpp
+++ b/src/base/utils/apikey.cpp
@@ -35,7 +35,7 @@
 
 namespace
 {
-    const int keyLength = 28;
+    constexpr int keyLength = 28;
     const QString prefix = u"qbt_"_s;
 }
 

--- a/src/base/utils/bytearray.cpp
+++ b/src/base/utils/bytearray.cpp
@@ -89,7 +89,7 @@ QByteArray Utils::ByteArray::asQByteArray(const QByteArrayView view)
 QByteArray Utils::ByteArray::toBase32(const QByteArray &in)
 {
     const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-    const char padchar = '=';
+    constexpr char padchar = '=';
 
     const qsizetype inSize = in.size();
 

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -177,7 +177,7 @@ bool Utils::Fs::sameFiles(const Path &path1, const Path &path2)
     if (!f1.open(QIODevice::ReadOnly) || !f2.open(QIODevice::ReadOnly))
         return false;
 
-    const int readSize = 1024 * 1024;  // 1 MiB
+    constexpr int readSize = 1024 * 1024;  // 1 MiB
     while (!f1.atEnd() && !f2.atEnd())
     {
         if (f1.read(readSize) != f2.read(readSize))

--- a/src/base/utils/gzip.cpp
+++ b/src/base/utils/gzip.cpp
@@ -86,7 +86,7 @@ QByteArray Utils::Gzip::decompress(const QByteArray &data, bool *ok)
     if (data.isEmpty())
         return {};
 
-    const int BUFSIZE = 1024 * 1024;
+    constexpr int BUFSIZE = 1024 * 1024;
     std::vector<char> tmpBuf(BUFSIZE);
 
     z_stream strm {};

--- a/src/base/utils/number.cpp
+++ b/src/base/utils/number.cpp
@@ -36,8 +36,8 @@ int Utils::Number::clampingAdd(const int num1, const int num2)
 {
     static_assert(sizeof(int64_t) > sizeof(int));
 
-    const int64_t intMin = std::numeric_limits<int>::min();
-    const int64_t intMax = std::numeric_limits<int>::max();
+    constexpr int64_t intMin = std::numeric_limits<int>::min();
+    constexpr int64_t intMax = std::numeric_limits<int>::max();
     const int64_t sumResult = static_cast<int64_t>(num1) + num2;
     const int64_t clampedValue = std::clamp(sumResult, intMin, intMax);
     return static_cast<int>(clampedValue);

--- a/src/base/utils/password.cpp
+++ b/src/base/utils/password.cpp
@@ -49,7 +49,7 @@ namespace Utils
     {
         namespace PBKDF2
         {
-            const int hashIterations = 100000;
+            constexpr int hashIterations = 100000;
             const auto hashMethod = EVP_sha512();
         }
     }

--- a/src/base/utils/randomlayer_linux.cpp
+++ b/src/base/utils/randomlayer_linux.cpp
@@ -88,7 +88,7 @@ namespace
     private:
         result_type getRandomViaAPI() const
         {
-            const int RETRY_MAX = 3;
+            constexpr int RETRY_MAX = 3;
 
             for (int i = 0; i < RETRY_MAX; ++i)
             {

--- a/src/gui/log/logmodel.cpp
+++ b/src/gui/log/logmodel.cpp
@@ -37,7 +37,7 @@
 #include "base/global.h"
 #include "gui/uithememanager.h"
 
-const int MAX_VISIBLE_MESSAGES = 20000;
+constexpr int MAX_VISIBLE_MESSAGES = 20000;
 
 BaseLogModel::Message::Message(const QString &time, const QString &message, const Log::MsgType type)
     : m_time {time}

--- a/src/gui/macosdockbadge/badgeview.mm
+++ b/src/gui/macosdockbadge/badgeview.mm
@@ -33,7 +33,7 @@
 
 #include "base/utils/misc.h"
 
-static const CGFloat kBetweenPadding = 2.0;
+static constexpr CGFloat kBetweenPadding = 2.0;
 static const NSColor *const kUploadBadgeColor = [NSColor colorWithRed:0.094 green:0.243 blue:0.835 alpha:0.9];    // #183ed5
 static const NSColor *const kDownloadBadgeColor = [NSColor colorWithRed:0.216 green:0.482 blue:0.173 alpha:0.9];  // #377b2c
 static const NSSize kBadgeSize = {128.0, 30.0};

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -93,8 +93,8 @@
 
 #define SETTINGS_KEY(name) u"OptionsDialog/" name
 
-const int WEBUI_MIN_USERNAME_LENGTH = 3;
-const int WEBUI_MIN_PASSWORD_LENGTH = 6;
+constexpr int WEBUI_MIN_USERNAME_LENGTH = 3;
+constexpr int WEBUI_MIN_PASSWORD_LENGTH = 6;
 
 namespace
 {

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -100,7 +100,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     connect(m_ui->filesList, &TorrentContentWidget::stateChanged, this, &PropertiesWidget::saveSettings);
 
     // set bar height relative to screen dpi
-    const int barHeight = 18;
+    constexpr int barHeight = 18;
 
     // Downloaded pieces progress bar
     m_ui->tempProgressBarArea->setVisible(false);

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -331,7 +331,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     painter.drawLine(fullRect.left(), rect.top() + 0.75 * rect.height(), rect.right(), rect.top() + 0.75 * rect.height());
     painter.drawLine(fullRect.left(), rect.bottom(), rect.right(), rect.bottom());
 
-    const int TIME_AXIS_DIVISIONS = 6;
+    constexpr int TIME_AXIS_DIVISIONS = 6;
     for (int i = 0; i < TIME_AXIS_DIVISIONS; ++i)
     {
         const int x = rect.left() + (i * rect.width()) / TIME_AXIS_DIVISIONS;

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -466,7 +466,7 @@ void AutomatedRssDownloader::onImportBtnClicked()
                     this, tr("Import RSS rules"), QDir::homePath()
                     , u"%1;;%2"_s.arg(m_formatFilterJSON, m_formatFilterLegacy), &selectedFilter)};
 
-    const int fileMaxSize = 10 * 1024 * 1024;
+    constexpr int fileMaxSize = 10 * 1024 * 1024;
     const auto readResult = Utils::IO::readFile(path, fileMaxSize);
     if (!readResult)
     {

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -73,9 +73,9 @@
 #include "searchjobwidget.h"
 #include "ui_searchwidget.h"
 
-const int HISTORY_FILE_MAX_SIZE = 10 * 1024 * 1024;
-const int SESSION_FILE_MAX_SIZE = 10 * 1024 * 1024;
-const int RESULTS_FILE_MAX_SIZE = 10 * 1024 * 1024;
+constexpr int HISTORY_FILE_MAX_SIZE = 10 * 1024 * 1024;
+constexpr int SESSION_FILE_MAX_SIZE = 10 * 1024 * 1024;
+constexpr int RESULTS_FILE_MAX_SIZE = 10 * 1024 * 1024;
 
 const QString DATA_FOLDER_NAME = u"SearchUI"_s;
 const QString HISTORY_FILE_NAME = u"History.txt"_s;

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -309,7 +309,7 @@ void TorrentContentWidget::applyPrioritiesByOrder()
 
     const QList<QPersistentModelIndex> selectedRows = toPersistentIndexes(selectionModel()->selectedRows(Priority));
 
-    const qsizetype priorityGroups = 3;
+    constexpr qsizetype priorityGroups = 3;
     const auto priorityGroupSize = std::max<qsizetype>((selectedRows.length() / priorityGroups), 1);
 
     for (qsizetype i = 0; i < selectedRows.length(); ++i)

--- a/src/gui/trackerlist/trackerlistmodel.cpp
+++ b/src/gui/trackerlist/trackerlistmodel.cpp
@@ -61,7 +61,7 @@ using namespace boost::multi_index;
 
 namespace
 {
-    const std::chrono::milliseconds ANNOUNCE_TIME_REFRESH_INTERVAL = 4s;
+    constexpr std::chrono::milliseconds ANNOUNCE_TIME_REFRESH_INTERVAL = 4s;
 
     const char STR_WORKING[] = QT_TRANSLATE_NOOP("TrackerListModel", "Working");
     const char STR_DISABLED[] = QT_TRANSLATE_NOOP("TrackerListModel", "Disabled");

--- a/src/gui/transferlistfilters/tagfiltermodel.cpp
+++ b/src/gui/transferlistfilters/tagfiltermodel.cpp
@@ -36,8 +36,8 @@
 #include "base/global.h"
 #include "gui/uithememanager.h"
 
-const int ROW_ALL = 0;
-const int ROW_UNTAGGED = 1;
+constexpr int ROW_ALL = 0;
+constexpr int ROW_UNTAGGED = 1;
 
 class TagModelItem
 {

--- a/src/gui/uithemesource.cpp
+++ b/src/gui/uithemesource.cpp
@@ -40,7 +40,7 @@
 
 namespace
 {
-    const qint64 FILE_MAX_SIZE = 1024 * 1024;
+    constexpr qint64 FILE_MAX_SIZE = 1024 * 1024;
 
     QJsonObject parseThemeConfig(const QByteArray &data)
     {

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -233,7 +233,7 @@ namespace
         }
 
         const int working = static_cast<int>(BitTorrent::TrackerEndpointState::Working);
-        const int disabled = 0;
+        constexpr int disabled = 0;
 
         const QString privateMsg {QCoreApplication::translate("TrackerListWidget", "This torrent is private")};
         const bool isTorrentPrivate = torrent->isPrivate();

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -72,7 +72,7 @@
 #include "clientdatastorage.h"
 #include "peerhostnameresolver.h"
 
-const int MAX_ALLOWED_FILESIZE = 10 * 1024 * 1024;
+constexpr int MAX_ALLOWED_FILESIZE = 10 * 1024 * 1024;
 const QString SESSION_COOKIE_NAME_PREFIX = u"QBT_SID_"_s;
 
 const QString WWW_FOLDER = u":/www"_s;


### PR DESCRIPTION
Replace `const` with `constexpr` where possible to express compile-time intent and enable stronger compiler guarantees and optimizations.
No runtime behavior changes.