### PR TITLE
WebUI: address 'useless assignment' warnings

### DIFF
--- a/src/webui/www/private/shareratio.html
+++ b/src/webui/www/private/shareratio.html
@@ -84,16 +84,20 @@
                     return;
 
                 const shareLimit = getSelectedRadioValue("shareLimit");
-                let ratioLimitValue = 0;
-                let seedingTimeLimitValue = 0;
-                let inactiveSeedingTimeLimitValue = 0;
+                let ratioLimitValue = 0; // eslint-disable-line no-useless-assignment -- ESLint trips over `else return;` case but we want to keep the variable initialized
+                let seedingTimeLimitValue = 0; // eslint-disable-line no-useless-assignment
+                let inactiveSeedingTimeLimitValue = 0; // eslint-disable-line no-useless-assignment
                 let shareLimitActionValue = "Default";
 
                 if (shareLimit === "default") {
-                    ratioLimitValue = seedingTimeLimitValue = inactiveSeedingTimeLimitValue = UseGlobalLimit;
+                    ratioLimitValue = UseGlobalLimit;
+                    seedingTimeLimitValue = UseGlobalLimit;
+                    inactiveSeedingTimeLimitValue = UseGlobalLimit;
                 }
                 else if (shareLimit === "none") {
-                    ratioLimitValue = seedingTimeLimitValue = inactiveSeedingTimeLimitValue = NoLimit;
+                    ratioLimitValue = NoLimit;
+                    seedingTimeLimitValue = NoLimit;
+                    inactiveSeedingTimeLimitValue = NoLimit;
                 }
                 else if (shareLimit === "custom") {
                     ratioLimitValue = document.getElementById("setRatio").checked ? document.getElementById("ratio").value : -1;

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2579,7 +2579,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     let maxRatioAct = 0;
                     switch (Number(pref.max_ratio_act)) {
                         case 0: // Stop
-                        default:
                             maxRatioAct = 0;
                             break;
                         case 1: // Remove


### PR DESCRIPTION
This addresses the `no-useless-assignment` warnings from ESLint v10.

The warnings: https://github.com/qbittorrent/qBittorrent/actions/runs/22100988810/job/63870341227
Doc: https://eslint.org/docs/latest/rules/no-useless-assignment