### PR TITLE
WebUI: Fix keyboard navigation when using virtual rendering

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -2513,8 +2513,11 @@ window.qBittorrent.DynamicTable ??= (() => {
                 return;
 
             const node = this.getNode(id);
-            if (node.isFolder)
+            if (node.isFolder) {
                 this.expandNode(node.rowId);
+                if (this.useVirtualList)
+                    this.rerender();
+            }
         }
 
         collapseFolder(id) {
@@ -2522,8 +2525,11 @@ window.qBittorrent.DynamicTable ??= (() => {
                 return;
 
             const node = this.getNode(id);
-            if (node.isFolder)
+            if (node.isFolder) {
                 this.collapseNode(node.rowId);
+                if (this.useVirtualList)
+                    this.rerender();
+            }
         }
 
         isAllCheckboxesChecked() {


### PR DESCRIPTION
This change ensures up/down and left/right navigation continue working as the table is updated. It also fixes an issue where expanding/collapsing a folder wouldn't update the table until the next render, which was usually the next fetch.