### PR TITLE
Replace invisible toolbar spacers with visible separators on macOS

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -293,11 +293,13 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
         if (action->isSeparator())
         {
             auto *line = new QWidget(this);
-            line->setFixedWidth(1);
             line->setAutoFillBackground(true);
+            line->setFixedWidth(1);
+
             QPalette pal = line->palette();
             pal.setColor(QPalette::Window, palette().color(QPalette::Mid));
             line->setPalette(pal);
+
             QAction *widgetAction = m_ui->toolBar->insertWidget(action, line);
             m_ui->toolBar->removeAction(action);
             if (action == m_queueSeparator)


### PR DESCRIPTION
On macOS, toolbar separators are replaced with transparent spacer widgets. This results in inconsistent spacing between icons with no visible group separation.

Replace them with thin 2x16px widgets colored using `palette(mid)` so icon groups are visually distinct. Adapts to both light and dark themes.

Also fixes `m_queueSeparator` not being hidden on macOS when torrent queueing is disabled. The old code replaced the separator action in the toolbar loop but never updated the member pointer, so `#ifndef Q_OS_MACOS` guards were added to skip the broken `setVisible()` calls. Now the pointer is updated to reference the replacement widget action, so the guards are no longer needed.


Before
<img width="361" height="45" alt="old toolbar" src="https://github.com/user-attachments/assets/0e15b204-815a-4c5f-be98-3a816df0b80f" />


After
<img width="342" height="48" alt="new toolbar" src="https://github.com/user-attachments/assets/d8bdcf04-ffe8-4573-a9cd-1abee18b36cb" />

