### PR TITLE
Search: clean up documentation format

### DIFF
--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -1,4 +1,4 @@
-# VERSION: 1.55
+# VERSION: 1.56
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)
@@ -46,7 +46,9 @@ import socks
 
 
 def _getBrowserUserAgent() -> str:
-    """ Disguise as browser to circumvent website blocking """
+    """
+    Disguise as browser to circumvent website blocking
+    """
 
     # Firefox release calendar
     # https://whattrainisitnow.com/calendar/
@@ -95,7 +97,9 @@ htmlentitydecode = html.unescape
 
 
 def retrieve_url(url: str, custom_headers: Mapping[str, str] = {}, request_data: Optional[Any] = None, ssl_context: Optional[ssl.SSLContext] = None, unescape_html_entities: bool = True) -> str:
-    """ Return the content of the url page as a string """
+    """
+    Return the content of the url page as a string
+    """
 
     request = urllib.request.Request(url, request_data, {**_headers, **custom_headers})
     try:
@@ -126,7 +130,9 @@ def retrieve_url(url: str, custom_headers: Mapping[str, str] = {}, request_data:
 
 
 def download_file(url: str, referer: Optional[str] = None, ssl_context: Optional[ssl.SSLContext] = None) -> str:
-    """ Download file at url and write it to a file, return the path to the file and the url """
+    """
+    Download file at url and write it to a file, return both the path to the file and the url
+    """
 
     # Download url
     request = urllib.request.Request(url, headers=_headers)

--- a/src/searchengine/nova3/justfile
+++ b/src/searchengine/nova3/justfile
@@ -4,17 +4,17 @@ PY_FILES := `find . -maxdepth 1 -type f -name '*.py' ! -name 'socks.py' -printf 
 default:
     just --list
 
-# Run type check
-check files=PY_FILES: fetch_aux
-    mypy \
-        {{ files }}
-    pyright \
-        {{ files }}
-
 # Byte-compile files
 build files=PY_FILES:
     python \
         -m compileall \
+        {{ files }}
+
+# Run checks on typings
+check files=PY_FILES: fetch_aux
+    mypy \
+        {{ files }}
+    pyright \
         {{ files }}
 
 # Fetch auxiliary files
@@ -45,6 +45,8 @@ lint files=PY_FILES:
         {{ files }}
     bandit \
         --skip B110,B310,B314,B405 \
+        {{ files }}
+    pydoclint \
         {{ files }}
 
 # Run tests

--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -1,4 +1,4 @@
-# VERSION: 1.51
+# VERSION: 1.52
 
 # Author:
 #  Fabien Devaux <fab AT gnux DOT info>
@@ -6,8 +6,6 @@
 #  Christophe Dumez <chris@qbittorrent.org> (qbittorrent integration)
 #  Thanks to gab #gcu @ irc.freenode.net (multipage support on PirateBay)
 #  Thanks to Elias <gekko04@users.sourceforge.net> (torrentreactor and isohunt search engines)
-#
-# Licence: BSD
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -65,34 +63,44 @@ except NotImplementedError:
 
 Category = Enum('Category', ['all', 'anime', 'books', 'games', 'movies', 'music', 'pictures', 'software', 'tv'])
 
-
-################################################################################
-# Every engine should have a "search" method taking
-# a space-free string as parameter (ex. "family+guy")
-# it should call prettyPrinter() with a dict as parameter.
-# The keys in the dict must be: link,name,size,seeds,leech,engine_url
-# As a convention, try to list results by decreasing number of seeds or similar
-################################################################################
-
-
 EngineModuleName = str  # the filename of the engine plugin
 
 
 class Engine(ABC):
+    """
+    The base class for a search engine
+
+    An engine must implement a ``search()`` method taking a **space-free** string
+    as argument (for example ``family+guy``)
+
+    If the site requires special handling for downloading .torrent files, then a
+    customized ``download_torrent()`` method must be implemented. For example:
+    .. code-block:: python
+
+        def download_torrent(self, url: str) -> None:
+            print(helpers.download_file(url))
+
+    """
+
     name: str
     url: str
     supported_categories: dict[str, str]
 
     @abstractmethod
     def search(self, query: str, category: str = Category.all.name) -> None:
+        """
+        Run the search query
+
+        Usually it would call ``novaprinter.prettyPrinter()`` with a ``dict`` as an argument
+        (or actually ``novaprinter.SearchResults``).
+        Refer to ``novaprinter.SearchResults`` for the keys.
+
+        When printing the search results, it is recommended to list the results by decreasing
+        number of seeds, or some other criteria that is sensible to the end user.
+        """
+
         #novaprinter.prettyPrinter()
         raise NotImplementedError
-
-    """
-    Provide customized .torrent file download implementation. For example in your own subclass:
-    def download_torrent(self, url: str) -> None:
-        print(helpers.download_file(url))
-    """
 
 
 # global state
@@ -100,10 +108,12 @@ engine_dict: dict[EngineModuleName, Optional[type[Engine]]] = {}
 
 
 def list_engines() -> list[EngineModuleName]:
-    """ List all engines,
-        including broken engines that would fail on import
+    """
+    List all engines
 
-        Return list of all engines' module name
+    Including broken engines that might fail on import.
+
+    :return: A list of all engines' module name
     """
 
     names: list[EngineModuleName] = []
@@ -137,13 +147,18 @@ def import_engine(engine_module_name: EngineModuleName) -> Optional[type[Engine]
 def get_capabilities(engines: Iterable[EngineModuleName]) -> str:
     """
     Return capabilities in XML format
-    <capabilities>
-      <engine_module_name>
-        <name>long name</name>
-        <url>http://example.com</url>
-        <categories>movies music games</categories>
-      </engine_module_name>
-    </capabilities>
+
+    For example:
+    .. code-block:: xml
+
+        <capabilities>
+          <engine_module_name>
+            <name>long name</name>
+            <url>http://example.com</url>
+            <categories>movies music games</categories>
+          </engine_module_name>
+        </capabilities>
+
     """
 
     capabilities_element = ET.Element('capabilities')
@@ -170,12 +185,11 @@ def get_capabilities(engines: Iterable[EngineModuleName]) -> str:
 
 
 def run_search(search_params: tuple[type[Engine], str, Category]) -> bool:
-    """ Run search in engine
+    """
+    Run search in engine
 
-        @param search_params Tuple with engine, query and category
-
-        @retval False if any exceptions occurred
-        @retval True  otherwise
+    :param search_params: A tuple with engine, query and category.
+    :return: ``False`` if any exceptions occurred. ``True`` otherwise.
     """
 
     engine_class, what, cat = search_params

--- a/src/searchengine/nova3/pyproject.toml
+++ b/src/searchengine/nova3/pyproject.toml
@@ -11,6 +11,7 @@ dev = [
     "isort",
     "mypy",
     "pycodestyle",
+    "pydoclint",
     "pyflakes",
     "pyright",
     "pytest",
@@ -20,6 +21,11 @@ dev = [
 [tool.mypy]
 explicit_package_bases = true
 strict = true
+
+[tool.pydoclint]
+style = "sphinx"
+arg-type-hints-in-docstring = false
+check-return-types = false
 
 [tool.pyright]
 typeCheckingMode = "strict"


### PR DESCRIPTION
Now it is using reStructuredText (reST) style for documenting the code.
Hopefully this will provide better coding experience for plugin writers using code editors.

Also hookup with CI to check the documentation format.

References:
https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
https://devguide.python.org/documentation/markup/
