### PR TITLE
Draw UI theme color swatches without stylesheets

### DIFF
--- a/src/gui/uithemedialog.cpp
+++ b/src/gui/uithemedialog.cpp
@@ -37,6 +37,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPalette>
 
 #include "base/3rdparty/expected.hpp"
 #include "base/global.h"
@@ -124,12 +125,17 @@ private:
     {
         if (color.isValid())
         {
-            setStyleSheet(u"#colorWidget { background-color: %1; }"_s.arg(color.name()));
+            QPalette pal = palette();
+            pal.setColor(QPalette::Window, color);
+            setPalette(pal);
+            setAutoFillBackground(true);
             setText({});
         }
         else
         {
-            setStyleSheet({});
+            setPalette({});
+            setAttribute(Qt::WA_SetPalette, false);
+            setAutoFillBackground(false);
             setText(tr("System"));
         }
     }


### PR DESCRIPTION
ColorWidget no longer uses a per-widget stylesheet or palette override.

For a valid color it paints the swatch directly inside the existing QLabel frame. For an invalid color QLabel keeps the native background and shows the translated System text. This also avoids stale widget styling when the app theme changes.

This is a small one-file change. The current GUI build and all 19 Qt tests pass locally.