### PR TITLE
Apply theme settings at runtime without restart

### DIFF
--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -97,6 +97,13 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
 #endif
 
     connect(Preferences::instance(), &Preferences::changed, this, &DesktopIntegration::onPreferencesChanged);
+#ifndef Q_OS_MACOS
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, [this]
+    {
+        if (m_systrayIcon)
+            m_systrayIcon->setIcon(getSystrayIcon());
+    });
+#endif
 }
 
 DesktopIntegration::~DesktopIntegration()

--- a/src/gui/lineedit.cpp
+++ b/src/gui/lineedit.cpp
@@ -50,8 +50,14 @@ LineEdit::LineEdit(QWidget *parent)
     : QLineEdit(parent)
     , m_delayedTextChangedTimer {new QTimer(this)}
 {
-    auto *action = new QAction(UIThemeManager::instance()->getIcon(u"edit-find"_s), QString(), this);
-    addAction(action, QLineEdit::LeadingPosition);
+    m_searchAction = new QAction(QString(), this);
+    addAction(m_searchAction, QLineEdit::LeadingPosition);
+    const auto applyUITheme = [this]
+    {
+        m_searchAction->setIcon(UIThemeManager::instance()->getIcon(u"edit-find"_s));
+    };
+    applyUITheme();
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, applyUITheme);
 
     setClearButtonEnabled(true);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);

--- a/src/gui/lineedit.h
+++ b/src/gui/lineedit.h
@@ -33,6 +33,7 @@
 
 class QKeyEvent;
 class QTimer;
+class QAction;
 
 class LineEdit final : public QLineEdit
 {
@@ -48,5 +49,6 @@ signals:
 private:
     void keyPressEvent(QKeyEvent *event) override;
 
+    QAction *m_searchAction = nullptr;
     QTimer *m_delayedTextChangedTimer = nullptr;
 };

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -43,6 +43,7 @@
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QFileSystemWatcher>
+#include <QFrame>
 #include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
@@ -125,6 +126,26 @@ namespace
     const QString PYTHON_INSTALLER_URL = u"https://www.python.org/ftp/python/3.14.2/python-3.14.2-amd64.exe"_s;
     const QByteArray PYTHON_INSTALLER_MD5 = QByteArrayLiteral("c887e19e66e66e6961c444283dafaa33");
     const QByteArray PYTHON_INSTALLER_SHA3_512 = QByteArrayLiteral("b5d83ec914dcb0c3892a521d0cbd96bf9bcb267bdee36ea4ee48a54c53fabd0aea98531eda81d1c1db31be8830f7b94430e0c838f5c2f2f8999a273f2833e450");
+#endif
+
+#ifdef Q_OS_MACOS
+    void applySeparatorPalette(QWidget *separator, const QWidget *parent)
+    {
+        QPalette palette = separator->palette();
+        palette.setColor(QPalette::Window, parent->window()->palette().color(QPalette::Mid));
+        separator->setPalette(palette);
+    }
+
+    QWidget *createToolBarSeparator(QWidget *parent)
+    {
+        auto *separator = new QWidget(parent);
+        separator->setAutoFillBackground(true);
+        separator->setFixedWidth(1);
+        separator->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+        separator->setProperty("toolbarSeparator", true);
+        applySeparatorPalette(separator, parent);
+        return separator;
+    }
 #endif
 }
 
@@ -290,24 +311,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     m_queueSeparatorMenu = m_ui->menuEdit->insertSeparator(m_ui->actionTopQueuePos);
 
 #ifdef Q_OS_MACOS
-    for (QAction *action : asConst(m_ui->toolBar->actions()))
-    {
-        if (action->isSeparator())
-        {
-            auto *line = new QWidget(this);
-            line->setAutoFillBackground(true);
-            line->setFixedWidth(1);
-
-            QPalette pal = line->palette();
-            pal.setColor(QPalette::Window, palette().color(QPalette::Mid));
-            line->setPalette(pal);
-
-            QAction *widgetAction = m_ui->toolBar->insertWidget(action, line);
-            m_ui->toolBar->removeAction(action);
-            if (action == m_queueSeparator)
-                m_queueSeparator = widgetAction;
-        }
-    }
+    replaceToolBarSeparators();
 #endif // Q_OS_MACOS
 
     // Transfer list slots
@@ -439,6 +443,9 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 #endif
     });
 
+    applyUITheme();
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &MainWindow::applyUITheme);
+
 #ifdef Q_OS_MACOS
     if (initialState == WindowState::Normal)
     {
@@ -524,6 +531,20 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 MainWindow::~MainWindow()
 {
     delete m_ui;
+}
+
+void MainWindow::applyUITheme()
+{
+#ifndef Q_OS_MACOS
+    setWindowIcon(UIThemeManager::instance()->getIcon(u"qbittorrent"_s));
+#else
+    for (QAction *action : asConst(m_ui->toolBar->actions()))
+    {
+        QWidget *const widget = m_ui->toolBar->widgetForAction(action);
+        if (widget && widget->property("toolbarSeparator").toBool())
+            applySeparatorPalette(widget, m_ui->toolBar);
+    }
+#endif
 }
 
 bool MainWindow::isExecutionLogEnabled() const
@@ -1358,7 +1379,7 @@ void MainWindow::showStatusBar(bool show)
     else if (!m_statusBar)
     {
         // Create status bar
-        m_statusBar = new StatusBar;
+        m_statusBar = new StatusBar(this);
         connect(m_statusBar.data(), &StatusBar::connectionButtonClicked, this, &MainWindow::showConnectionSettings);
         connect(m_statusBar.data(), &StatusBar::alternativeSpeedsButtonClicked, this, &MainWindow::toggleAlternativeSpeeds);
         setStatusBar(m_statusBar);
@@ -1768,6 +1789,23 @@ void MainWindow::on_actionExecutionLogs_triggered(bool checked)
     m_ui->actionCriticalMessages->setEnabled(checked);
     setExecutionLogEnabled(checked);
 }
+
+#ifdef Q_OS_MACOS
+void MainWindow::replaceToolBarSeparators()
+{
+    for (QAction *action : asConst(m_ui->toolBar->actions()))
+    {
+        if (!action->isSeparator())
+            continue;
+
+        auto *separator = createToolBarSeparator(m_ui->toolBar);
+        QAction *const widgetAction = m_ui->toolBar->insertWidget(action, separator);
+        m_ui->toolBar->removeAction(action);
+        if (action == m_queueSeparator)
+            m_queueSeparator = widgetAction;
+    }
+}
+#endif
 
 void MainWindow::on_actionNormalMessages_triggered(const bool checked)
 {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QList>
 #include <QMainWindow>
 #include <QPointer>
 
@@ -188,7 +189,11 @@ private slots:
 #endif
 
 private:
+    void applyUITheme();
     void populateDesktopIntegrationMenu();
+#ifdef Q_OS_MACOS
+    void replaceToolBarSeparators();
+#endif
 
     void closeEvent(QCloseEvent *) override;
     void showEvent(QShowEvent *) override;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -239,31 +239,31 @@ void OptionsDialog::updateSidebarMetrics()
 {
     const QSize iconSize = Utils::Gui::largeIconSize(this);
     const QFontMetrics fontMetrics {m_ui->tabSelection->font()};
-    const int horizontalPadding = (fontMetrics.averageCharWidth() * 2);
-    const int verticalPadding = fontMetrics.averageCharWidth();
+    const int horizontalPadding = (fontMetrics.averageCharWidth() * 4);
 
     int maxTextWidth = 0;
+    int maxHeight = -1;
     for (int i = 0; i < m_ui->tabSelection->count(); ++i)
-        maxTextWidth = std::max(maxTextWidth, fontMetrics.horizontalAdvance(m_ui->tabSelection->item(i)->text()));
+    {
+        QListWidgetItem *const item = m_ui->tabSelection->item(i);
+        maxTextWidth = std::max(maxTextWidth, fontMetrics.horizontalAdvance(item->text()));
+        maxHeight = std::max(maxHeight, m_ui->tabSelection->visualItemRect(item).height());
+    }
 
-    const int itemWidth = std::max(iconSize.width(), maxTextWidth) + horizontalPadding;
-    const int itemHeight = iconSize.height() + (fontMetrics.lineSpacing() * 2) + verticalPadding;
-    const QSize itemSize {itemWidth, itemHeight};
+    if (maxHeight <= 0)
+        maxHeight = iconSize.height() + (fontMetrics.lineSpacing() * 2);
+
+    const int itemHeight = static_cast<int>(maxHeight * 1.2);
 
     m_ui->tabSelection->setIconSize(iconSize);
-    m_ui->tabSelection->setGridSize(itemSize);
-    m_ui->tabSelection->setMinimumWidth(itemWidth + horizontalPadding);
-    m_ui->tabSelection->setSpacing(verticalPadding / 2);
-    m_ui->tabSelection->setWordWrap(true);
-    m_ui->tabSelection->setTextElideMode(Qt::ElideNone);
+    m_ui->tabSelection->setMinimumWidth(std::max((itemHeight * 2), (maxTextWidth + horizontalPadding)));
 
     for (int i = 0; i < m_ui->tabSelection->count(); ++i)
-        m_ui->tabSelection->item(i)->setSizeHint(itemSize);
+        m_ui->tabSelection->item(i)->setSizeHint(QSize(std::numeric_limits<int>::max(), itemHeight));
 }
 
 void OptionsDialog::loadUIThemeResources()
 {
-    updateSidebarMetrics();
     m_ui->tabSelection->item(TAB_UI)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-desktop"_s));
     m_ui->tabSelection->item(TAB_BITTORRENT)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-bittorrent"_s, u"preferences-system-network"_s));
     m_ui->tabSelection->item(TAB_CONNECTION)->setIcon(UIThemeManager::instance()->getIcon(u"network-connect"_s, u"network-wired"_s));
@@ -275,6 +275,7 @@ void OptionsDialog::loadUIThemeResources()
     m_ui->tabSelection->item(TAB_WEBUI)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-webui"_s, u"network-server"_s));
 #endif
     m_ui->tabSelection->item(TAB_ADVANCED)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-advanced"_s, u"preferences-other"_s));
+    updateSidebarMetrics();
 
     m_ui->deleteTorrentWarningIcon->setPixmap(QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical).pixmap(16, 16));
     m_ui->IpFilterRefreshBtn->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));
@@ -1665,7 +1666,7 @@ void OptionsDialog::changePage(QListWidgetItem *current, QListWidgetItem *previo
 
 void OptionsDialog::loadSplitterState()
 {
-    const int width = std::max(m_ui->tabSelection->minimumWidth(), m_ui->tabSelection->gridSize().width());
+    const int width = std::max(m_ui->tabSelection->minimumWidth(), (m_ui->tabSelection->item(TAB_UI)->sizeHint().height() * 2));
     const QStringList defaultSizes = {QString::number(width), QString::number(m_ui->hsplitter->width() - width)};
 
     QList<int> splitterSizes;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -273,6 +273,9 @@ void OptionsDialog::updateSidebarMetrics()
 
 void OptionsDialog::loadUIThemeResources()
 {
+    const QList<int> splitterSizes = m_ui->hsplitter->sizes();
+    const bool preserveSplitterSizes = isVisible();
+
     m_ui->tabSelection->item(TAB_UI)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-desktop"_s));
     m_ui->tabSelection->item(TAB_BITTORRENT)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-bittorrent"_s, u"preferences-system-network"_s));
     m_ui->tabSelection->item(TAB_CONNECTION)->setIcon(UIThemeManager::instance()->getIcon(u"network-connect"_s, u"network-wired"_s));
@@ -285,6 +288,8 @@ void OptionsDialog::loadUIThemeResources()
 #endif
     m_ui->tabSelection->item(TAB_ADVANCED)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-advanced"_s, u"preferences-other"_s));
     updateSidebarMetrics();
+    if (preserveSplitterSizes)
+        m_ui->hsplitter->setSizes(splitterSizes);
 
     m_ui->deleteTorrentWarningIcon->setPixmap(QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical).pixmap(16, 16));
     m_ui->IpFilterRefreshBtn->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -264,7 +264,11 @@ void OptionsDialog::updateSidebarMetrics()
     m_ui->tabSelection->setMinimumWidth(itemWidth + frameWidth + scrollBarWidth);
 
     for (int i = 0; i < m_ui->tabSelection->count(); ++i)
-        m_ui->tabSelection->item(i)->setSizeHint(itemSize);
+    {
+        QListWidgetItem *const item = m_ui->tabSelection->item(i);
+        item->setSizeHint(itemSize);
+        item->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+    }
 }
 
 void OptionsDialog::loadUIThemeResources()

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -237,26 +237,29 @@ OptionsDialog::~OptionsDialog()
 
 void OptionsDialog::updateSidebarMetrics()
 {
-    const QSize iconSize = Utils::Gui::largeIconSize(this);
     const QFontMetrics fontMetrics {m_ui->tabSelection->font()};
     const int horizontalPadding = (fontMetrics.averageCharWidth() * 4);
+    const int frameWidth = (m_ui->tabSelection->frameWidth() * 2);
+    const int scrollBarWidth = style()->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, m_ui->tabSelection);
 
     int maxTextWidth = 0;
+    int maxItemWidth = 0;
     int maxHeight = -1;
     for (int i = 0; i < m_ui->tabSelection->count(); ++i)
     {
         QListWidgetItem *const item = m_ui->tabSelection->item(i);
+        const QRect itemRect = m_ui->tabSelection->visualItemRect(item);
         maxTextWidth = std::max(maxTextWidth, fontMetrics.horizontalAdvance(item->text()));
-        maxHeight = std::max(maxHeight, m_ui->tabSelection->visualItemRect(item).height());
+        maxItemWidth = std::max(maxItemWidth, itemRect.width());
+        maxHeight = std::max(maxHeight, itemRect.height());
     }
 
     if (maxHeight <= 0)
-        maxHeight = iconSize.height() + (fontMetrics.lineSpacing() * 2);
+        maxHeight = (fontMetrics.lineSpacing() * 3);
 
     const int itemHeight = static_cast<int>(maxHeight * 1.2);
 
-    m_ui->tabSelection->setIconSize(iconSize);
-    m_ui->tabSelection->setMinimumWidth(std::max((itemHeight * 2), (maxTextWidth + horizontalPadding)));
+    m_ui->tabSelection->setMinimumWidth(std::max(maxItemWidth, (maxTextWidth + horizontalPadding)) + frameWidth + scrollBarWidth);
 
     for (int i = 0; i < m_ui->tabSelection->count(); ++i)
         m_ui->tabSelection->item(i)->setSizeHint(QSize(std::numeric_limits<int>::max(), itemHeight));

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -237,32 +237,34 @@ OptionsDialog::~OptionsDialog()
 
 void OptionsDialog::updateSidebarMetrics()
 {
+    const QSize iconSize = Utils::Gui::largeIconSize(this);
     const QFontMetrics fontMetrics {m_ui->tabSelection->font()};
-    const int horizontalPadding = (fontMetrics.averageCharWidth() * 4);
+    const int horizontalPadding = std::max(
+        style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, m_ui->tabSelection),
+        fontMetrics.averageCharWidth());
+    const int verticalPadding = std::max(
+        style()->pixelMetric(QStyle::PM_FocusFrameVMargin, nullptr, m_ui->tabSelection),
+        std::max(1, (fontMetrics.averageCharWidth() / 2)));
     const int frameWidth = (m_ui->tabSelection->frameWidth() * 2);
     const int scrollBarWidth = style()->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, m_ui->tabSelection);
 
     int maxTextWidth = 0;
