### PR TITLE
Make RSS settings warning clickable

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -742,6 +742,11 @@ void MainWindow::displayRSSTab(bool enable)
         {
             m_rssWidget = new RSSWidget(app(), m_tabs);
             connect(m_rssWidget.data(), &RSSWidget::unreadCountUpdated, this, &MainWindow::handleRSSUnreadCountUpdated);
+            connect(m_rssWidget.data(), &RSSWidget::openRSSSettingsLinkActivated, this, [this]
+            {
+                on_actionOptions_triggered();
+                m_options->showRSSTab();
+            });
 #ifdef Q_OS_MACOS
             m_tabs->addTab(m_rssWidget, tr("RSS (%1)").arg(RSS::Session::instance()->rootFolder()->unreadCount()));
 #else

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -2233,6 +2233,11 @@ void OptionsDialog::showConnectionTab()
     m_ui->tabSelection->setCurrentRow(TAB_CONNECTION);
 }
 
+void OptionsDialog::showRSSTab()
+{
+    m_ui->tabSelection->setCurrentRow(TAB_RSS);
+}
+
 #ifndef DISABLE_WEBUI
 void OptionsDialog::on_registerDNSBtn_clicked()
 {

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -81,6 +81,7 @@ public:
 
 public slots:
     void showConnectionTab();
+    void showRSSTab();
 
 private slots:
     void adjustProxyOptions();

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -181,6 +181,8 @@ RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     connect(m_ui->splitterMain, &QSplitter::splitterMoved, this, &RSSWidget::saveSlidersPosition);
     connect(m_ui->splitterSide, &QSplitter::splitterMoved, this, &RSSWidget::saveSlidersPosition);
 
+    connect(m_ui->labelWarn, &QLabel::linkActivated, this, &RSSWidget::openRSSSettingsLinkActivated);
+
     if (RSS::Session::instance()->isProcessingEnabled())
         m_ui->labelWarn->hide();
     connect(RSS::Session::instance(), &RSS::Session::processingStateChanged

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -62,6 +62,7 @@ public slots:
     void updateRefreshInterval(int val) const;
 
 signals:
+    void openRSSSettingsLinkActivated();
     void unreadCountUpdated(int count);
 
 private slots:

--- a/src/gui/rss/rsswidget.ui
+++ b/src/gui/rss/rsswidget.ui
@@ -24,14 +24,17 @@
        <italic>true</italic>
       </font>
      </property>
-     <property name="styleSheet">
-      <string notr="true">color: red;</string>
+     <property name="toolTip">
+      <string>Open RSS settings</string>
      </property>
      <property name="text">
-      <string>Fetching of RSS feeds is disabled now! You can enable it in application settings.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;#&quot;&gt;&lt;span style=&quot; text-decoration: none; color:#ff0000;&quot;&gt;Fetching of RSS feeds is disabled now! You can enable it in application settings.&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Turns the existing RSS-disabled warning into a link to the RSS settings page.

The link markup, tooltip and interaction settings live in rsswidget.ui. C++ only connects the link activation to the existing Options dialog flow.

Current GUI build and all 19 Qt tests pass locally.