### PR TITLE
Fix LineEdit dark corner artifacts on macOS

### DIFF
--- a/src/gui/lineedit.cpp
+++ b/src/gui/lineedit.cpp
@@ -33,6 +33,7 @@
 
 #include <QAction>
 #include <QKeyEvent>
+#include <QPalette>
 #include <QTimer>
 
 #include "base/global.h"
@@ -54,6 +55,12 @@ LineEdit::LineEdit(QWidget *parent)
 
     setClearButtonEnabled(true);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+
+#ifdef Q_OS_MACOS
+    QPalette pal = palette();
+    pal.setBrush(QPalette::Base, Qt::transparent);
+    setPalette(pal);
+#endif
 
     m_delayedTextChangedTimer->setSingleShot(true);
     connect(m_delayedTextChangedTimer, &QTimer::timeout, this, [this]


### PR DESCRIPTION
On macOS dark mode, the rounded search field (LineEdit) shows dark rectangular background bleeding through at all four corners. This is visible on the toolbar filter and any other LineEdit instance.

The cause: setUnifiedTitleAndToolBarOnMac(true) gives the toolbar a translucent vibrancy background. Qt's QCommonStyle::drawPrimitive(PE_PanelLineEdit) fills the full rectangular widget area with the opaque QPalette::Base color before QMacStyle draws the rounded NSTextField frame on top. The gap between the rectangular fill and the rounded frame creates the dark corner artifacts.

The fix sets QPalette::Base to Qt::transparent on LineEdit so the rectangular fill becomes invisible. Only the NSTextField's own rounded background renders, and the toolbar's vibrancy shows through cleanly at the corners.

Applied at the LineEdit class level so all 5 instances (main toolbar, search results, properties, add torrent dialog, RSS) are covered. No header changes needed.

Before:
<img width="213" height="35" alt="before search" src="https://github.com/user-attachments/assets/1ed9c49f-e104-49bf-b755-a54370fd144f" />


After:
<img width="219" height="42" alt="after search" src="https://github.com/user-attachments/assets/c7154ce3-ee0c-4b7b-bce0-e8408813b55d" />
