### PR TITLE
Add support for widely used image types in HTTP server

### DIFF
--- a/src/base/http/responsegenerator.cpp
+++ b/src/base/http/responsegenerator.cpp
@@ -93,7 +93,8 @@ void Http::compressContent(Response &response)
 
     // filter out known hard-to-compress types
     const QString contentType = response.headers[HEADER_CONTENT_TYPE];
-    if ((contentType == CONTENT_TYPE_GIF) || (contentType == CONTENT_TYPE_PNG))
+    if ((contentType == CONTENT_TYPE_GIF) || (contentType == CONTENT_TYPE_JPEG)
+        || (contentType == CONTENT_TYPE_PNG) || (contentType == CONTENT_TYPE_WEBP))
         return;
 
     // try compressing

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -73,10 +73,12 @@ namespace Http
     inline const QString CONTENT_TYPE_HTML = u"text/html"_s;
     inline const QString CONTENT_TYPE_CSS = u"text/css"_s;
     inline const QString CONTENT_TYPE_TXT = u"text/plain; charset=UTF-8"_s;
+    inline const QString CONTENT_TYPE_JPEG = u"image/jpeg"_s;
     inline const QString CONTENT_TYPE_JS = u"application/javascript"_s;
     inline const QString CONTENT_TYPE_JSON = u"application/json"_s;
     inline const QString CONTENT_TYPE_GIF = u"image/gif"_s;
     inline const QString CONTENT_TYPE_PNG = u"image/png"_s;
+    inline const QString CONTENT_TYPE_WEBP = u"image/webp"_s;
     inline const QString CONTENT_TYPE_FORM_ENCODED = u"application/x-www-form-urlencoded"_s;
     inline const QString CONTENT_TYPE_FORM_DATA = u"multipart/form-data"_s;
 


### PR DESCRIPTION
3rd-party WebUI might send JPEG/WebP images and the HTTP server should not try to compress them.