### PR TITLE
Remove leftover keys after migrating settings

### DIFF
--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -326,7 +326,7 @@ namespace
             {
                 const auto value = settingsStorage->loadValue<QVariant>(mapping.oldKey);
                 settingsStorage->storeValue(mapping.newKey, value);
-                // TODO: Remove oldKey after ~v4.4.3 and bump migration version
+                settingsStorage->removeValue(mapping.oldKey);
             }
         }
     }


### PR DESCRIPTION
Closes #23787.

The v4.4 migration (`version < 2`) copied old setting keys to their new locations but never deleted the originals. The TODO comment said to clean this up after v4.4.3 — we're well past that.

Changes:
- Delete each old key immediately after copying its value in `migrateSettingKeys()`
- Add a `version < 9` migration step (`cleanupLegacySettingKeys()`) to remove the stale keys for users who already ran the v2 migration
- Bump `MIGRATION_VERSION` to 9