### PR TITLE
Replace setStyleSheet with QPalette for error text

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -34,6 +34,7 @@
 #include <QFileDialog>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPalette>
 #include <QRegularExpression>
 #include <QShortcut>
 #include <QSignalBlocker>
@@ -741,13 +742,16 @@ void AutomatedRssDownloader::updateMustLineValidity()
 
     if (valid)
     {
-        m_ui->lineContains->setStyleSheet({});
+        m_ui->lineContains->setPalette({});
+        m_ui->lineContains->setAttribute(Qt::WA_SetPalette, false);
         m_ui->labelMustStat->setPixmap(QPixmap());
         m_ui->labelMustStat->setToolTip({});
     }
     else
     {
-        m_ui->lineContains->setStyleSheet(u"QLineEdit { color: #ff0000; }"_s);
+        QPalette errorPalette = m_ui->lineContains->palette();
+        errorPalette.setColor(QPalette::Text, Qt::red);
+        m_ui->lineContains->setPalette(errorPalette);
         m_ui->labelMustStat->setPixmap(UIThemeManager::instance()->getIcon(u"dialog-warning"_s, u"task-attention"_s).pixmap(16, 16));
         m_ui->labelMustStat->setToolTip(error);
     }
@@ -788,13 +792,16 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
 
     if (valid)
     {
-        m_ui->lineNotContains->setStyleSheet({});
+        m_ui->lineNotContains->setPalette({});
+        m_ui->lineNotContains->setAttribute(Qt::WA_SetPalette, false);
         m_ui->labelMustNotStat->setPixmap(QPixmap());
         m_ui->labelMustNotStat->setToolTip({});
     }
     else
     {
-        m_ui->lineNotContains->setStyleSheet(u"QLineEdit { color: #ff0000; }"_s);
+        QPalette errorPalette = m_ui->lineNotContains->palette();
+        errorPalette.setColor(QPalette::Text, Qt::red);
+        m_ui->lineNotContains->setPalette(errorPalette);
         m_ui->labelMustNotStat->setPixmap(UIThemeManager::instance()->getIcon(u"dialog-warning"_s, u"task-attention"_s).pixmap(16, 16));
         m_ui->labelMustNotStat->setToolTip(error);
     }
@@ -807,12 +814,15 @@ void AutomatedRssDownloader::updateEpisodeFilterValidity()
 
     if (valid)
     {
-        m_ui->lineEFilter->setStyleSheet({});
+        m_ui->lineEFilter->setPalette({});
+        m_ui->lineEFilter->setAttribute(Qt::WA_SetPalette, false);
         m_ui->labelEpFilterStat->setPixmap({});
     }
     else
     {
-        m_ui->lineEFilter->setStyleSheet(u"QLineEdit { color: #ff0000; }"_s);
+        QPalette errorPalette = m_ui->lineEFilter->palette();
+        errorPalette.setColor(QPalette::Text, Qt::red);
+        m_ui->lineEFilter->setPalette(errorPalette);
         m_ui->labelEpFilterStat->setPixmap(UIThemeManager::instance()->getIcon(u"dialog-warning"_s, u"task-attention"_s).pixmap(16, 16));
     }
 }


### PR DESCRIPTION
Glasses said we are trying to refactor the codebase to a cleaner separation of concerns type files so I quickly made these changes and tested them. No functional changes are there, only improved code hygiene. The RSS auto-downloader dialog uses setStyleSheet to turn QLineEdit text red when the user enters an invalid regex or episode filter pattern. This overrides palette-based theming and breaks runtime light/dark mode switching.

This replaces the QSS color override with QPalette manipulation. When a field contains invalid input, QPalette::Text is set to Qt::red. When input becomes valid again, the widget-level palette is cleared using setPalette({}) followed by setAttribute(WA_SetPalette, false) so the widget properly re-inherits its palette from the parent, rather than retaining a stale resolved text color.

Affected fields: "Must Contain", "Must Not Contain", and "Episode Filter" in the RSS auto-downloading rules dialog.
