### PR TITLE
WebUI: set appropriate `autocomplete` attribute on password fields

### DIFF
--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -376,7 +376,7 @@
                             <label for="mail_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
                         </td>
                         <td>
-                            <input type="password" id="mail_password_text">
+                            <input type="password" id="mail_password_text" autocomplete="new-password">
                         </td>
                     </tr>
                 </tbody>
@@ -566,7 +566,7 @@
                             <label for="peer_proxy_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
                         </td>
                         <td>
-                            <input type="password" id="peer_proxy_password_text">
+                            <input type="password" id="peer_proxy_password_text" autocomplete="new-password">
                         </td>
                     </tr>
                 </tbody>
@@ -1184,7 +1184,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         <label for="dyndns_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="password" id="dyndns_password_text">
+                        <input type="password" id="dyndns_password_text" autocomplete="new-password">
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#new-password :
>When creating a new account or changing passwords, this should be used for an "Enter your new
>password" or "Confirm new password" field, as opposed to a general "Enter your current
>password" field that might be present. This may be used by the browser both to avoid
>accidentally filling in an existing password and to offer assistance in creating a secure password.

Also see:
https://html-validate.org/rules/autocomplete-password.html
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-new-password
