### PR TITLE
Fix About dialog text cutoff on macOS

### DIFF
--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -111,6 +111,8 @@ AboutDialog::AboutDialog(QWidget *parent)
 
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
         resize(dialogSize);
+    else
+        adjustSize();
 }
 
 AboutDialog::~AboutDialog()


### PR DESCRIPTION
The About dialog (`Help > About`) clips text at its default size on macOS. The `.ui` file hardcodes a 545×295 geometry, which is too small for macOS font metrics — the DB-IP paragraph and library versions get cut off, requiring manual resize.

`setupUi()` applies the hardcoded size. The dialog has size persistence (`m_storeDialogSize`), but on first launch there's no saved size, so the undersized default is used.

Fix: fall back to `adjustSize()` when no persisted size exists. This lets Qt compute the dimensions from layout contents via `sizeHint()`, adapting to any font metrics or DPI.

Before
<img width="536" height="395" alt="Screenshot 2026-03-06 at 00 18 15" src="https://github.com/user-attachments/assets/b4993d1c-9a1b-47f8-8b29-55cb1c00dbfa" />


After
<img width="535" height="413" alt="Screenshot 2026-03-06 at 00 31 36" src="https://github.com/user-attachments/assets/e81a6240-349d-4d8b-a47e-6e8d657b427b" />