-    int maxItemWidth = 0;
-    int maxHeight = -1;
     for (int i = 0; i < m_ui->tabSelection->count(); ++i)
-    {
-        QListWidgetItem *const item = m_ui->tabSelection->item(i);
-        const QRect itemRect = m_ui->tabSelection->visualItemRect(item);
-        maxTextWidth = std::max(maxTextWidth, fontMetrics.horizontalAdvance(item->text()));
-        maxItemWidth = std::max(maxItemWidth, itemRect.width());
-        maxHeight = std::max(maxHeight, itemRect.height());
-    }
+        maxTextWidth = std::max(maxTextWidth, fontMetrics.horizontalAdvance(m_ui->tabSelection->item(i)->text()));
 
-    if (maxHeight <= 0)
-        maxHeight = (fontMetrics.lineSpacing() * 3);
+    const int itemWidth = std::max(iconSize.width(), maxTextWidth) + (horizontalPadding * 4);
+    const int itemHeight = iconSize.height() + fontMetrics.lineSpacing() + (verticalPadding * 6);
+    const QSize itemSize {itemWidth, itemHeight};
 
-    const int itemHeight = static_cast<int>(maxHeight * 1.2);
-
-    m_ui->tabSelection->setMinimumWidth(std::max(maxItemWidth, (maxTextWidth + horizontalPadding)) + frameWidth + scrollBarWidth);
+    m_ui->tabSelection->setIconSize(iconSize);
+    m_ui->tabSelection->setGridSize(itemSize);
+    m_ui->tabSelection->setSpacing(verticalPadding);
+    m_ui->tabSelection->setWordWrap(true);
+    m_ui->tabSelection->setTextElideMode(Qt::ElideNone);
+    m_ui->tabSelection->setMinimumWidth(itemWidth + frameWidth + scrollBarWidth);
 
     for (int i = 0; i < m_ui->tabSelection->count(); ++i)
-        m_ui->tabSelection->item(i)->setSizeHint(QSize(std::numeric_limits<int>::max(), itemHeight));
+        m_ui->tabSelection->item(i)->setSizeHint(itemSize);
 }
 
 void OptionsDialog::loadUIThemeResources()
@@ -1669,7 +1671,7 @@ void OptionsDialog::changePage(QListWidgetItem *current, QListWidgetItem *previo
 
 void OptionsDialog::loadSplitterState()
 {
-    const int width = std::max(m_ui->tabSelection->minimumWidth(), (m_ui->tabSelection->item(TAB_UI)->sizeHint().height() * 2));
+    const int width = std::max(m_ui->tabSelection->minimumWidth(), m_ui->tabSelection->gridSize().width());
     const QStringList defaultSizes = {QString::number(width), QString::number(m_ui->hsplitter->width() - width)};
 
     QList<int> splitterSizes;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -42,7 +42,9 @@
 #include <QDialogButtonBox>
 #include <QEvent>
 #include <QFileDialog>
+#include <QFontMetrics>
 #include <QMessageBox>
+#include <QStyle>
 #include <QStyleFactory>
 #include <QSystemTrayIcon>
 #include <QTranslator>
@@ -171,29 +173,9 @@ OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
     m_ui->hsplitter->setCollapsible(1, false);
 
     // Main icons
-    m_ui->tabSelection->item(TAB_UI)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-desktop"_s));
-    m_ui->tabSelection->item(TAB_BITTORRENT)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-bittorrent"_s, u"preferences-system-network"_s));
-    m_ui->tabSelection->item(TAB_CONNECTION)->setIcon(UIThemeManager::instance()->getIcon(u"network-connect"_s, u"network-wired"_s));
-    m_ui->tabSelection->item(TAB_DOWNLOADS)->setIcon(UIThemeManager::instance()->getIcon(u"download"_s, u"folder-download"_s));
-    m_ui->tabSelection->item(TAB_SPEED)->setIcon(UIThemeManager::instance()->getIcon(u"speedometer"_s, u"chronometer"_s));
-    m_ui->tabSelection->item(TAB_RSS)->setIcon(UIThemeManager::instance()->getIcon(u"application-rss"_s, u"application-rss+xml"_s));
-    m_ui->tabSelection->item(TAB_SEARCH)->setIcon(UIThemeManager::instance()->getIcon(u"edit-find"_s));
 #ifdef DISABLE_WEBUI
     m_ui->tabSelection->item(TAB_WEBUI)->setHidden(true);
-#else
-    m_ui->tabSelection->item(TAB_WEBUI)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-webui"_s, u"network-server"_s));
 #endif
-    m_ui->tabSelection->item(TAB_ADVANCED)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-advanced"_s, u"preferences-other"_s));
-
-    // set uniform size for all icons
-    int maxHeight = -1;
-    for (int i = 0; i < m_ui->tabSelection->count(); ++i)
-        maxHeight = std::max(maxHeight, m_ui->tabSelection->visualItemRect(m_ui->tabSelection->item(i)).size().height());
-    for (int i = 0; i < m_ui->tabSelection->count(); ++i)
-    {
-        const QSize size(std::numeric_limits<int>::max(), static_cast<int>(maxHeight * 1.2));
-        m_ui->tabSelection->item(i)->setSizeHint(size);
-    }
 
     connect(m_ui->tabSelection, &QListWidget::currentItemChanged, this, &ThisType::changePage);
 
@@ -213,6 +195,9 @@ OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
     m_advancedSettings = new AdvancedSettings(app, m_ui->tabAdvancedPage);
     m_ui->advPageLayout->addWidget(m_advancedSettings);
     connect(m_advancedSettings, &AdvancedSettings::settingsChanged, this, &ThisType::enableApplyButton);
+
+    loadUIThemeResources();
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &OptionsDialog::loadUIThemeResources);
 
     // setup apply button
     m_applyButton->setEnabled(false);
@@ -248,6 +233,56 @@ OptionsDialog::~OptionsDialog()
     m_storeLastViewedPage = m_ui->tabSelection->currentRow();
 
     delete m_ui;
+}
+
+void OptionsDialog::updateSidebarMetrics()
+{
+    const QSize iconSize = Utils::Gui::largeIconSize(this);
+    const QFontMetrics fontMetrics {m_ui->tabSelection->font()};
+    const int horizontalPadding = (fontMetrics.averageCharWidth() * 2);
+    const int verticalPadding = fontMetrics.averageCharWidth();
+
+    int maxTextWidth = 0;
+    for (int i = 0; i < m_ui->tabSelection->count(); ++i)
+        maxTextWidth = std::max(maxTextWidth, fontMetrics.horizontalAdvance(m_ui->tabSelection->item(i)->text()));
+
+    const int itemWidth = std::max(iconSize.width(), maxTextWidth) + horizontalPadding;
+    const int itemHeight = iconSize.height() + (fontMetrics.lineSpacing() * 2) + verticalPadding;
+    const QSize itemSize {itemWidth, itemHeight};
+
+    m_ui->tabSelection->setIconSize(iconSize);
+    m_ui->tabSelection->setGridSize(itemSize);
+    m_ui->tabSelection->setMinimumWidth(itemWidth + horizontalPadding);
+    m_ui->tabSelection->setSpacing(verticalPadding / 2);
+    m_ui->tabSelection->setWordWrap(true);
+    m_ui->tabSelection->setTextElideMode(Qt::ElideNone);
+
+    for (int i = 0; i < m_ui->tabSelection->count(); ++i)
+        m_ui->tabSelection->item(i)->setSizeHint(itemSize);
+}
+
+void OptionsDialog::loadUIThemeResources()
+{
+    updateSidebarMetrics();
+    m_ui->tabSelection->item(TAB_UI)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-desktop"_s));
+    m_ui->tabSelection->item(TAB_BITTORRENT)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-bittorrent"_s, u"preferences-system-network"_s));
+    m_ui->tabSelection->item(TAB_CONNECTION)->setIcon(UIThemeManager::instance()->getIcon(u"network-connect"_s, u"network-wired"_s));
+    m_ui->tabSelection->item(TAB_DOWNLOADS)->setIcon(UIThemeManager::instance()->getIcon(u"download"_s, u"folder-download"_s));
+    m_ui->tabSelection->item(TAB_SPEED)->setIcon(UIThemeManager::instance()->getIcon(u"speedometer"_s, u"chronometer"_s));
+    m_ui->tabSelection->item(TAB_RSS)->setIcon(UIThemeManager::instance()->getIcon(u"application-rss"_s, u"application-rss+xml"_s));
+    m_ui->tabSelection->item(TAB_SEARCH)->setIcon(UIThemeManager::instance()->getIcon(u"edit-find"_s));
+#ifndef DISABLE_WEBUI
+    m_ui->tabSelection->item(TAB_WEBUI)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-webui"_s, u"network-server"_s));
+#endif
+    m_ui->tabSelection->item(TAB_ADVANCED)->setIcon(UIThemeManager::instance()->getIcon(u"preferences-advanced"_s, u"preferences-other"_s));
+
+    m_ui->deleteTorrentWarningIcon->setPixmap(QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical).pixmap(16, 16));
+    m_ui->IpFilterRefreshBtn->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));
+    m_ui->labelGlobalRate->setPixmap(UIThemeManager::instance()->getScaledPixmap(u"slow_off"_s, Utils::Gui::mediumIconSize(this).height()));
+    m_ui->labelAltRate->setPixmap(UIThemeManager::instance()->getScaledPixmap(u"slow"_s, Utils::Gui::mediumIconSize(this).height()));
+#ifndef DISABLE_WEBUI
+    loadWebUIHttpsStatusIcons();
+#endif
 }
 
 void OptionsDialog::loadBehaviorTabOptions()
@@ -488,17 +523,41 @@ void OptionsDialog::saveBehaviorTabOptions() const
     }
     pref->setLocale(locale);
 
-    pref->setStyle(m_ui->comboStyle->currentData().toString());
+    auto *themeManager = UIThemeManager::instance();
+    const QString styleName = m_ui->comboStyle->currentData().toString();
 
 #ifdef QBT_HAS_COLORSCHEME_OPTION
-    UIThemeManager::instance()->setColorScheme(m_ui->comboColorScheme->currentData().value<ColorScheme>());
+    const ColorScheme colorScheme = m_ui->comboColorScheme->currentData().value<ColorScheme>();
 #endif
 
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    pref->useSystemIcons(m_ui->checkUseSystemIcon->isChecked());
+    const bool useSystemIcons = m_ui->checkUseSystemIcon->isChecked();
 #endif
-    pref->setUseCustomUITheme(m_ui->checkUseCustomTheme->isChecked());
-    pref->setCustomUIThemePath(m_ui->customThemeFilePath->selectedPath());
+    const bool useCustomTheme = m_ui->checkUseCustomTheme->isChecked();
+    const Path customThemePath = m_ui->customThemeFilePath->selectedPath();
+
+    const bool shouldApplyTheme = (pref->getStyle() != styleName)
+#ifdef QBT_HAS_COLORSCHEME_OPTION
+        || (themeManager->colorScheme() != colorScheme)
+#endif
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+        || (pref->useSystemIcons() != useSystemIcons)
+#endif
+        || (pref->useCustomUITheme() != useCustomTheme)
+        || (useCustomTheme && (pref->customUIThemePath() != customThemePath));
+
+    pref->setStyle(styleName);
+#ifdef QBT_HAS_COLORSCHEME_OPTION
+    themeManager->setColorScheme(colorScheme);
+#endif
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    pref->useSystemIcons(useSystemIcons);
+#endif
+    pref->setUseCustomUITheme(useCustomTheme);
+    pref->setCustomUIThemePath(customThemePath);
+
+    if (shouldApplyTheme)
+        themeManager->applyThemeSettings();
 
     pref->setConfirmTorrentDeletion(m_ui->confirmDeletion->isChecked());
     pref->setAlternatingRowColors(m_ui->checkAltRowColors->isChecked());
