### PR TITLE
WebUI: migrate away from MooTools `empty()` method

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -742,7 +742,7 @@ window.qBittorrent.DynamicTable ??= (() => {
         }
 
         deselectAll() {
-            this.selectedRows.empty();
+            this.selectedRows.length = 0;
         }
 
         selectRow(rowId) {


### PR DESCRIPTION
The replacement code is the same with MooTools so it should work without issues.

References:
https://github.com/mootools/mootools-core/blob/187a16bae2d7144ea4b81aa5c0586498f0fe17c7/Source/Types/Array.js#L127-L130
https://stackoverflow.com/a/1232046
