### PR TITLE
Fix wrong SIZE after force recheck with excluded files

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2085,6 +2085,11 @@ void TorrentImpl::handleTorrentChecked()
     {
         qDebug("\"%s\" have just finished checking.", qUtf8Printable(name()));
 
+        // Re-apply file priorities so that libtorrent recalculates
+        // total_wanted / total_wanted_done correctly (workaround for
+        // libtorrent not resetting these after force_recheck()).
+        prioritizeFiles(m_filePriorities);
+
         if (!m_hasMissingFiles)
         {
             if ((progress() < 1.0) && (wantedSize() > 0))


### PR DESCRIPTION
Closes #23151.

### Problem
When files are set to "don't download" and physically deleted, a force recheck leaves `total_wanted` stale. The SIZE column then displays an incorrect value.

### Fix
Re-apply file priorities via `prioritize_files()` after a torrent check completes (in `handleTorrentChecked()`), so that libtorrent recalculates `total_wanted` / `total_wanted_done` correctly.

This is a lightweight workaround — the priorities themselves don't change, but calling `prioritize_files()` forces libtorrent to recompute the wanted totals.