@@ -604,7 +663,6 @@ void OptionsDialog::loadDownloadsTabOptions()
     const TorrentFileGuard::AutoDeleteMode autoDeleteMode = TorrentFileGuard::autoDeleteMode();
     m_ui->deleteTorrentBox->setChecked(autoDeleteMode != TorrentFileGuard::Never);
     m_ui->deleteCancelledTorrentBox->setChecked(autoDeleteMode == TorrentFileGuard::Always);
-    m_ui->deleteTorrentWarningIcon->setPixmap(QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical).pixmap(16, 16));
     m_ui->deleteTorrentWarningIcon->hide();
     m_ui->deleteTorrentWarningLabel->hide();
     m_ui->deleteTorrentWarningLabel->setToolTip(u"<html><body><p>" +
@@ -939,7 +997,6 @@ void OptionsDialog::loadConnectionTabOptions()
     m_ui->textFilterPath->setFileNameFilter(tr("All supported filters") + u" (*.dat *.p2p *.p2b);;.dat (*.dat);;.p2p (*.p2p);;.p2b (*.p2b)");
     m_ui->textFilterPath->setSelectedPath(session->IPFilterFile());
 
-    m_ui->IpFilterRefreshBtn->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));
     m_ui->IpFilterRefreshBtn->setEnabled(m_ui->checkIPFilter->isChecked());
     m_ui->checkIpFilterTrackers->setChecked(session->isTrackerFilteringEnabled());
 
@@ -1038,11 +1095,9 @@ void OptionsDialog::loadSpeedTabOptions()
     const auto *pref = Preferences::instance();
     const auto *session = BitTorrent::Session::instance();
 
-    m_ui->labelGlobalRate->setPixmap(UIThemeManager::instance()->getScaledPixmap(u"slow_off"_s, Utils::Gui::mediumIconSize(this).height()));
     m_ui->spinUploadLimit->setValue(session->globalUploadSpeedLimit() / 1024);
     m_ui->spinDownloadLimit->setValue(session->globalDownloadSpeedLimit() / 1024);
 
-    m_ui->labelAltRate->setPixmap(UIThemeManager::instance()->getScaledPixmap(u"slow"_s, Utils::Gui::mediumIconSize(this).height()));
     m_ui->spinUploadLimitAlt->setValue(session->altGlobalUploadSpeedLimit() / 1024);
     m_ui->spinDownloadLimitAlt->setValue(session->altGlobalDownloadSpeedLimit() / 1024);
 
@@ -1343,6 +1398,30 @@ void OptionsDialog::saveSearchTabOptions() const
 }
 
 #ifndef DISABLE_WEBUI
+void OptionsDialog::updateWebUIHttpsCertStatus()
+{
+    const auto certData = Utils::IO::readFile(m_ui->textWebUIHttpsCert->selectedPath(), Utils::Net::MAX_SSL_FILE_SIZE).value_or(QByteArray());
+    m_isWebUIHttpsCertValid = Utils::Net::isSSLCertificatesValid(certData);
+
+    loadWebUIHttpsStatusIcons();
+}
+
+void OptionsDialog::updateWebUIHttpsKeyStatus()
+{
+    const auto keyData = Utils::IO::readFile(m_ui->textWebUIHttpsKey->selectedPath(), Utils::Net::MAX_SSL_FILE_SIZE).value_or(QByteArray());
+    m_isWebUIHttpsKeyValid = !Utils::SSLKey::load(keyData).isNull();
+
+    loadWebUIHttpsStatusIcons();
+}
+
+void OptionsDialog::loadWebUIHttpsStatusIcons()
+{
+    m_ui->lblSslCertStatus->setPixmap(UIThemeManager::instance()->getScaledPixmap(
+        (m_isWebUIHttpsCertValid ? u"security-high"_s : u"security-low"_s), 24));
+    m_ui->lblSslKeyStatus->setPixmap(UIThemeManager::instance()->getScaledPixmap(
+        (m_isWebUIHttpsKeyValid ? u"security-high"_s : u"security-low"_s), 24));
+}
+
 void OptionsDialog::loadWebUITabOptions()
 {
     const auto *pref = Preferences::instance();
@@ -1366,8 +1445,10 @@ void OptionsDialog::loadWebUITabOptions()
     m_ui->spinWebUIPort->setValue(pref->getWebUIPort());
     m_ui->checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
     m_ui->checkWebUIHttps->setChecked(pref->isWebUIHttpsEnabled());
-    webUIHttpsCertChanged(pref->getWebUIHttpsCertificatePath());
-    webUIHttpsKeyChanged(pref->getWebUIHttpsKeyPath());
+    m_ui->textWebUIHttpsCert->setSelectedPath(pref->getWebUIHttpsCertificatePath());
+    m_ui->textWebUIHttpsKey->setSelectedPath(pref->getWebUIHttpsKeyPath());
+    updateWebUIHttpsCertStatus();
+    updateWebUIHttpsKeyStatus();
     m_ui->textWebUIUsername->setText(pref->getWebUIUsername());
 
     // API Key
@@ -1411,9 +1492,9 @@ void OptionsDialog::loadWebUITabOptions()
     connect(m_ui->checkWebUIUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUIHttps, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIHttpsCert, &FileSystemPathLineEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->textWebUIHttpsCert, &FileSystemPathLineEdit::selectedPathChanged, this, &OptionsDialog::webUIHttpsCertChanged);
+    connect(m_ui->textWebUIHttpsCert, &FileSystemPathLineEdit::selectedPathChanged, this, [this](const Path &) { updateWebUIHttpsCertStatus(); });
     connect(m_ui->textWebUIHttpsKey, &FileSystemPathLineEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->textWebUIHttpsKey, &FileSystemPathLineEdit::selectedPathChanged, this, &OptionsDialog::webUIHttpsKeyChanged);
+    connect(m_ui->textWebUIHttpsKey, &FileSystemPathLineEdit::selectedPathChanged, this, [this](const Path &) { updateWebUIHttpsKeyStatus(); });
 
     connect(m_ui->textWebUIUsername, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIPassword, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -1584,8 +1665,7 @@ void OptionsDialog::changePage(QListWidgetItem *current, QListWidgetItem *previo
 
 void OptionsDialog::loadSplitterState()
 {
-    // width has been modified, use height as width reference instead
-    const int width = m_ui->tabSelection->item(TAB_UI)->sizeHint().height() * 2;
+    const int width = std::max(m_ui->tabSelection->minimumWidth(), m_ui->tabSelection->gridSize().width());
     const QStringList defaultSizes = {QString::number(width), QString::number(m_ui->hsplitter->width() - width)};
 
     QList<int> splitterSizes;
@@ -2092,26 +2172,6 @@ Path OptionsDialog::getFilter() const
 }
 
 #ifndef DISABLE_WEBUI
-void OptionsDialog::webUIHttpsCertChanged(const Path &path)
-{
-    const auto readResult = Utils::IO::readFile(path, Utils::Net::MAX_SSL_FILE_SIZE);
-    const bool isCertValid = Utils::Net::isSSLCertificatesValid(readResult.value_or(QByteArray()));
-
-    m_ui->textWebUIHttpsCert->setSelectedPath(path);
-    m_ui->lblSslCertStatus->setPixmap(UIThemeManager::instance()->getScaledPixmap(
-        (isCertValid ? u"security-high"_s : u"security-low"_s), 24));
-}
-
-void OptionsDialog::webUIHttpsKeyChanged(const Path &path)
-{
-    const auto readResult = Utils::IO::readFile(path, Utils::Net::MAX_SSL_FILE_SIZE);
-    const bool isKeyValid = !Utils::SSLKey::load(readResult.value_or(QByteArray())).isNull();
-
-    m_ui->textWebUIHttpsKey->setSelectedPath(path);
-    m_ui->lblSslKeyStatus->setPixmap(UIThemeManager::instance()->getScaledPixmap(
-        (isKeyValid ? u"security-high"_s : u"security-low"_s), 24));
-}
-
 bool OptionsDialog::isWebUIEnabled() const
 {
     return m_ui->checkWebUI->isChecked();

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -107,8 +107,6 @@ private slots:
     void setLocale(const QString &localeStr);
 
 #ifndef DISABLE_WEBUI
-    void webUIHttpsCertChanged(const Path &path);
-    void webUIHttpsKeyChanged(const Path &path);
     void on_registerDNSBtn_clicked();
     void onBtnWebUIAPIKeyCopyClicked();
     void onBtnWebUIAPIKeyRotateClicked();
@@ -147,7 +145,12 @@ private:
 #ifndef DISABLE_WEBUI
     void loadWebUITabOptions();
     void saveWebUITabOptions() const;
+    void updateWebUIHttpsCertStatus();
+    void updateWebUIHttpsKeyStatus();
+    void loadWebUIHttpsStatusIcons();
 #endif // DISABLE_WEBUI
+    void updateSidebarMetrics();
+    void loadUIThemeResources();
 
     // General options
     void initializeLanguageCombo();
@@ -217,5 +220,7 @@ private:
 
 #ifndef DISABLE_WEBUI
     QString m_currentAPIKey;
+    bool m_isWebUIHttpsCertValid = false;
+    bool m_isWebUIHttpsKeyValid = false;
 #endif
 };

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -139,18 +139,6 @@
               </property>
               <layout class="QVBoxLayout" name="UISettingsBoxLayout">
                <item>
-                <widget class="QLabel" name="labelRestartRequired">
-                 <property name="font">
-                  <font>
-                   <italic>true</italic>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Changing Interface settings requires application restart</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <layout class="QHBoxLayout" name="layoutLanguage">
                  <item>
                   <widget class="QLabel" name="labelLanguage">
@@ -176,6 +164,18 @@
                   </spacer>
                  </item>
                 </layout>
+               </item>
+               <item>
+                <widget class="QLabel" name="labelRestartRequired">
+                 <property name="font">
+                  <font>
+                   <italic>true</italic>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Changing language requires application restart</string>
+                 </property>
+                </widget>
                </item>
                <item>
                 <layout class="QGridLayout" name="layoutStyle">

--- a/src/gui/properties/downloadedpiecesbar.cpp
+++ b/src/gui/properties/downloadedpiecesbar.cpp
@@ -55,6 +55,7 @@ DownloadedPiecesBar::DownloadedPiecesBar(QWidget *parent)
     : base(parent)
 {
     updateColorsImpl();
+    initializeThemeRefresh();
 }
 
 QList<float> DownloadedPiecesBar::bitfieldToFloatVector(const QBitArray &vecin, int reqSize)

--- a/src/gui/properties/pieceavailabilitybar.cpp
+++ b/src/gui/properties/pieceavailabilitybar.cpp
@@ -39,6 +39,7 @@
 PieceAvailabilityBar::PieceAvailabilityBar(QWidget *parent)
     : base {parent}
 {
+    initializeThemeRefresh();
 }
 
 QList<float> PieceAvailabilityBar::intToFloatVector(const QList<int> &vecin, int reqSize)

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -119,7 +119,8 @@ PiecesBar::PiecesBar(QWidget *parent)
     : QWidget(parent)
 {
     setMouseTracking(true);
-    updateColorsImpl();
+    refreshTheme();
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &PiecesBar::refreshTheme);
 }
 
 void PiecesBar::setTorrent(const BitTorrent::Torrent *torrent)
@@ -137,20 +138,21 @@ void PiecesBar::clear()
 
 bool PiecesBar::event(QEvent *e)
 {
-    const QEvent::Type eventType = e->type();
-    if (eventType == QEvent::ToolTip)
+    if (e->type() == QEvent::ToolTip)
     {
         showToolTip(static_cast<QHelpEvent *>(e));
         return true;
     }
 
-    if (eventType == QEvent::PaletteChange)
-    {
-        updateColors();
-        redraw();
-    }
-
     return base::event(e);
+}
+
+void PiecesBar::changeEvent(QEvent *e)
+{
+    if ((e->type() == QEvent::PaletteChange) || (e->type() == QEvent::StyleChange))
+        refreshTheme();
+
+    base::changeEvent(e);
 }
 
 void PiecesBar::enterEvent(QEnterEvent *e)
@@ -213,6 +215,16 @@ void PiecesBar::redraw()
         m_image = image;
         update();
     }
+}
+
+void PiecesBar::refreshTheme()
+{
+    updateColors();
+
+    if (m_image.isNull())
+        update();
+    else
+        redraw();
 }
 
 QColor PiecesBar::backgroundColor() const

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -120,7 +120,6 @@ PiecesBar::PiecesBar(QWidget *parent)
 {
     setMouseTracking(true);
     updateColorsImpl();
-    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &PiecesBar::refreshTheme);
 }
 
 void PiecesBar::setTorrent(const BitTorrent::Torrent *torrent)
@@ -215,6 +214,11 @@ void PiecesBar::redraw()
         m_image = image;
         update();
     }
