### PR TITLE
Update MIME type for JavaScript

### DIFF
--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -74,7 +74,7 @@ namespace Http
     inline const QString CONTENT_TYPE_CSS = u"text/css"_s;
     inline const QString CONTENT_TYPE_TXT = u"text/plain; charset=UTF-8"_s;
     inline const QString CONTENT_TYPE_JPEG = u"image/jpeg"_s;
-    inline const QString CONTENT_TYPE_JS = u"application/javascript"_s;
+    inline const QString CONTENT_TYPE_JS = u"text/javascript"_s;
     inline const QString CONTENT_TYPE_JSON = u"application/json"_s;
     inline const QString CONTENT_TYPE_GIF = u"image/gif"_s;
     inline const QString CONTENT_TYPE_PNG = u"image/png"_s;


### PR DESCRIPTION
RFC 9239 (May 2022) has deprecated all other MIME names for JS and `text/javascript` is the standard.

https://www.rfc-editor.org/rfc/rfc9239.html#section-6.1.1