### PR TITLE
Replace StatusBar border stylesheet with QProxyStyle

### DIFF
--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -55,6 +55,7 @@ namespace
         void drawPrimitive(PrimitiveElement element, const QStyleOption *option,
                            QPainter *painter, const QWidget *widget = nullptr) const override
         {
+            // Suppress the frame around individual status bar items without using a stylesheet.
             if (element == PE_FrameStatusBarItem)
                 return;
             QProxyStyle::drawPrimitive(element, option, painter, widget);
@@ -72,11 +73,29 @@ namespace
     }
 }
 
+void StatusBar::applyStatusBarStyle()
+{
+#ifndef Q_OS_MACOS
+    if (m_statusBarStyle)
+    {
+        setStyle(QApplication::style());
+        delete m_statusBarStyle;
+        m_statusBarStyle = nullptr;
+    }
+
+    m_statusBarStyle = new StatusBarStyle(QApplication::style()->name());
+    m_statusBarStyle->setParent(this);
+    setStyle(m_statusBarStyle);
+#endif
+}
+
 StatusBar::StatusBar(QWidget *parent)
     : QStatusBar(parent)
 {
 #ifndef Q_OS_MACOS
-    setStyle(new StatusBarStyle(style()));
+    applyStatusBarStyle();
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged
+        , this, &StatusBar::applyStatusBarStyle, Qt::QueuedConnection);
 #endif
 
     BitTorrent::Session *const session = BitTorrent::Session::instance();
@@ -166,7 +185,7 @@ StatusBar::StatusBar(QWidget *parent)
     layout->addWidget(m_upSpeedLbl);
 
     addPermanentWidget(container);
-    setStyleSheet(u"QWidget {margin: 0;}"_s);
+    container->setStyleSheet(u"QWidget {margin: 0;}"_s);
     container->adjustSize();
     adjustSize();
     updateFreeDiskSpaceVisibility();
@@ -197,11 +216,13 @@ void StatusBar::showRestartRequired()
     const QPixmap pixmap = style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(Utils::Gui::smallIconSize());
     auto *restartIconLbl = new QLabel(this);
     restartIconLbl->setPixmap(pixmap);
+    restartIconLbl->setStyleSheet(u"margin: 0;"_s);
     restartIconLbl->setToolTip(restartText);
     insertWidget(0, restartIconLbl);
 
     auto *restartLbl = new QLabel(this);
     restartLbl->setText(restartText);
+    restartLbl->setStyleSheet(u"margin: 0;"_s);
     insertWidget(1, restartLbl);
 }
 

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -32,6 +32,7 @@
 
 class QLabel;
 class QPushButton;
+class QStyle;
 
 namespace BitTorrent
 {
@@ -61,6 +62,7 @@ private slots:
     void optionsSaved();
 
 private:
+    void applyStatusBarStyle();
     void updateConnectionStatus();
     void updateDHTNodesNumber();
     void updateFreeDiskSpaceLabel(qint64 value);
@@ -69,6 +71,7 @@ private:
     void updateExternalAddressesVisibility();
     void updateSpeedLabels();
 
+    QStyle *m_statusBarStyle = nullptr;
     QPushButton *m_dlSpeedLbl = nullptr;
     QPushButton *m_upSpeedLbl = nullptr;
     QLabel *m_freeDiskSpaceLbl = nullptr;


### PR DESCRIPTION
My Final refactoring PR related to QSS stuff, there was another case but i couldn't find a clean alternative to QSS so i just left it there for now until either I figure out a way or someone smarter does. 

The status bar uses setStyleSheet("QStatusBar::item { border-width: 0; }") to remove frames drawn around each status bar item. This QSS override can interfere with palette-based theming and break runtime light/dark mode switching.

This replaces the stylesheet with a QProxyStyle that simply skips drawing PE_FrameStatusBarItem. This is the canonical Qt approach for suppressing specific style primitives without affecting palette resolution, and follows the same pattern already used in progressbarpainter.cpp.

The #ifndef Q_OS_MACOS guard is preserved since macOS uses QMacStyle which does not draw status bar item frames.