+}
+
+void PiecesBar::initializeThemeRefresh()
+{
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &PiecesBar::refreshTheme);
 }
 
 void PiecesBar::refreshTheme()

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -119,7 +119,7 @@ PiecesBar::PiecesBar(QWidget *parent)
     : QWidget(parent)
 {
     setMouseTracking(true);
-    refreshTheme();
+    updateColorsImpl();
     connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &PiecesBar::refreshTheme);
 }
 

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -63,6 +63,7 @@ protected:
     void mouseMoveEvent(QMouseEvent *e) override;
     void paintEvent(QPaintEvent *e) override;
 
+    void initializeThemeRefresh();
     virtual void updateColors();
     void redraw();
 

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -57,6 +57,7 @@ public:
 
 protected:
     bool event(QEvent *e) override;
+    void changeEvent(QEvent *e) override;
     void enterEvent(QEnterEvent *e) override;
     void leaveEvent(QEvent *e) override;
     void mouseMoveEvent(QMouseEvent *e) override;
@@ -79,6 +80,7 @@ protected:
     static constexpr int borderWidth = 1;
 
 private:
+    void refreshTheme();
     void showToolTip(const QHelpEvent*);
     void highlightFile(int imagePos);
 

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -118,10 +118,10 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
 
     // Tracker list
     m_trackerList = new TrackerListWidget(this);
-    m_ui->trackerUpButton->setIcon(UIThemeManager::instance()->getIcon(u"go-up"_s));
     m_ui->trackerUpButton->setIconSize(Utils::Gui::smallIconSize());
-    m_ui->trackerDownButton->setIcon(UIThemeManager::instance()->getIcon(u"go-down"_s));
     m_ui->trackerDownButton->setIconSize(Utils::Gui::smallIconSize());
+    loadUIThemeResources();
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &PropertiesWidget::loadUIThemeResources);
     connect(m_ui->trackerUpButton, &QPushButton::clicked, m_trackerList, &TrackerListWidget::decreaseSelectedTrackerTiers);
     connect(m_ui->trackerDownButton, &QPushButton::clicked, m_trackerList, &TrackerListWidget::increaseSelectedTrackerTiers);
     m_ui->hBoxLayoutTrackers->insertWidget(0, m_trackerList);
@@ -273,6 +273,14 @@ PropTabBar *PropertiesWidget::tabBar() const
 LineEdit *PropertiesWidget::contentFilterLine() const
 {
     return m_contentFilterLine;
+}
+
+void PropertiesWidget::loadUIThemeResources()
+{
+    m_ui->trackerUpButton->setIconSize(Utils::Gui::smallIconSize());
+    m_ui->trackerDownButton->setIconSize(Utils::Gui::smallIconSize());
+    m_ui->trackerUpButton->setIcon(UIThemeManager::instance()->getIcon(u"go-up"_s));
+    m_ui->trackerDownButton->setIcon(UIThemeManager::instance()->getIcon(u"go-down"_s));
 }
 
 void PropertiesWidget::updateSavePath(BitTorrent::Torrent *const torrent)

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -103,6 +103,7 @@ private slots:
 
 private:
     QPushButton *getButtonFromIndex(int index);
+    void loadUIThemeResources();
     void showContentFilterContextMenu();
     void setContentFilterPattern();
 

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -43,64 +43,42 @@ PropTabBar::PropTabBar(QWidget *parent)
     setSpacing(3);
     m_btnGroup = new QButtonGroup(this);
     // General tab
-    QPushButton *mainInfosButton = new QPushButton(
-#ifndef Q_OS_MACOS
-            UIThemeManager::instance()->getIcon(u"help-about"_s, u"document-properties"_s),
-#endif
-            tr("General"), parent);
+    QPushButton *mainInfosButton = new QPushButton(tr("General"), parent);
     mainInfosButton->setShortcut(Qt::ALT | Qt::Key_G);
     addWidget(mainInfosButton);
     m_btnGroup->addButton(mainInfosButton, MainTab);
     // Trackers tab
-    QPushButton *trackersButton = new QPushButton(
-#ifndef Q_OS_MACOS
-            UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s),
-#endif
-            tr("Trackers"), parent);
+    QPushButton *trackersButton = new QPushButton(tr("Trackers"), parent);
     trackersButton->setShortcut(Qt::ALT | Qt::Key_C);
     addWidget(trackersButton);
     m_btnGroup->addButton(trackersButton, TrackersTab);
     // Peers tab
-    QPushButton *peersButton = new QPushButton(
-#ifndef Q_OS_MACOS
-            UIThemeManager::instance()->getIcon(u"peers"_s),
-#endif
-            tr("Peers"), parent);
+    QPushButton *peersButton = new QPushButton(tr("Peers"), parent);
     peersButton->setShortcut(Qt::ALT | Qt::Key_R);
     addWidget(peersButton);
     m_btnGroup->addButton(peersButton, PeersTab);
     // URL seeds tab
-    QPushButton *URLSeedsButton = new QPushButton(
-#ifndef Q_OS_MACOS
-            UIThemeManager::instance()->getIcon(u"network-server"_s),
-#endif
-            tr("HTTP Sources"), parent);
+    QPushButton *URLSeedsButton = new QPushButton(tr("HTTP Sources"), parent);
     URLSeedsButton->setShortcut(Qt::ALT | Qt::Key_B);
     addWidget(URLSeedsButton);
     m_btnGroup->addButton(URLSeedsButton, URLSeedsTab);
     // Files tab
-    QPushButton *filesButton = new QPushButton(
-#ifndef Q_OS_MACOS
-            UIThemeManager::instance()->getIcon(u"directory"_s),
-#endif
-            tr("Content"), parent);
+    QPushButton *filesButton = new QPushButton(tr("Content"), parent);
     filesButton->setShortcut(Qt::ALT | Qt::Key_Z);
     addWidget(filesButton);
     m_btnGroup->addButton(filesButton, FilesTab);
     // Spacer
     addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
     // Speed tab
-    QPushButton *speedButton = new QPushButton(
-#ifndef Q_OS_MACOS
-            UIThemeManager::instance()->getIcon(u"chart-line"_s),
-#endif
-            tr("Speed"), parent);
+    QPushButton *speedButton = new QPushButton(tr("Speed"), parent);
     speedButton->setShortcut(Qt::ALT | Qt::Key_D);
     addWidget(speedButton);
     m_btnGroup->addButton(speedButton, SpeedTab);
     // SIGNAL/SLOT
     connect(m_btnGroup, &QButtonGroup::idClicked
             , this, &PropTabBar::setCurrentIndex);
+    loadUIThemeResources();
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &PropTabBar::loadUIThemeResources);
 }
 
 int PropTabBar::currentIndex() const
@@ -138,4 +116,16 @@ void PropTabBar::setCurrentIndex(int index)
     m_currentIndex = index;
     // Emit the signal
     emit tabChanged(index);
+}
+
+void PropTabBar::loadUIThemeResources()
+{
+#ifndef Q_OS_MACOS
+    m_btnGroup->button(MainTab)->setIcon(UIThemeManager::instance()->getIcon(u"help-about"_s, u"document-properties"_s));
+    m_btnGroup->button(TrackersTab)->setIcon(UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s));
+    m_btnGroup->button(PeersTab)->setIcon(UIThemeManager::instance()->getIcon(u"peers"_s));
+    m_btnGroup->button(URLSeedsTab)->setIcon(UIThemeManager::instance()->getIcon(u"network-server"_s));
+    m_btnGroup->button(FilesTab)->setIcon(UIThemeManager::instance()->getIcon(u"directory"_s));
+    m_btnGroup->button(SpeedTab)->setIcon(UIThemeManager::instance()->getIcon(u"chart-line"_s));
+#endif
 }

--- a/src/gui/properties/proptabbar.h
+++ b/src/gui/properties/proptabbar.h
@@ -60,6 +60,7 @@ public slots:
     void setCurrentIndex(int index);
 
 private:
+    void loadUIThemeResources();
     QButtonGroup *m_btnGroup = nullptr;
     int m_currentIndex = -1;
 };

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -250,6 +250,14 @@ void SpeedPlotView::setPeriod(const TimePeriod period)
     viewport()->update();
 }
 
+void SpeedPlotView::changeEvent(QEvent *event)
+{
+    if ((event->type() == QEvent::PaletteChange) || (event->type() == QEvent::StyleChange))
+        viewport()->update();
+
+    QGraphicsView::changeEvent(event);
+}
+
 const SpeedPlotView::DataCircularBuffer &SpeedPlotView::currentData() const
 {
     return m_currentAverager->data();
@@ -282,6 +290,7 @@ quint64 SpeedPlotView::maxYValue() const
 void SpeedPlotView::paintEvent(QPaintEvent *)
 {
     QPainter painter(viewport());
+    const QPalette viewPalette = viewport()->palette();
 
     QRect fullRect = viewport()->rect();
     QRect rect = viewport()->rect();
@@ -309,6 +318,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     }
 
     int i = 0;
+    painter.setPen(viewPalette.color(QPalette::WindowText));
     for (const QString &label : speedLabels)
     {
         QRectF labelRect(rect.topLeft() + QPointF(-yAxisWidth, (i++) * 0.25 * rect.height() - fontMetrics.height()),
@@ -322,7 +332,9 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     QPen gridPen;
     gridPen.setStyle(Qt::DashLine);
     gridPen.setWidthF(1);
-    gridPen.setColor(QColor(128, 128, 128, 128));
+    QColor gridColor = viewPalette.color(QPalette::Mid);
+    gridColor.setAlpha(128);
+    gridPen.setColor(gridColor);
     painter.setPen(gridPen);
 
     painter.drawLine(fullRect.left(), rect.top(), rect.right(), rect.top());
@@ -393,7 +405,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     }
 
     QRectF legendBackgroundRect(QPoint(legendTopLeft.x() - 4, legendTopLeft.y() - 4), QSizeF(legendWidth + 8, legendHeight + 8));
-    QColor legendBackgroundColor = QWidget::palette().color(QWidget::backgroundRole());
+    QColor legendBackgroundColor = viewPalette.color(QPalette::Base);
     legendBackgroundColor.setAlpha(128);  // 50% transparent
     painter.fillRect(legendBackgroundRect, legendBackgroundColor);
 

--- a/src/gui/properties/speedplotview.h
+++ b/src/gui/properties/speedplotview.h
@@ -88,6 +88,7 @@ public:
     void pushPoint(const SampleData &point);
 
 protected:
+    void changeEvent(QEvent *event) override;
     void paintEvent(QPaintEvent *event) override;
 
 private:

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -28,6 +28,7 @@
 
 #include "statusbar.h"
 
+#include <QApplication>
 #include <QFrame>
 #include <QLabel>
 #include <QPushButton>
@@ -43,6 +44,17 @@
 
 namespace
 {
+    QString statusBarStyleSheet()
+    {
+        QString styleSheet = u"QWidget { margin: 0; }"_s;
+#ifndef Q_OS_MACOS
+        // Redefining global stylesheet breaks certain elements on mac like tabs.
+        // Qt checks whether the stylesheet class inherits("QMacStyle") and this becomes false.
+        styleSheet += u"QStatusBar::item { border-width: 0; }";
+#endif
+        return styleSheet;
+    }
+
     QWidget *createSeparator(QWidget *parent)
     {
         auto *separator = new QFrame(parent);
@@ -68,13 +80,7 @@ namespace
 StatusBar::StatusBar(QWidget *parent)
     : QStatusBar(parent)
 {
-    QString styleSheet = u"QWidget { margin: 0; }"_s;
-#ifndef Q_OS_MACOS
-    // Redefining global stylesheet breaks certain elements on mac like tabs.
-    // Qt checks whether the stylesheet class inherits("QMacStyle") and this becomes false.
-    styleSheet += u"QStatusBar::item { border-width: 0; }";
-#endif
-    setStyleSheet(styleSheet);
+    setStyleSheet(statusBarStyleSheet());
 
     const auto *session = BitTorrent::Session::instance();
     connect(session, &BitTorrent::Session::speedLimitModeChanged, this, &StatusBar::updateAltSpeedsBtn);
@@ -149,6 +155,7 @@ StatusBar::StatusBar(QWidget *parent)
     connect(session, &BitTorrent::Session::freeDiskSpaceChecked, this, &StatusBar::updateFreeDiskSpaceLabel);
 
     connect(Preferences::instance(), &Preferences::changed, this, &StatusBar::optionsSaved);
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &StatusBar::applyTheme);
 }
 
 void StatusBar::showRestartRequired()
@@ -165,6 +172,17 @@ void StatusBar::showRestartRequired()
     auto *restartLbl = new QLabel(this);
     restartLbl->setText(restartText);
     insertWidget(1, restartLbl);
+}
+
+void StatusBar::applyTheme()
+{
+    setStyleSheet(statusBarStyleSheet());
+    setPalette(qApp->palette());
+    style()->unpolish(this);
+    style()->polish(this);
+    updateConnectionStatus();
+    updateAltSpeedsBtn(BitTorrent::Session::instance()->isAltGlobalSpeedLimitEnabled());
+    update();
 }
 
 void StatusBar::updateConnectionStatus()

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -54,6 +54,7 @@ public slots:
     void showRestartRequired();
 
 private slots:
+    void applyTheme();
     void refresh();
     void updateAltSpeedsBtn(bool alternative);
     void capSpeed();

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -162,26 +162,55 @@ namespace
         }
     };
 #endif // Q_OS_WIN
