### PR TITLE
GHA CI: Add dependency package `@eslint/js`

### DIFF
--- a/src/webui/www/eslint.config.mjs
+++ b/src/webui/www/eslint.config.mjs
@@ -39,7 +39,6 @@ export default [
             "no-implicit-coercion": "error",
             "no-undef": "off",
             "no-unused-vars": "off",
-            "no-useless-assignment": "off",
             "no-var": "error",
             "object-shorthand": ["error", "consistent"],
             "operator-assignment": "error",


### PR DESCRIPTION
Seems like the release of eslint v10 is breaking the WebUI build:

https://github.com/qbittorrent/qBittorrent/actions/runs/22073426394/job/63783233812?pr=23847

with the error `Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js' imported from /home/runner/work/qBittorrent/qBittorrent/src/webui/www/eslint.config.mjs`

So let's include `@eslint/js` in the `package.json` `devDependencies`