### PR TITLE
WebUI: skip editCategory API call when nothing changed

### DIFF
--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -188,7 +188,34 @@
                             });
                         break;
 
-                    case "edit":
+                    case "edit": {
+                        // avoid a pointless 409 from the server when nothing actually changed
+                        let origDlPathMode = "default";
+                        let origDlPath = "";
+                        switch (categoryData.downloadPath) {
+                            case false:
+                                origDlPathMode = "no";
+                                break;
+                            case null:
+                                origDlPathMode = "default";
+                                break;
+                            default:
+                                origDlPathMode = "yes";
+                                origDlPath = categoryData.downloadPath;
+                                break;
+                        }
+
+                        const curDlPath = (useDownloadPath.value === "yes")
+                            ? document.getElementById("downloadPath").value.trim()
+                            : "";
+
+                        if ((savePath === categoryData.savePath)
+                                && (useDownloadPath.value === origDlPathMode)
+                                && (curDlPath === origDlPath)) {
+                            window.parent.qBittorrent.Client.closeFrameWindow(window);
+                            return;
+                        }
+
                         fetch("api/v2/torrents/editCategory", {
                                 method: "POST",
                                 body: new URLSearchParams({
@@ -207,6 +234,7 @@
                                 window.parent.qBittorrent.Client.closeFrameWindow(window);
                             });
                         break;
+                    }
                 }
             });
 


### PR DESCRIPTION
## Problem

Fixes #23845

When editing a category in the WebUI and clicking Save without making any changes, the dialog always sent a POST to `/api/v2/torrents/editCategory`. The server returns `409 Conflict` when the submitted data is identical to the existing category, which causes an error alert to be shown to the user — even though the user did nothing wrong.

The native Qt GUI handles this correctly by doing nothing when no changes are made.

## Fix

Before making the API call in the `edit` action, compare the current field values (save path, download path option, download path) against the original values loaded from `categoryData`. If nothing has changed, simply close the dialog without contacting the server.

Also renames the **OK** button to **Save** for clarity.

## Changes

- `src/webui/www/private/newcategory.html`: add no-op detection in the `edit` case; rename OK button to Save