+
+    QFileIconProvider *createFileIconProvider()
+    {
+#if defined(Q_OS_WIN)
+        return new QFileIconProvider;
+#elif defined(Q_OS_MACOS)
+        return new MacFileIconProvider;
+#else
+        return doesQFileIconProviderWork() ? static_cast<QFileIconProvider *>(new QFileIconProvider)
+                                           : static_cast<QFileIconProvider *>(new MimeFileIconProvider);
+#endif
+    }
 }
 
 TorrentContentModel::TorrentContentModel(QObject *parent)
     : QAbstractItemModel(parent)
     , m_rootItem(new TorrentContentModelFolder(QList<QString>({ tr("Name"), tr("Total Size"), tr("Progress"), tr("Download Priority"), tr("Remaining"), tr("Availability") })))
-#if defined(Q_OS_WIN)
-    , m_fileIconProvider {new QFileIconProvider}
-#elif defined(Q_OS_MACOS)
-    , m_fileIconProvider {new MacFileIconProvider}
-#else
-    , m_fileIconProvider {doesQFileIconProviderWork() ? new QFileIconProvider : new MimeFileIconProvider}
-#endif
+    , m_fileIconProvider {createFileIconProvider()}
 {
     m_fileIconProvider->setOptions(QFileIconProvider::DontUseCustomDirectoryIcons);
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &TorrentContentModel::onUIThemeChanged);
 }
 
 TorrentContentModel::~TorrentContentModel()
 {
     delete m_fileIconProvider;
     delete m_rootItem;
+}
+
+void TorrentContentModel::onUIThemeChanged()
+{
+    delete m_fileIconProvider;
+    m_fileIconProvider = createFileIconProvider();
+    m_fileIconProvider->setOptions(QFileIconProvider::DontUseCustomDirectoryIcons);
+
+    const auto notify = [this](auto &&self, const QModelIndex &parent) -> void
+    {
+        const int rows = rowCount(parent);
+        if (rows <= 0)
+            return;
+
+        emit dataChanged(index(0, TorrentContentModelItem::COL_NAME, parent)
+                , index((rows - 1), TorrentContentModelItem::COL_NAME, parent), {Qt::DecorationRole});
+
+        for (int row = 0; row < rows; ++row)
+            self(self, index(row, 0, parent));
+    };
+
+    notify(notify, {});
 }
 
 void TorrentContentModel::updateFilesProgress()

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -89,6 +89,7 @@ private:
 
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
     QStringList mimeTypes() const override;
+    void onUIThemeChanged();
     void populate();
     void updateFilesProgress();
     void updateFilesPriorities();

--- a/src/gui/transferlistfilters/categoryfiltermodel.cpp
+++ b/src/gui/transferlistfilters/categoryfiltermodel.cpp
@@ -194,6 +194,7 @@ CategoryFilterModel::CategoryFilterModel(QObject *parent)
     connect(session, &Session::subcategoriesSupportChanged, this, &CategoryFilterModel::subcategoriesSupportChanged);
     connect(session, &Session::torrentsLoaded, this, &CategoryFilterModel::torrentsLoaded);
     connect(session, &Session::torrentAboutToBeRemoved, this, &CategoryFilterModel::torrentAboutToBeRemoved);
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &CategoryFilterModel::onUIThemeChanged);
 
     populate();
 }
@@ -310,6 +311,23 @@ QString CategoryFilterModel::categoryName(const QModelIndex &index) const
         return {};
 
     return static_cast<CategoryModelItem *>(index.internalPointer())->fullName();
+}
+
+void CategoryFilterModel::onUIThemeChanged()
+{
+    const auto notify = [this](auto &&self, const QModelIndex &parent) -> void
+    {
+        const int rows = rowCount(parent);
+        if (rows <= 0)
+            return;
+
+        emit dataChanged(index(0, 0, parent), index((rows - 1), 0, parent), {Qt::DecorationRole});
+
+        for (int row = 0; row < rows; ++row)
+            self(self, index(row, 0, parent));
+    };
+
+    notify(notify, {});
 }
 
 QModelIndex CategoryFilterModel::index(CategoryModelItem *item) const

--- a/src/gui/transferlistfilters/categoryfiltermodel.h
+++ b/src/gui/transferlistfilters/categoryfiltermodel.h
@@ -68,6 +68,7 @@ private slots:
     void subcategoriesSupportChanged();
 
 private:
+    void onUIThemeChanged();
     void populate();
     QModelIndex index(CategoryModelItem *item) const;
     CategoryModelItem *findItem(const QString &fullName) const;

--- a/src/gui/transferlistfilters/statusfilterwidget.cpp
+++ b/src/gui/transferlistfilters/statusfilterwidget.cpp
@@ -45,51 +45,39 @@ StatusFilterWidget::StatusFilterWidget(QWidget *parent, TransferListWidget *tran
     // Add status filters
     auto *all = new QListWidgetItem(this);
     all->setData(Qt::DisplayRole, tr("All (0)", "this is for the status filter"));
-    all->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-all"_s, u"filterall"_s));
     auto *downloading = new QListWidgetItem(this);
     downloading->setData(Qt::DisplayRole, tr("Downloading (0)"));
-    downloading->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"downloading"_s));
     auto *seeding = new QListWidgetItem(this);
     seeding->setData(Qt::DisplayRole, tr("Seeding (0)"));
-    seeding->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"upload"_s, u"uploading"_s));
     auto *completed = new QListWidgetItem(this);
     completed->setData(Qt::DisplayRole, tr("Completed (0)"));
-    completed->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"checked-completed"_s, u"completed"_s));
     auto *running = new QListWidgetItem(this);
     running->setData(Qt::DisplayRole, tr("Running (0)"));
-    running->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s));
     auto *stopped = new QListWidgetItem(this);
     stopped->setData(Qt::DisplayRole, tr("Stopped (0)"));
-    stopped->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"stopped"_s, u"media-playback-pause"_s));
     auto *active = new QListWidgetItem(this);
     active->setData(Qt::DisplayRole, tr("Active (0)"));
-    active->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-active"_s, u"filteractive"_s));
     auto *inactive = new QListWidgetItem(this);
     inactive->setData(Qt::DisplayRole, tr("Inactive (0)"));
-    inactive->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-inactive"_s, u"filterinactive"_s));
     auto *stalled = new QListWidgetItem(this);
     stalled->setData(Qt::DisplayRole, tr("Stalled (0)"));
-    stalled->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-stalled"_s, u"filterstalled"_s));
     auto *stalledUploading = new QListWidgetItem(this);
     stalledUploading->setData(Qt::DisplayRole, tr("Stalled Uploading (0)"));
-    stalledUploading->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"stalledUP"_s));
     auto *stalledDownloading = new QListWidgetItem(this);
     stalledDownloading->setData(Qt::DisplayRole, tr("Stalled Downloading (0)"));
-    stalledDownloading->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"stalledDL"_s));
     auto *checking = new QListWidgetItem(this);
     checking->setData(Qt::DisplayRole, tr("Checking (0)"));
-    checking->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"force-recheck"_s, u"checking"_s));
     auto *moving = new QListWidgetItem(this);
     moving->setData(Qt::DisplayRole, tr("Moving (0)"));
-    moving->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"set-location"_s));
     auto *errored = new QListWidgetItem(this);
     errored->setData(Qt::DisplayRole, tr("Errored (0)"));
-    errored->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"error"_s));
+    loadUIThemeResources();
 
     const QList<BitTorrent::Torrent *> torrents = BitTorrent::Session::instance()->torrents();
     update(torrents);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentsUpdated
             , this, &StatusFilterWidget::update);
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &StatusFilterWidget::loadUIThemeResources);
 
     const Preferences *const pref = Preferences::instance();
     connect(pref, &Preferences::changed, this, &StatusFilterWidget::configure);
@@ -120,6 +108,24 @@ QSize StatusFilterWidget::sizeHint() const
         sizeHintForColumn(0),
         // Height should be exactly the height of the content
         static_cast<int>((sizeHintForRow(0) + 2 * spacing()) * (numVisibleItems + 0.5))};
+}
+
+void StatusFilterWidget::loadUIThemeResources()
+{
+    item(TorrentFilter::All)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-all"_s, u"filterall"_s));
+    item(TorrentFilter::Downloading)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"downloading"_s));
+    item(TorrentFilter::Seeding)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"upload"_s, u"uploading"_s));
+    item(TorrentFilter::Completed)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"checked-completed"_s, u"completed"_s));
+    item(TorrentFilter::Running)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s));
+    item(TorrentFilter::Stopped)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"stopped"_s, u"media-playback-pause"_s));
+    item(TorrentFilter::Active)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-active"_s, u"filteractive"_s));
+    item(TorrentFilter::Inactive)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-inactive"_s, u"filterinactive"_s));
+    item(TorrentFilter::Stalled)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"filter-stalled"_s, u"filterstalled"_s));
+    item(TorrentFilter::StalledUploading)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"stalledUP"_s));
+    item(TorrentFilter::StalledDownloading)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"stalledDL"_s));
+    item(TorrentFilter::Checking)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"force-recheck"_s, u"checking"_s));
+    item(TorrentFilter::Moving)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"set-location"_s));
+    item(TorrentFilter::Errored)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"error"_s));
 }
 
 void StatusFilterWidget::updateTorrentStatus(const BitTorrent::Torrent *torrent)

--- a/src/gui/transferlistfilters/statusfilterwidget.h
+++ b/src/gui/transferlistfilters/statusfilterwidget.h
@@ -57,6 +57,7 @@ private:
     void torrentAboutToBeDeleted(BitTorrent::Torrent *) override;
 
     void configure();
+    void loadUIThemeResources();
 
     void update(const QList<BitTorrent::Torrent *> &torrents);
     void updateTorrentStatus(const BitTorrent::Torrent *torrent);

--- a/src/gui/transferlistfilters/tagfiltermodel.cpp
+++ b/src/gui/transferlistfilters/tagfiltermodel.cpp
@@ -86,6 +86,7 @@ TagFilterModel::TagFilterModel(QObject *parent)
     connect(session, &Session::torrentTagRemoved, this, &TagFilterModel::torrentTagRemoved);
     connect(session, &Session::torrentsLoaded, this, &TagFilterModel::torrentsLoaded);
     connect(session, &Session::torrentAboutToBeRemoved, this, &TagFilterModel::torrentAboutToBeRemoved);
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &TagFilterModel::onUIThemeChanged);
     populate();
 }
 
@@ -282,6 +283,12 @@ void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)
             emit dataChanged(i, i);
         }
     }
+}
+
+void TagFilterModel::onUIThemeChanged()
+{
+    if (rowCount() > 0)
+        emit dataChanged(index(0, 0), index((rowCount() - 1), 0), {Qt::DecorationRole});
 }
 
 void TagFilterModel::populate()

--- a/src/gui/transferlistfilters/tagfiltermodel.h
+++ b/src/gui/transferlistfilters/tagfiltermodel.h
@@ -68,6 +68,7 @@ private slots:
     void torrentAboutToBeRemoved(BitTorrent::Torrent *torrent);
 
 private:
+    void onUIThemeChanged();
     void populate();
     void addToModel(const Tag &tag, int count);
     void removeFromModel(int row);

--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -146,12 +146,10 @@ TrackersFilterWidget::TrackersFilterWidget(QWidget *parent, TransferListWidget *
 {
     auto *allTrackersItem = new QListWidgetItem(this);
     allTrackersItem->setData(Qt::DisplayRole, formatItemText(ALL_ROW, 0));
-    allTrackersItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s));
     auto *trackerlessItem = new QListWidgetItem(this);
     trackerlessItem->setData(Qt::DisplayRole, formatItemText(TRACKERLESS_ROW, 0));
-    trackerlessItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"trackerless"_s, u"network-server"_s));
 
-    m_trackers[NULL_HOST] = {0, trackerlessItem};
+    m_trackers[NULL_HOST] = {0, trackerlessItem, {}};
 
     const auto *pref = Preferences::instance();
     const bool useSeparateTrackerStatusFilter = pref->useSeparateTrackerStatusFilter();
@@ -169,6 +167,8 @@ TrackersFilterWidget::TrackersFilterWidget(QWidget *parent, TransferListWidget *
         }
     });
 
+    loadUIThemeResources();
+
     const auto *btSession = BitTorrent::Session::instance();
     handleTorrentsLoaded(btSession->torrents());
 
