### PR TITLE
Rename FYR Macedonia to North Macedonia

### DIFF
--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -293,7 +293,7 @@ QString GeoIPManager::CountryName(const QString &countryISOCode)
         {u"MF"_s, tr("Saint Martin (French part)")},
         {u"MG"_s, tr("Madagascar")},
         {u"MH"_s, tr("Marshall Islands")},
-        {u"MK"_s, tr("Macedonia, The Former Yugoslav Republic of")},
+        {u"MK"_s, tr("North Macedonia")},
         {u"ML"_s, tr("Mali")},
         {u"MM"_s, tr("Myanmar")},
         {u"MN"_s, tr("Mongolia")},


### PR DESCRIPTION
The "Former Yugoslav Republic of Macedonia" hasn't been called that since 2019, the name "North Macedonia" is now used. This commit changes `{u"MK"_s, tr("Macedonia, The Former Yugoslav Republic of")},` in src/base/net/geoipmanager.cpp to `{u"MK"_s, tr("North Macedonia")},`.