### PR TITLE
Fix Comment area background mismatch in Add New Torrent dialog

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -304,7 +304,8 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
 {
     m_ui->setupUi(this);
 
-    m_ui->scrollArea->setStyleSheet(u"background: transparent;"_s);
+    m_ui->scrollArea->viewport()->setAutoFillBackground(false);
+    m_ui->scrollAreaWidgetContents->setAutoFillBackground(false);
 
     m_ui->savePath->setMode(FileSystemPathEdit::Mode::DirectorySave);
     m_ui->savePath->setDialogCaption(tr("Choose save path"));


### PR DESCRIPTION
In dark mode (especially on macOS), the Comment row in the Add New Torrent dialog has a visibly different background from the rest of the Torrent Information group box. The QScrollArea viewport defaults to QPalette::Base (darker), while the surrounding group box uses QPalette::Window (lighter grey), creating a two-toned appearance.

This sets the scroll area's background to transparent so the group box background shows through uniformly, fixing the visual mismatch.

setStyleSheet is used throughout the GUI codebase for similar local overrides (statusbar borders, text alignment, color previews), so this is consistent with existing patterns.


Before:
<img width="750" height="212" alt="Screenshot 2026-03-08 at 01 45 56" src="https://github.com/user-attachments/assets/4c764a79-22da-46f4-bc8e-31d36d6fc09f" />

After:
<img width="760" height="197" alt="Screenshot 2026-03-08 at 02 06 31" src="https://github.com/user-attachments/assets/65bc86be-bfdb-4f58-a678-b8d4c5ebac5b" />