@@ -176,14 +176,45 @@ TrackersFilterWidget::TrackersFilterWidget(QWidget *parent, TransferListWidget *
     connect(btSession, &BitTorrent::Session::trackersRemoved, this, &TrackersFilterWidget::handleTorrentTrackersRemoved);
     connect(btSession, &BitTorrent::Session::trackersReset, this, &TrackersFilterWidget::handleTorrentTrackersReset);
     connect(btSession, &BitTorrent::Session::trackerEntryStatusesUpdated, this, &TrackersFilterWidget::handleTorrentTrackerStatusesUpdated);
-
     setCurrentRow(0, QItemSelectionModel::SelectCurrent);
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &TrackersFilterWidget::loadUIThemeResources);
 }
 
 TrackersFilterWidget::~TrackersFilterWidget()
 {
     for (const Path &iconPath : asConst(m_iconPaths))
         Utils::Fs::removeFile(iconPath);
+}
+
+QIcon TrackersFilterWidget::trackerItemIcon(const QString &trackerHost, const TrackerData &trackerData) const
+{
+    if (trackerHost == NULL_HOST)
+        return UIThemeManager::instance()->getIcon(u"trackerless"_s, u"network-server"_s);
+
+    if (!trackerData.icon.isNull())
+        return trackerData.icon;
+
+    return UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s);
+}
+
+void TrackersFilterWidget::updateTrackerItemIcon(const QString &trackerHost, const TrackerData &trackerData)
+{
+    Q_ASSERT(trackerData.item);
+    trackerData.item->setData(Qt::DecorationRole, trackerItemIcon(trackerHost, trackerData));
+}
+
+void TrackersFilterWidget::loadUIThemeResources()
+{
+    item(ALL_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s));
+    for (auto it = m_trackers.cbegin(); it != m_trackers.cend(); ++it)
+        updateTrackerItemIcon(it.key(), it.value());
+
+    if (m_handleTrackerStatuses)
+    {
+        item(TRACKERERROR_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
+        item(OTHERERROR_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
+        item(WARNING_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-warning"_s, u"dialog-warning"_s));
+    }
 }
 
 void TrackersFilterWidget::handleTorrentTrackersAdded(const BitTorrent::Torrent *torrent, const QList<BitTorrent::TrackerEntry> &trackers)
@@ -254,10 +285,9 @@ void TrackersFilterWidget::increaseTorrentsCount(const QString &trackerHost, con
     else
     {
         trackerItem = new QListWidgetItem();
-        trackerItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s));
-
-        const TrackerData trackerData {0, trackerItem};
+        const TrackerData trackerData {0, trackerItem, {}};
         trackersIt = m_trackers.insert(trackerHost, trackerData);
+        updateTrackerItemIcon(trackerHost, trackersIt.value());
 
         const QString scheme = getScheme(trackerHost);
         downloadFavicon(trackerHost, u"%1://%2/favicon.ico"_s.arg((scheme.startsWith(u"http") ? scheme : u"http"_s), getFaviconHost(trackerHost)));
@@ -405,17 +435,14 @@ void TrackersFilterWidget::enableTrackerStatusItems(const bool value)
     {
         auto *trackerErrorItem = new QListWidgetItem;
         trackerErrorItem->setData(Qt::DisplayRole, formatItemText(TRACKERERROR_ROW, 0));
-        trackerErrorItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
         insertItem(TRACKERERROR_ROW, trackerErrorItem);
 
         auto *otherErrorItem = new QListWidgetItem;
         otherErrorItem->setData(Qt::DisplayRole, formatItemText(OTHERERROR_ROW, 0));
-        otherErrorItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
         insertItem(OTHERERROR_ROW, otherErrorItem);
 
         auto *warningItem = new QListWidgetItem;
         warningItem->setData(Qt::DisplayRole, formatItemText(WARNING_ROW, 0));
-        warningItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-warning"_s, u"dialog-warning"_s));
         insertItem(WARNING_ROW, warningItem);
 
         const QList<BitTorrent::Torrent *> torrents = BitTorrent::Session::instance()->torrents();
@@ -436,6 +463,7 @@ void TrackersFilterWidget::enableTrackerStatusItems(const bool value)
         warningItem->setText(formatItemText(WARNING_ROW, m_warnings.size()));
         trackerErrorItem->setText(formatItemText(TRACKERERROR_ROW, m_trackerErrors.size()));
         otherErrorItem->setText(formatItemText(OTHERERROR_ROW, m_errors.size()));
+        loadUIThemeResources();
     }
     else
     {
@@ -497,7 +525,7 @@ void TrackersFilterWidget::handleFavicoDownloadFinished(const Net::DownloadResul
             const QString faviconURL = QStringView(result.url).chopped(4) + u".png";
             for (const auto &trackerHost : trackerHosts)
             {
-                if (m_trackers.contains(trackerHost))
+                if (m_trackers.find(trackerHost) != m_trackers.end())
                     downloadFavicon(trackerHost, faviconURL);
             }
         }
@@ -508,17 +536,14 @@ void TrackersFilterWidget::handleFavicoDownloadFinished(const Net::DownloadResul
     bool matchedTrackerFound = false;
     for (const auto &trackerHost : trackerHosts)
     {
-        if (!m_trackers.contains(trackerHost))
+        const auto trackerIt = m_trackers.find(trackerHost);
+        if (trackerIt == m_trackers.end())
             continue;
 
         matchedTrackerFound = true;
-
-        QListWidgetItem *trackerItem = item(rowFromTracker(trackerHost));
-        Q_ASSERT(trackerItem);
-        if (!trackerItem) [[unlikely]]
-            continue;
-
-        trackerItem->setData(Qt::DecorationRole, icon);
+        TrackerData &trackerData = trackerIt.value();
+        trackerData.icon = icon;
+        updateTrackerItemIcon(trackerHost, trackerData);
     }
 
     if (matchedTrackerFound)

--- a/src/gui/transferlistfilters/trackersfilterwidget.h
+++ b/src/gui/transferlistfilters/trackersfilterwidget.h
@@ -31,6 +31,7 @@
 
 #include <QtContainerFwd>
 #include <QHash>
+#include <QIcon>
 
 #include "base/path.h"
 #include "basefilterwidget.h"
@@ -63,6 +64,13 @@ private slots:
     void handleFavicoDownloadFinished(const Net::DownloadResult &result);
 
 private:
+    struct TrackerData
+    {
+        qsizetype torrentsCount = 0;
+        QListWidgetItem *item = nullptr;
+        QIcon icon;
+    };
+
     // These 4 methods are virtual slots in the base class.
     // No need to redeclare them here as slots.
     void showMenu() override;
@@ -79,8 +87,11 @@ private:
 
     void onRemoveTrackerTriggered();
 
+    QIcon trackerItemIcon(const QString &trackerHost, const TrackerData &trackerData) const;
+    void updateTrackerItemIcon(const QString &trackerHost, const TrackerData &trackerData);
     void increaseTorrentsCount(const QString &trackerHost, qsizetype torrentsCount);
     void decreaseTorrentsCount(const QString &trackerHost);
+    void loadUIThemeResources();
     void refreshStatusItems(const BitTorrent::Torrent *torrent);
     QString trackerFromRow(int row) const;
     int rowFromTracker(const QString &tracker) const;
@@ -90,12 +101,6 @@ private:
     void enableTrackerStatusItems(bool value);
 
     qsizetype numSpecialRows() const;
-
-    struct TrackerData
-    {
-        qsizetype torrentsCount = 0;
-        QListWidgetItem *item = nullptr;
-    };
 
     QHash<QString, TrackerData> m_trackers;   // <tracker host, tracker data>
     QSet<const BitTorrent::Torrent *> m_errors;

--- a/src/gui/transferlistfilters/trackerstatusfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackerstatusfilterwidget.cpp
@@ -79,16 +79,9 @@ TrackerStatusFilterWidget::TrackerStatusFilterWidget(QWidget *parent, TransferLi
     : BaseFilterWidget(parent, transferList)
 {
     auto *anyStatusItem = new QListWidgetItem(this);
-    anyStatusItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s));
-
     auto *warningItem = new QListWidgetItem(this);
-    warningItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-warning"_s, u"dialog-warning"_s));
-
     auto *trackerErrorItem = new QListWidgetItem(this);
-    trackerErrorItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
-
     auto *otherErrorItem = new QListWidgetItem(this);
-    otherErrorItem->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
 
     const auto *btSession = BitTorrent::Session::instance();
 
@@ -109,9 +102,12 @@ TrackerStatusFilterWidget::TrackerStatusFilterWidget(QWidget *parent, TransferLi
             m_errors.insert(torrent);
     }
 
+    loadUIThemeResources();
+
     connect(btSession, &BitTorrent::Session::trackersRemoved, this, &TrackerStatusFilterWidget::handleTorrentTrackersRemoved);
     connect(btSession, &BitTorrent::Session::trackersReset, this, &TrackerStatusFilterWidget::handleTorrentTrackersReset);
     connect(btSession, &BitTorrent::Session::trackerEntryStatusesUpdated, this, &TrackerStatusFilterWidget::handleTorrentTrackerStatusesUpdated);
+    connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, &TrackerStatusFilterWidget::loadUIThemeResources);
 
     anyStatusItem->setText(formatItemText(ANY_ROW, m_totalTorrents));
     warningItem->setText(formatItemText(WARNING_ROW, m_warnings.size()));
@@ -120,6 +116,14 @@ TrackerStatusFilterWidget::TrackerStatusFilterWidget(QWidget *parent, TransferLi
 
     setCurrentRow(0, QItemSelectionModel::SelectCurrent);
     setVisible(Preferences::instance()->getTrackerStatusFilterState());
+}
+
+void TrackerStatusFilterWidget::loadUIThemeResources()
+{
+    item(ANY_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"trackers"_s, u"network-server"_s));
+    item(WARNING_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-warning"_s, u"dialog-warning"_s));
+    item(TRACKERERROR_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
+    item(OTHERERROR_ROW)->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"tracker-error"_s, u"dialog-error"_s));
 }
 
 void TrackerStatusFilterWidget::handleTorrentTrackersRemoved(const BitTorrent::Torrent *torrent)

--- a/src/gui/transferlistfilters/trackerstatusfilterwidget.h
+++ b/src/gui/transferlistfilters/trackerstatusfilterwidget.h
@@ -57,6 +57,7 @@ private:
             , const QList<BitTorrent::TrackerEntry> &newEntries);
     void handleTorrentTrackerStatusesUpdated(const BitTorrent::Torrent *torrent);
 
+    void loadUIThemeResources();
     void refreshItems(const BitTorrent::Torrent *torrent);
 
     QSet<const BitTorrent::Torrent *> m_errors;

--- a/src/gui/uithemedialog.cpp
+++ b/src/gui/uithemedialog.cpp
@@ -268,8 +268,8 @@ void UIThemeDialog::accept()
 
     const Path editedThemeConfig = userConfigPath() / Path(CONFIG_FILE_NAME);
     const auto *pref = Preferences::instance();
-    const bool shouldReapplyTheme = !pref->useCustomUITheme()
-        || (pref->customUIThemePath() == editedThemeConfig);
+    const bool shouldReapplyTheme = pref->useCustomUITheme()
+        && (pref->customUIThemePath() == editedThemeConfig);
     if (shouldReapplyTheme)
         UIThemeManager::instance()->applyThemeSettings();
 

--- a/src/gui/uithemedialog.cpp
+++ b/src/gui/uithemedialog.cpp
@@ -42,10 +42,12 @@
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/path.h"
+#include "base/preferences.h"
 #include "base/profile.h"
 #include "base/utils/fs.h"
 #include "base/utils/io.h"
 #include "uithemecommon.h"
+#include "uithememanager.h"
 #include "utils.h"
 
 #include "ui_uithemedialog.h"
@@ -263,6 +265,13 @@ void UIThemeDialog::accept()
         hasError = true;
     if (!storeIcons())
         hasError = true;
+
+    const Path editedThemeConfig = userConfigPath() / Path(CONFIG_FILE_NAME);
+    const auto *pref = Preferences::instance();
+    const bool shouldReapplyTheme = !pref->useCustomUITheme()
+        || (pref->customUIThemePath() == editedThemeConfig);
+    if (shouldReapplyTheme)
+        UIThemeManager::instance()->applyThemeSettings();
 
     if (hasError)
     {

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -30,12 +30,18 @@
 
 #include "uithememanager.h"
 
+#include <utility>
+
 #include <QApplication>
+#include <QIconEngine>
 #include <QPalette>
+#include <QPainter>
 #include <QPixmapCache>
 #include <QResource>
+#include <QSignalBlocker>
 #include <QStyle>
 #include <QStyleHints>
+#include <QWidget>
 
 #include "base/global.h"
 #include "base/logger.h"
@@ -51,7 +57,76 @@ namespace
         const QColor &color = palette.color(QPalette::Active, QPalette::Base);
         return (color.lightness() < 127);
     }
+
+    class TopLevelWidgetUpdateBlocker
+    {
+    public:
+        TopLevelWidgetUpdateBlocker()
+        {
+            const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
+            m_widgets.reserve(topLevelWidgets.size());
+            for (QWidget *widget : topLevelWidgets)
+            {
+                if (widget && widget->updatesEnabled())
+                {
+                    widget->setUpdatesEnabled(false);
+                    m_widgets.append(widget);
+                }
+            }
+        }
+
+        ~TopLevelWidgetUpdateBlocker()
+        {
+            for (QWidget *widget : asConst(m_widgets))
+            {
+                widget->setUpdatesEnabled(true);
+                widget->update();
+            }
+        }
+
+    private:
+        QWidgetList m_widgets;
+    };
 }
+
+class UIThemeIconEngine final : public QIconEngine
+{
+public:
+    explicit UIThemeIconEngine(QString iconId, QString fallback)
+        : m_iconId {std::move(iconId)}
+        , m_fallback {std::move(fallback)}
+    {
+    }
+
+    void paint(QPainter *painter, const QRect &rect, const QIcon::Mode mode, const QIcon::State state) override
+    {
+        resolvedIcon().paint(painter, rect, Qt::AlignCenter, mode, state);
+    }
+
+    QPixmap pixmap(const QSize &size, const QIcon::Mode mode, const QIcon::State state) override
+    {
+        return resolvedIcon().pixmap(size, mode, state);
+    }
+
+    QIconEngine *clone() const override
+    {
+        return new UIThemeIconEngine(m_iconId, m_fallback);
+    }
+
+    QString key() const override
+    {
+        return u"UIThemeIconEngine"_s;
+    }
+
+private:
+    QIcon resolvedIcon() const
+    {
+        return UIThemeManager::instance()->loadIcon(m_iconId, m_fallback);
+    }
+
+    QString m_iconId;
+    QString m_fallback;
+};
 
 UIThemeManager *UIThemeManager::m_instance = nullptr;
 
