### PR TITLE
Change torrent filtering logic in GUI

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1356,9 +1356,15 @@ void TransferListWidget::applyAnnounceStatusFilter(const std::optional<BitTorren
 void TransferListWidget::applyFilter(const QString &name, const TransferListModel::Column &type)
 {
     m_sortFilterModel->setFilterKeyColumn(type);
-    const QString pattern = (Preferences::instance()->getRegexAsFilteringPatternForTransferList()
-                ? name : Utils::String::wildcardToRegexPattern(name));
-    m_sortFilterModel->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));
+    if (Preferences::instance()->getRegexAsFilteringPatternForTransferList())
+    {
+        m_sortFilterModel->setFilterRegularExpression(QRegularExpression(name, QRegularExpression::CaseInsensitiveOption));
+    }
+    else
+    {
+        m_sortFilterModel->setFilterFixedString(name);
+        m_sortFilterModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
+    }
 }
 
 void TransferListWidget::applyStatusFilter(const int filterIndex)


### PR DESCRIPTION
* Makes plain text filter actually work as plain text.
* Drops wildcard handling.

That overall makes GUI and WebUI torrent filters work the same way.

Fixes #23897.
