### PR TITLE
Fix priority text overlap when editor is active  

### DIFF
--- a/src/gui/torrentcontentitemdelegate.cpp
+++ b/src/gui/torrentcontentitemdelegate.cpp
@@ -74,8 +74,8 @@ QWidget *TorrentContentItemDelegate::createEditor(QWidget *parent, const QStyleO
         return nullptr;
 
     auto *editor = new QComboBox(parent);
-    editor->setFocusPolicy(Qt::StrongFocus);
     editor->setAutoFillBackground(true);
+    editor->setFocusPolicy(Qt::StrongFocus);
     editor->addItem(tr("Do not download", "Do not download (priority)"));
     editor->addItem(tr("Normal", "Normal (priority)"));
     editor->addItem(tr("High", "High (priority)"));


### PR DESCRIPTION
On macOS, clicking the priority combobox in the Content tab causes duplicated text. The delegate paints the display text underneath the QComboBox widget, which doesn't fully occlude it with the native Cocoa style.

Track the currently edited index via createEditor/destroyEditor and skip painting the priority cell while its editor is open.

Before
<img width="342" height="256" alt="Old" src="https://github.com/user-attachments/assets/d77ea6a0-d275-408b-99f2-b4fc54c36d34" />

After
<img width="343" height="250" alt="New" src="https://github.com/user-attachments/assets/838ebb6c-5943-48af-b568-2e040318f791" />

