### PR TITLE
Fix macOS delete shortcuts to match platform conventions

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -218,7 +218,7 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
     connect(editHotkey, &QShortcut::activated, this, &TransferListWidget::renameSelectedTorrent);
     const auto *deleteHotkey = new QShortcut(Utils::KeySequence::deleteItem(), this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(deleteHotkey, &QShortcut::activated, this, &TransferListWidget::softDeleteSelectedTorrents);
-    const auto *permDeleteHotkey = new QShortcut((Qt::SHIFT | Qt::Key_Delete), this, nullptr, nullptr, Qt::WidgetShortcut);
+    const auto *permDeleteHotkey = new QShortcut(Utils::KeySequence::permanentlyDeleteItem(), this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(permDeleteHotkey, &QShortcut::activated, this, &TransferListWidget::permDeleteSelectedTorrents);
     const auto *doubleClickHotkeyReturn = new QShortcut(Qt::Key_Return, this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(doubleClickHotkeyReturn, &QShortcut::activated, this, &TransferListWidget::torrentDoubleClicked);

--- a/src/gui/utils/keysequence.cpp
+++ b/src/gui/utils/keysequence.cpp
@@ -34,8 +34,17 @@
 QKeySequence Utils::KeySequence::deleteItem()
 {
 #ifdef Q_OS_MACOS
-    return Qt::CTRL | Qt::Key_Backspace;
+    return Qt::Key_Backspace;
 #else
     return QKeySequence::Delete;
+#endif
+}
+
+QKeySequence Utils::KeySequence::permanentlyDeleteItem()
+{
+#ifdef Q_OS_MACOS
+    return Qt::CTRL | Qt::Key_Backspace;
+#else
+    return Qt::SHIFT | Qt::Key_Delete;
 #endif
 }

--- a/src/gui/utils/keysequence.h
+++ b/src/gui/utils/keysequence.h
@@ -35,4 +35,5 @@ namespace Utils::KeySequence
     // QKeySequence variable cannot be initialized at compile time. It will crash at startup.
 
     QKeySequence deleteItem();
+    QKeySequence permanentlyDeleteItem();
 }


### PR DESCRIPTION
On macOS, the torrent delete shortcuts didn't match platform conventions. Delete did nothing (required Cmd+Delete for soft delete), and permanent delete required Shift+Fn+Delete which is undiscoverable on MacBook keyboards and super unintuitive.

This remaps macOS shortcuts to match Finder behavior:

Before (macOS):
Soft delete: Cmd+Delete
Perm delete: Shift+Fn+Delete

After (macOS):
Soft delete: Delete
Perm delete: Cmd+Delete

Win/Linux shortcuts are unchanged.

deleteItem() now returns plain Key_Backspace on macOS instead of CTRL | Key_Backspace. A new permanentlyDeleteItem() centralizes the perm delete shortcut (Cmd+Delete on macOS, Shift+Delete elsewhere), and TransferListWidget uses it instead of a hardcoded Shift+Delete.

All other widgets using deleteItem() (RSS, tracker list, peer list, web seeds) also benefit since plain Delete is standard macOS list-view behavior.