### PR TITLE
StatusBar: Remove redundant margin stylesheet

### DIFF
--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -153,7 +153,6 @@ StatusBar::StatusBar(QWidget *parent)
     layout->addWidget(m_upSpeedLbl);
 
     addPermanentWidget(container);
-    setStyleSheet(u"QWidget {margin: 0;}"_s);
     container->adjustSize();
     adjustSize();
     updateFreeDiskSpaceVisibility();


### PR DESCRIPTION
Continuing previous refacotring work. No UI changes were recorded (or at least I couldn't notice any) 

The status bar constructor applies setStyleSheet("QWidget {margin: 0;}") to zero out CSS box-model margins on all child widgets. This is redundant because the layout already calls setContentsMargins(0,0,0,0) at line 73, and Qt widgets have no CSS margins when no stylesheet is active.

Removing this stylesheet avoids unnecessary QSS that can interfere with palette-based theming and runtime light/dark mode switching. Visually verified that the status bar spacing is identical before and after the change.