@@ -68,7 +143,8 @@ void UIThemeManager::initInstance()
 }
 
 UIThemeManager::UIThemeManager()
-    : m_useCustomTheme {Preferences::instance()->useCustomUITheme()}
+    : m_defaultStyleName {QApplication::style()->name()}
+    , m_useCustomTheme {Preferences::instance()->useCustomUITheme()}
 #ifdef QBT_HAS_COLORSCHEME_OPTION
     , m_colorSchemeSetting {u"Appearance/ColorScheme"_s}
 #endif
@@ -76,44 +152,15 @@ UIThemeManager::UIThemeManager()
     , m_useSystemIcons {Preferences::instance()->useSystemIcons()}
 #endif
 {
-    if (const QString styleName = Preferences::instance()->getStyle(); styleName.compare(u"system", Qt::CaseInsensitive) != 0)
-    {
-        if (!QApplication::setStyle(styleName))
-            LogMsg(tr("Set app style failed. Unknown style: \"%1\"").arg(styleName), Log::WARNING);
-    }
-
-#ifdef QBT_HAS_COLORSCHEME_OPTION
-    applyColorScheme();
-#endif
+    applyThemeSettingsInternal();
 
     // NOTE: Qt::QueuedConnection can be omitted as soon as support for Qt 6.5 is dropped
     connect(QApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &UIThemeManager::onColorSchemeChanged, Qt::QueuedConnection);
+}
 
-    if (m_useCustomTheme)
-    {
-        const Path themePath = Preferences::instance()->customUIThemePath();
-
-        if (themePath.hasExtension(u".qbtheme"_s))
-        {
-            if (QResource::registerResource(themePath.data(), u"/uitheme"_s))
-                m_themeSource = std::make_unique<QRCThemeSource>();
-            else
-                LogMsg(tr("Failed to load UI theme from file: \"%1\"").arg(themePath.toString()), Log::WARNING);
-        }
-        else if (themePath.filename() == CONFIG_FILE_NAME)
-        {
-            m_themeSource = std::make_unique<FolderThemeSource>(themePath.parentPath());
-        }
-    }
-
-    if (!m_themeSource)
-        m_themeSource = std::make_unique<DefaultThemeSource>();
-
-    if (m_useCustomTheme)
-    {
-        applyPalette();
-        applyStyleSheet();
-    }
+UIThemeManager::~UIThemeManager()
+{
+    unregisterThemeResource();
 }
 
 UIThemeManager *UIThemeManager::instance()
@@ -153,20 +200,101 @@ void UIThemeManager::applyColorScheme() const
 }
 #endif
 
+void UIThemeManager::loadThemeSource()
+{
+    m_themeSource.reset();
+
+    if (m_useCustomTheme)
+    {
+        const Path themePath = Preferences::instance()->customUIThemePath();
+
+        if (themePath.hasExtension(u".qbtheme"_s))
+        {
+            if (QResource::registerResource(themePath.data(), u"/uitheme"_s))
+            {
+                m_themeSource = std::make_unique<QRCThemeSource>();
+                m_registeredResourcePath = themePath;
+            }
+            else
+            {
+                LogMsg(tr("Failed to load UI theme from file: \"%1\"").arg(themePath.toString()), Log::WARNING);
+            }
+        }
+        else if (themePath.filename() == CONFIG_FILE_NAME)
+        {
+            m_themeSource = std::make_unique<FolderThemeSource>(themePath.parentPath());
+        }
+    }
+
+    if (!m_themeSource)
+        m_themeSource = std::make_unique<DefaultThemeSource>();
+}
+
+void UIThemeManager::clearIconCaches()
+{
+    m_icons.clear();
+    m_darkModeIcons.clear();
+    QPixmapCache::clear();
+}
+
+void UIThemeManager::unregisterThemeResource()
+{
+    if (!m_registeredResourcePath.isEmpty())
+    {
+        QResource::unregisterResource(m_registeredResourcePath.data(), u"/uitheme"_s);
+        m_registeredResourcePath = {};
+    }
+}
+
+void UIThemeManager::applyStyle() const
+{
+    const QString styleName = Preferences::instance()->getStyle();
+    if (styleName.compare(u"system"_s, Qt::CaseInsensitive) != 0)
+    {
+        if (!QApplication::setStyle(styleName))
+            LogMsg(tr("Set app style failed. Unknown style: \"%1\"").arg(styleName), Log::WARNING);
+    }
+    else
+    {
+        QApplication::setStyle(m_defaultStyleName);
+    }
+}
+
 void UIThemeManager::applyStyleSheet() const
 {
     qApp->setStyleSheet(QString::fromUtf8(m_themeSource->readStyleSheet()));
 }
 
-void UIThemeManager::onColorSchemeChanged()
+void UIThemeManager::applyCurrentTheme()
 {
-    emit themeChanged();
+    if (m_useCustomTheme)
+    {
+        applyPalette();
+        applyStyleSheet();
+    }
+    else
+    {
+        qApp->setPalette(QApplication::style()->standardPalette());
+        qApp->setStyleSheet({});
+    }
 
-    // workaround to refresh styled controls once color scheme is changed
-    QApplication::setStyle(QApplication::style()->name());
+    clearIconCaches();
 }
 
-QIcon UIThemeManager::getIcon(const QString &iconId, [[maybe_unused]] const QString &fallback) const
+void UIThemeManager::onColorSchemeChanged()
+{
+    const TopLevelWidgetUpdateBlocker updateBlocker;
+    applyStyle();
+    applyCurrentTheme();
+    emit themeChanged();
+}
+
+QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) const
+{
+    return QIcon(new UIThemeIconEngine(iconId, fallback));
+}
+
+QIcon UIThemeManager::loadIcon(const QString &iconId, [[maybe_unused]] const QString &fallback) const
 {
     const auto colorMode = isDarkTheme() ? ColorMode::Dark : ColorMode::Light;
     auto &icons = (colorMode == ColorMode::Dark) ? m_darkModeIcons : m_icons;
@@ -231,6 +359,34 @@ QColor UIThemeManager::getColor(const QString &id) const
     return color;
 }
 
+void UIThemeManager::applyThemeSettings()
+{
+    const TopLevelWidgetUpdateBlocker updateBlocker;
+    applyThemeSettingsInternal();
+    emit themeChanged();
+}
+
+void UIThemeManager::applyThemeSettingsInternal()
+{
+    const auto *pref = Preferences::instance();
+    m_useCustomTheme = pref->useCustomUITheme();
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    m_useSystemIcons = pref->useSystemIcons();
+#endif
+
+    unregisterThemeResource();
+
+#ifdef QBT_HAS_COLORSCHEME_OPTION
+    const QSignalBlocker signalBlocker {qApp->styleHints()};
+    applyColorScheme();
+#endif
+
+    applyStyle();
+    loadThemeSource();
+    applyCurrentTheme();
+}
+
 void UIThemeManager::applyPalette() const
 {
     struct ColorDescriptor
@@ -269,7 +425,7 @@ void UIThemeManager::applyPalette() const
         {u"Palette.ButtonTextDisabled"_s, QPalette::ButtonText, QPalette::Disabled}
     };
 
-    QPalette palette = qApp->palette();
+    QPalette palette = QApplication::style()->standardPalette();
     for (const ColorDescriptor &colorDescriptor : paletteColorDescriptors)
     {
         // For backward compatibility, the palette color overrides are read from the section of the "light mode" colors

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -390,7 +390,8 @@ void UIThemeManager::refreshSystemAppearance()
     const AppearanceRefreshGuard refreshGuard {m_isRefreshingAppearance};
     syncThemeSettings();
     refreshNativeAppearance(false);
-    refreshThemeResources(applyThemeOverlay());
+    applyThemeOverlay();
+    refreshThemeResources(true);
 }
 
 void UIThemeManager::refreshNativeAppearance(const bool useConfiguredStyle)

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -32,13 +32,16 @@
 
 #include <utility>
 
+#include <QAbstractItemView>
 #include <QApplication>
 #include <QEvent>
+#include <QHeaderView>
 #include <QIconEngine>
 #include <QPalette>
 #include <QPainter>
 #include <QPixmapCache>
 #include <QResource>
+#include <QSet>
 #include <QSignalBlocker>
 #include <QStyle>
 #include <QStyleHints>
@@ -107,6 +110,55 @@ namespace
     private:
         bool &m_flag;
     };
+
+    void appendWidget(QWidget *widget, QSet<QWidget *> &visitedWidgets, QWidgetList &widgets)
+    {
+        if (widget && !visitedWidgets.contains(widget))
+        {
+            visitedWidgets.insert(widget);
+            widgets.append(widget);
+        }
+    }
+
+    QWidgetList widgetsForRepolish()
+    {
+        QWidgetList widgets;
+        QSet<QWidget *> visitedWidgets;
+
+        const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
+        for (QWidget *topLevelWidget : topLevelWidgets)
+        {
+            appendWidget(topLevelWidget, visitedWidgets, widgets);
+            for (QWidget *childWidget : topLevelWidget->findChildren<QWidget *>())
+                appendWidget(childWidget, visitedWidgets, widgets);
+        }
+
+        const QWidgetList currentWidgets = widgets;
+        for (QWidget *widget : currentWidgets)
+        {
+            if (const auto *itemView = qobject_cast<QAbstractItemView *>(widget))
+                appendWidget(itemView->viewport(), visitedWidgets, widgets);
+
+            if (const auto *headerView = qobject_cast<QHeaderView *>(widget))
+                appendWidget(headerView->viewport(), visitedWidgets, widgets);
+        }
+
+        return widgets;
+    }
+
+    void repolishWidgets()
+    {
+        const QWidgetList widgets = widgetsForRepolish();
+        for (QWidget *widget : widgets)
+            widget->style()->unpolish(widget);
+
+        for (QWidget *widget : widgets)
+        {
+            widget->style()->polish(widget);
+            widget->updateGeometry();
+            widget->update();
+        }
+    }
 }
 
 class UIThemeIconEngine final : public QIconEngine
@@ -306,9 +358,9 @@ void UIThemeManager::applyStyle(const bool useConfiguredStyle) const
     }
 }
 
-void UIThemeManager::applyStyleSheet() const
+void UIThemeManager::applyStyleSheet(const QByteArray &styleSheet) const
 {
-    qApp->setStyleSheet(QString::fromUtf8(m_themeSource->readStyleSheet()));
+    qApp->setStyleSheet(QString::fromUtf8(styleSheet));
 }
 
 void UIThemeManager::scheduleSystemAppearanceRefresh()
@@ -338,13 +390,13 @@ void UIThemeManager::refreshSystemAppearance()
     const AppearanceRefreshGuard refreshGuard {m_isRefreshingAppearance};
     syncThemeSettings();
     refreshNativeAppearance(false);
-    applyThemeOverlay();
-    emit themeChanged();
+    refreshThemeResources(applyThemeOverlay());
 }
 
 void UIThemeManager::refreshNativeAppearance(const bool useConfiguredStyle)
 {
     qApp->setStyleSheet({});
+    qApp->setPalette(QPalette {});
 
     applyStyle(useConfiguredStyle);
 
@@ -356,20 +408,31 @@ void UIThemeManager::refreshNativeAppearance(const bool useConfiguredStyle)
     m_nativePalette = qApp->palette();
 }
 
-void UIThemeManager::applyThemeOverlay()
+void UIThemeManager::refreshThemeResources(const bool shouldRepolishWidgets)
 {
+    if (shouldRepolishWidgets)
+        repolishWidgets();
+
+    clearIconCaches();
+    emit themeChanged();
+}
+
+bool UIThemeManager::applyThemeOverlay()
+{
+    const QByteArray styleSheet = m_useCustomTheme ? m_themeSource->readStyleSheet() : QByteArray {};
+    const bool shouldRepolishWidgets = ((styleSheet != m_appliedStyleSheet)
+            || (m_useCustomTheme != m_hadCustomThemeOverlay));
+
     if (m_useCustomTheme)
     {
         applyPalette();
-        applyStyleSheet();
-    }
-    else
-    {
-        qApp->setPalette(m_nativePalette);
-        qApp->setStyleSheet({});
+        if (!styleSheet.isEmpty())
+            applyStyleSheet(styleSheet);
     }
 
-    clearIconCaches();
+    m_hadCustomThemeOverlay = m_useCustomTheme;
+    m_appliedStyleSheet = styleSheet;
+    return shouldRepolishWidgets;
 }
 
 QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) const
@@ -446,7 +509,6 @@ void UIThemeManager::applyThemeSettings()
 {
     const TopLevelWidgetUpdateBlocker updateBlocker;
     applyThemeSettingsInternal();
-    emit themeChanged();
 }
 
 void UIThemeManager::applyThemeSettingsInternal()
@@ -454,10 +516,10 @@ void UIThemeManager::applyThemeSettingsInternal()
     const AppearanceRefreshGuard refreshGuard {m_isRefreshingAppearance};
     syncThemeSettings();
 
+    refreshNativeAppearance(true);
     unregisterThemeResource();
     loadThemeSource();
