### PR TITLE
Remove validation check for old file path during rename

### DIFF
--- a/src/base/bittorrent/abstractfilestorage.cpp
+++ b/src/base/bittorrent/abstractfilestorage.cpp
@@ -38,8 +38,7 @@
 
 void BitTorrent::AbstractFileStorage::renameFile(const Path &oldPath, const Path &newPath)
 {
-    if (!oldPath.isValid())
-        throw RuntimeError(tr("The old path is invalid: '%1'.").arg(oldPath.toString()));
+
     if (!newPath.isValid())
         throw RuntimeError(tr("The new path is invalid: '%1'.").arg(newPath.toString()));
     if (newPath.isAbsolute())
@@ -64,8 +63,6 @@ void BitTorrent::AbstractFileStorage::renameFile(const Path &oldPath, const Path
 
 void BitTorrent::AbstractFileStorage::renameFolder(const Path &oldFolderPath, const Path &newFolderPath)
 {
-    if (!oldFolderPath.isValid())
-        throw RuntimeError(tr("The old path is invalid: '%1'.").arg(oldFolderPath.toString()));
     if (!newFolderPath.isValid())
         throw RuntimeError(tr("The new path is invalid: '%1'.").arg(newFolderPath.toString()));
     if (newFolderPath.isAbsolute())

--- a/src/base/bittorrent/abstractfilestorage.cpp
+++ b/src/base/bittorrent/abstractfilestorage.cpp
@@ -38,7 +38,6 @@
 
 void BitTorrent::AbstractFileStorage::renameFile(const Path &oldPath, const Path &newPath)
 {
-
     if (!newPath.isValid())
         throw RuntimeError(tr("The new path is invalid: '%1'.").arg(newPath.toString()));
     if (newPath.isAbsolute())


### PR DESCRIPTION
Closes #23834.

**What**: Remove validation check for old file path during rename.

**Why**: The previous validation prevented renaming files whose existing
paths contained disallowed characters (e.g., ":" on macOS).
This made it impossible to rename files specifically because
their current names were invalid.

Removing this check allows invalid filenames and folder names 
to be corrected.

**Tested on**: macOS, Windows 11.