### PR TITLE
WebUI: Fix header text displayed in table in Firefox

### DIFF
--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -391,9 +391,6 @@
                         </div>
                         <div id="addTorrentFilesTableDiv" class="dynamicTableDiv">
                             <table class="dynamicTable">
-                                <thead>
-                                    <tr class="dynamicTableHeader"></tr>
-                                </thead>
                                 <tbody></tbody>
                             </table>
                         </div>

--- a/src/webui/www/private/css/dynamicTable.css
+++ b/src/webui/www/private/css/dynamicTable.css
@@ -171,13 +171,6 @@ div:has(> div.dynamicTableFixedHeaderDiv):not(.invisible) {
     overflow: auto;
 }
 
-.dynamicTableDiv thead th {
-    height: 0 !important;
-    line-height: 0 !important;
-    padding-bottom: 0 !important;
-    padding-top: 0 !important;
-}
-
 /* Trackers table */
 #torrentTrackersTableDiv tr:not(.selected, :hover) {
     & .trackerDisabled {

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -834,10 +834,6 @@ td.statusBarSeparator {
     overflow: auto;
 }
 
-#searchResults .dynamicTable {
-    width: 100%;
-}
-
 #searchResults .numSearchResults {
     font-style: italic;
 }

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -464,9 +464,6 @@
             </div>
             <div id="bulkRenameFilesTableDiv" class="dynamicTableDiv">
                 <table class="dynamicTable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
                     <tbody></tbody>
                 </table>
             </div>

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -116,9 +116,6 @@
             </div>
             <div id="logMessageTableDiv" class="dynamicTableDiv">
                 <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
                     <tbody></tbody>
                 </table>
             </div>
@@ -133,9 +130,6 @@
             </div>
             <div id="logPeerTableDiv" class="dynamicTableDiv">
                 <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
                     <tbody></tbody>
                 </table>
             </div>

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -118,9 +118,6 @@
         </div>
         <div id="torrentTrackersTableDiv" class="dynamicTableDiv">
             <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
                 <tbody></tbody>
             </table>
         </div>
@@ -138,9 +135,6 @@
         </div>
         <div id="torrentPeersTableDiv" class="dynamicTableDiv">
             <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
                 <tbody></tbody>
             </table>
         </div>
@@ -158,9 +152,6 @@
         </div>
         <div id="torrentWebseedsTableDiv" class="dynamicTableDiv">
             <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
                 <tbody></tbody>
             </table>
         </div>
@@ -178,9 +169,6 @@
         </div>
         <div id="torrentFilesTableDiv" class="dynamicTableDiv">
             <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
                 <tbody></tbody>
             </table>
         </div>

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -161,9 +161,6 @@
             </div>
             <div id="rssFeedTableDiv" class="dynamicTableDiv">
                 <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
                     <tbody></tbody>
                 </table>
             </div>
@@ -178,9 +175,6 @@
             </div>
             <div id="rssArticleTableDiv" class="dynamicTableDiv">
                 <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
                     <tbody></tbody>
                 </table>
             </div>

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -149,9 +149,6 @@
                 </div>
                 <div id="rssDownloaderRuleTableDiv" class="dynamicTableDiv">
                     <table class="dynamicTable unselectable">
-                        <thead>
-                            <tr class="dynamicTableHeader"></tr>
-                        </thead>
                         <tbody></tbody>
                     </table>
                 </div>
@@ -297,9 +294,6 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 </div>
                 <div id="rssDownloaderFeedSelectionTableDiv" class="dynamicTableDiv">
                     <table class="dynamicTable unselectable">
-                        <thead>
-                            <tr class="dynamicTableHeader"></tr>
-                        </thead>
                         <tbody></tbody>
                     </table>
                 </div>
@@ -321,9 +315,6 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             </div>
             <div id="rssDownloaderArticlesTableDiv" class="dynamicTableDiv">
                 <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
                     <tbody></tbody>
                 </table>
             </div>

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -210,9 +210,6 @@
         </div>
         <div id="searchResultsTableDiv" class="dynamicTableDiv">
             <table class="dynamicTable unselectable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
                 <tbody></tbody>
             </table>
         </div>

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -19,10 +19,6 @@
         height: calc(100% - 135px);
     }
 
-    #searchPluginsTable .dynamicTable {
-        width: 100%;
-    }
-
     #searchPluginsTableDiv {
         height: calc(100% - 26px);
     }
@@ -50,9 +46,6 @@
         </div>
         <div id="searchPluginsTableDiv" class="dynamicTableDiv">
             <table class="dynamicTable unselectable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
                 <tbody></tbody>
             </table>
         </div>

--- a/src/webui/www/private/views/torrentcreator.html
+++ b/src/webui/www/private/views/torrentcreator.html
@@ -49,9 +49,6 @@
         </div>
         <div id="torrentCreationTasksTableDiv" class="dynamicTableDiv">
             <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
                 <tbody></tbody>
             </table>
         </div>

--- a/src/webui/www/private/views/transferlist.html
+++ b/src/webui/www/private/views/transferlist.html
@@ -8,9 +8,6 @@
 
 <div id="torrentsTableDiv" class="dynamicTableDiv">
     <table class="dynamicTable unselectable">
-        <thead>
-            <tr class="dynamicTableHeader"></tr>
-        </thead>
         <tbody></tbody>
     </table>
 </div>


### PR DESCRIPTION
When using virtual rows, header text was incorrectly rendered in the table. This only occurred when using Firefox. To fix this, we now use a colgroup to define column width instead of a hidden thead element. This results in correct behavior across all browsers.

Before:
![Screenshot 2026-02-19 at 19 06 55](https://github.com/user-attachments/assets/a06ab9fc-5e6d-40fc-a55c-2f961a4d0690)

After:
![Screenshot 2026-02-19 at 19 07 12](https://github.com/user-attachments/assets/42ec739b-0691-41ae-b594-79d40d560ab8)
