### PR TITLE
WebUI: Fix stale row selection cleanup

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -871,7 +871,8 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         updateTable(fullUpdate = false) {
             const rows = this.getFilteredAndSortedRows();
-            window.qBittorrent.Misc.filterInPlace(this.selectedRows, (selectedRow => selectedRow in rows));
+            const rowIds = new Set(rows.map(row => row.rowId));
+            window.qBittorrent.Misc.filterInPlace(this.selectedRows, (selectedRow => rowIds.has(selectedRow)));
 
             if (this.useVirtualList) {
                 // rerender on table update


### PR DESCRIPTION
`selectedRow in rows` incorrectly checks array indices instead of row IDs, so selections could be incorrectly kept or pruned.

Follow up to #23837 and #23752.