### PR TITLE
GHA CI: enable dependabot updates for pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,20 @@ updates:
     commit-message:
       prefix: "GHA CI"
     groups:
-      github-actions:
+      GHA_CI-dependency-update:
+        patterns:
+          - "*"
+    labels:
+      - "CI"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    commit-message:
+      prefix: "GHA CI"
+    groups:
+      GHA_CI-dependency-update:
         patterns:
           - "*"
     labels:


### PR DESCRIPTION
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-