-    refreshNativeAppearance(true);
-    applyThemeOverlay();
+    refreshThemeResources(applyThemeOverlay());
 }
 
 void UIThemeManager::applyPalette() const
@@ -498,7 +560,7 @@ void UIThemeManager::applyPalette() const
         {u"Palette.ButtonTextDisabled"_s, QPalette::ButtonText, QPalette::Disabled}
     };
 
-    QPalette palette = QApplication::style()->standardPalette();
+    QPalette palette = m_nativePalette;
     for (const ColorDescriptor &colorDescriptor : paletteColorDescriptors)
     {
         // For backward compatibility, the palette color overrides are read from the section of the "light mode" colors

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -33,6 +33,7 @@
 #include <utility>
 
 #include <QApplication>
+#include <QEvent>
 #include <QIconEngine>
 #include <QPalette>
 #include <QPainter>
@@ -41,6 +42,7 @@
 #include <QSignalBlocker>
 #include <QStyle>
 #include <QStyleHints>
+#include <QTimer>
 #include <QWidget>
 
 #include "base/global.h"
@@ -86,6 +88,24 @@ namespace
 
     private:
         QWidgetList m_widgets;
+    };
+
+    class AppearanceRefreshGuard
+    {
+    public:
+        explicit AppearanceRefreshGuard(bool &flag)
+            : m_flag {flag}
+        {
+            m_flag = true;
+        }
+
+        ~AppearanceRefreshGuard()
+        {
+            m_flag = false;
+        }
+
+    private:
+        bool &m_flag;
     };
 }
 
@@ -152,6 +172,7 @@ UIThemeManager::UIThemeManager()
     , m_useSystemIcons {Preferences::instance()->useSystemIcons()}
 #endif
 {
+    qApp->installEventFilter(this);
     applyThemeSettingsInternal();
 
     // NOTE: Qt::QueuedConnection can be omitted as soon as support for Qt 6.5 is dropped
@@ -160,6 +181,7 @@ UIThemeManager::UIThemeManager()
 
 UIThemeManager::~UIThemeManager()
 {
+    qApp->removeEventFilter(this);
     unregisterThemeResource();
 }
 
@@ -199,6 +221,24 @@ void UIThemeManager::applyColorScheme() const
     }
 }
 #endif
+
+bool UIThemeManager::eventFilter(QObject *object, QEvent *event)
+{
+    if ((object == qApp) && (event->type() == QEvent::ApplicationPaletteChange))
+        scheduleSystemAppearanceRefresh();
+
+    return QObject::eventFilter(object, event);
+}
+
+void UIThemeManager::syncThemeSettings()
+{
+    const auto *pref = Preferences::instance();
+    m_useCustomTheme = pref->useCustomUITheme();
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    m_useSystemIcons = pref->useSystemIcons();
+#endif
+}
 
 void UIThemeManager::loadThemeSource()
 {
@@ -246,8 +286,14 @@ void UIThemeManager::unregisterThemeResource()
     }
 }
 
-void UIThemeManager::applyStyle() const
+void UIThemeManager::applyStyle(const bool useConfiguredStyle) const
 {
+    if (!useConfiguredStyle)
+    {
+        QApplication::setStyle(QApplication::style()->name());
+        return;
+    }
+
     const QString styleName = Preferences::instance()->getStyle();
     if (styleName.compare(u"system"_s, Qt::CaseInsensitive) != 0)
     {
@@ -265,7 +311,52 @@ void UIThemeManager::applyStyleSheet() const
     qApp->setStyleSheet(QString::fromUtf8(m_themeSource->readStyleSheet()));
 }
 
-void UIThemeManager::applyCurrentTheme()
+void UIThemeManager::scheduleSystemAppearanceRefresh()
+{
+    if (m_isRefreshingAppearance || m_isAppearanceRefreshPending)
+        return;
+
+    m_isAppearanceRefreshPending = true;
+    QTimer::singleShot(0, this, [this]
+    {
+        m_isAppearanceRefreshPending = false;
+        refreshSystemAppearance();
+    });
+}
+
+void UIThemeManager::onColorSchemeChanged()
+{
+    scheduleSystemAppearanceRefresh();
+}
+
+void UIThemeManager::refreshSystemAppearance()
+{
+    if (m_isRefreshingAppearance)
+        return;
+
+    const TopLevelWidgetUpdateBlocker updateBlocker;
+    const AppearanceRefreshGuard refreshGuard {m_isRefreshingAppearance};
+    syncThemeSettings();
+    refreshNativeAppearance(false);
+    applyThemeOverlay();
+    emit themeChanged();
+}
+
+void UIThemeManager::refreshNativeAppearance(const bool useConfiguredStyle)
+{
+    qApp->setStyleSheet({});
+
+    applyStyle(useConfiguredStyle);
+
+#ifdef QBT_HAS_COLORSCHEME_OPTION
+    const QSignalBlocker signalBlocker {qApp->styleHints()};
+    applyColorScheme();
+#endif
+
+    m_nativePalette = qApp->palette();
+}
+
+void UIThemeManager::applyThemeOverlay()
 {
     if (m_useCustomTheme)
     {
@@ -274,19 +365,11 @@ void UIThemeManager::applyCurrentTheme()
     }
     else
     {
-        qApp->setPalette(QApplication::style()->standardPalette());
+        qApp->setPalette(m_nativePalette);
         qApp->setStyleSheet({});
     }
 
     clearIconCaches();
-}
-
-void UIThemeManager::onColorSchemeChanged()
-{
-    const TopLevelWidgetUpdateBlocker updateBlocker;
-    applyStyle();
-    applyCurrentTheme();
-    emit themeChanged();
 }
 
 QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) const
@@ -368,23 +451,13 @@ void UIThemeManager::applyThemeSettings()
 
 void UIThemeManager::applyThemeSettingsInternal()
 {
-    const auto *pref = Preferences::instance();
-    m_useCustomTheme = pref->useCustomUITheme();
-
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    m_useSystemIcons = pref->useSystemIcons();
-#endif
+    const AppearanceRefreshGuard refreshGuard {m_isRefreshingAppearance};
+    syncThemeSettings();
 
     unregisterThemeResource();
-
-#ifdef QBT_HAS_COLORSCHEME_OPTION
-    const QSignalBlocker signalBlocker {qApp->styleHints()};
-    applyColorScheme();
-#endif
-
-    applyStyle();
     loadThemeSource();
-    applyCurrentTheme();
+    refreshNativeAppearance(true);
+    applyThemeOverlay();
 }
 
 void UIThemeManager::applyPalette() const

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -389,7 +389,7 @@ void UIThemeManager::refreshSystemAppearance()
     const TopLevelWidgetUpdateBlocker updateBlocker;
     const AppearanceRefreshGuard refreshGuard {m_isRefreshingAppearance};
     syncThemeSettings();
-    refreshNativeAppearance(false);
+    refreshNativeAppearance(true);
     applyThemeOverlay();
     refreshThemeResources(true);
 }
@@ -421,8 +421,7 @@ void UIThemeManager::refreshThemeResources(const bool shouldRepolishWidgets)
 bool UIThemeManager::applyThemeOverlay()
 {
     const QByteArray styleSheet = m_useCustomTheme ? m_themeSource->readStyleSheet() : QByteArray {};
-    const bool shouldRepolishWidgets = ((styleSheet != m_appliedStyleSheet)
-            || (m_useCustomTheme != m_hadCustomThemeOverlay));
+    const QPalette nativePalette = qApp->palette();
 
     if (m_useCustomTheme)
     {
@@ -430,6 +429,10 @@ bool UIThemeManager::applyThemeOverlay()
         if (!styleSheet.isEmpty())
             applyStyleSheet(styleSheet);
     }
+
+    const bool shouldRepolishWidgets = ((styleSheet != m_appliedStyleSheet)
+            || (m_useCustomTheme != m_hadCustomThemeOverlay)
+            || (qApp->palette() != nativePalette));
 
     m_hadCustomThemeOverlay = m_useCustomTheme;
     m_appliedStyleSheet = styleSheet;

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -50,6 +50,8 @@
 #include "colorscheme.h"
 #endif
 
+class UIThemeIconEngine;
+
 class UIThemeManager final : public QObject
 {
     Q_OBJECT
@@ -71,12 +73,24 @@ public:
 
     QColor getColor(const QString &id) const;
 
+    void applyThemeSettings();
+
 signals:
     void themeChanged();
 
 private:
-    UIThemeManager(); // singleton class
+    friend class UIThemeIconEngine;
 
+    UIThemeManager(); // singleton class
+    ~UIThemeManager() override;
+
+    void applyThemeSettingsInternal();
+    QIcon loadIcon(const QString &iconId, const QString &fallback = {}) const;
+    void loadThemeSource();
+    void clearIconCaches();
+    void unregisterThemeResource();
+    void applyCurrentTheme();
+    void applyStyle() const;
     void applyPalette() const;
     void applyStyleSheet() const;
     void onColorSchemeChanged();
@@ -86,14 +100,16 @@ private:
 #endif
 
     static UIThemeManager *m_instance;
-    const bool m_useCustomTheme;
+    const QString m_defaultStyleName;
+    bool m_useCustomTheme;
 #ifdef QBT_HAS_COLORSCHEME_OPTION
     SettingValue<ColorScheme> m_colorSchemeSetting;
 #endif
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    const bool m_useSystemIcons;
+    bool m_useSystemIcons;
 #endif
     std::unique_ptr<UIThemeSource> m_themeSource;
+    Path m_registeredResourcePath;
     mutable QHash<QString, QIcon> m_icons;
     mutable QHash<QString, QIcon> m_darkModeIcons;
     mutable QHash<QString, QIcon> m_flags;

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -32,6 +32,7 @@
 
 #include <QtSystemDetection>
 #include <QtVersionChecks>
+#include <QByteArray>
 #include <QColor>
 #include <QEvent>
 #include <QHash>
@@ -93,14 +94,15 @@ private:
     void scheduleSystemAppearanceRefresh();
     void refreshSystemAppearance();
     void refreshNativeAppearance(bool useConfiguredStyle);
+    void refreshThemeResources(bool shouldRepolishWidgets);
     QIcon loadIcon(const QString &iconId, const QString &fallback = {}) const;
     void loadThemeSource();
     void clearIconCaches();
     void unregisterThemeResource();
-    void applyThemeOverlay();
+    bool applyThemeOverlay();
     void applyStyle(bool useConfiguredStyle) const;
     void applyPalette() const;
-    void applyStyleSheet() const;
+    void applyStyleSheet(const QByteArray &styleSheet) const;
     void onColorSchemeChanged();
 
 #ifdef QBT_HAS_COLORSCHEME_OPTION
@@ -121,6 +123,8 @@ private:
     QPalette m_nativePalette;
     std::unique_ptr<UIThemeSource> m_themeSource;
     Path m_registeredResourcePath;
+    bool m_hadCustomThemeOverlay = false;
+    QByteArray m_appliedStyleSheet;
     mutable QHash<QString, QIcon> m_icons;
     mutable QHash<QString, QIcon> m_darkModeIcons;
     mutable QHash<QString, QIcon> m_flags;

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -33,9 +33,11 @@
 #include <QtSystemDetection>
 #include <QtVersionChecks>
 #include <QColor>
+#include <QEvent>
 #include <QHash>
 #include <QIcon>
 #include <QObject>
+#include <QPalette>
 #include <QPixmap>
 #include <QString>
 
@@ -84,13 +86,19 @@ private:
     UIThemeManager(); // singleton class
     ~UIThemeManager() override;
 
+    bool eventFilter(QObject *object, QEvent *event) override;
+
+    void syncThemeSettings();
     void applyThemeSettingsInternal();
+    void scheduleSystemAppearanceRefresh();
+    void refreshSystemAppearance();
+    void refreshNativeAppearance(bool useConfiguredStyle);
     QIcon loadIcon(const QString &iconId, const QString &fallback = {}) const;
     void loadThemeSource();
     void clearIconCaches();
     void unregisterThemeResource();
-    void applyCurrentTheme();
-    void applyStyle() const;
+    void applyThemeOverlay();
+    void applyStyle(bool useConfiguredStyle) const;
     void applyPalette() const;
     void applyStyleSheet() const;
     void onColorSchemeChanged();
@@ -102,12 +110,15 @@ private:
     static UIThemeManager *m_instance;
     const QString m_defaultStyleName;
     bool m_useCustomTheme;
+    bool m_isRefreshingAppearance = false;
+    bool m_isAppearanceRefreshPending = false;
 #ifdef QBT_HAS_COLORSCHEME_OPTION
     SettingValue<ColorScheme> m_colorSchemeSetting;
 #endif
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     bool m_useSystemIcons;
 #endif
+    QPalette m_nativePalette;
     std::unique_ptr<UIThemeSource> m_themeSource;
     Path m_registeredResourcePath;
     mutable QHash<QString, QIcon> m_icons;


### PR DESCRIPTION
Theme changes (color scheme, Qt style, custom theme toggle/path) only wrote to disk and needed a restart. This makes them apply live.

A file-local QIconEngine subclass delegates paint calls to loadIcon(), so when caches are cleared on theme change, all icons re-resolve automatically. No consumer file changes needed.

- getIcon() returns engine-backed QIcon; old body moved to loadIcon()
- applyThemeSettings() rebuilds theme source, re-applies palette/stylesheet, clears caches, forces repaint
- setColorScheme() now calls applyColorScheme()
- Old .qbtheme resources properly unregistered before re-registering
