### PR TITLE
WebUI: Color progress bars by torrent state

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -19,6 +19,13 @@
     --color-border-default: hsl(0deg 0% 85%);
     --color-icon-hover: brightness(0) invert(100%) sepia(100%) saturate(0%)
         hue-rotate(108deg) brightness(104%) contrast(104%);
+    --color-progress-downloading: hsl(210deg 65% 46%);
+    --color-progress-seeding: hsl(110deg 50% 34%);
+    --color-progress-stopped: hsl(0deg 0% 45%);
+    --color-progress-error: hsl(0deg 65% 50%);
+    --color-progress-checking: hsl(40deg 70% 34%);
+    --color-progress-queued: hsl(210deg 20% 46%);
+    --color-progress-stalled: hsl(210deg 30% 47%);
 
     & #torrentTrackersTableDiv tr {
         --color-tracker-disabled: hsl(240deg 4% 46%);
@@ -43,6 +50,13 @@
         --color-background-default: hsl(0deg 0% 25%);
         --color-background-hover: hsl(26deg 50% 55%);
         --color-border-default: hsl(0deg 0% 33%);
+        --color-progress-downloading: hsl(210deg 45% 38%);
+        --color-progress-seeding: hsl(142deg 40% 35%);
+        --color-progress-stopped: hsl(220deg 8% 35%);
+        --color-progress-error: hsl(0deg 45% 42%);
+        --color-progress-checking: hsl(40deg 40% 38%);
+        --color-progress-queued: hsl(220deg 12% 35%);
+        --color-progress-stalled: hsl(210deg 18% 38%);
 
         & #torrentTrackersTableDiv tr {
             --color-tracker-disabled: hsl(240deg 6% 83%);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1223,6 +1223,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["num_seeds"].dataProperties.push("num_complete");
             this.columns["num_leechs"].dataProperties.push("num_incomplete");
             this.columns["time_active"].dataProperties.push("seeding_time");
+            this.columns["progress"].dataProperties.push("state");
 
             this.initColumnsFunctions();
         }
@@ -1476,6 +1477,40 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["category"].compareRows = compareNames;
             this.columns["tags"].compareRows = compareNames;
 
+            const getProgressColor = (state) => {
+                switch (state) {
+                    case "downloading":
+                    case "forcedDL":
+                    case "metaDL":
+                    case "forcedMetaDL":
+                        return "var(--color-progress-downloading)";
+                    case "uploading":
+                    case "forcedUP":
+                    case "stalledUP":
+                        return "var(--color-progress-seeding)";
+                    case "stalledDL":
+                        return "var(--color-progress-stalled)";
+                    case "stoppedDL":
+                    case "stoppedUP":
+                        return "var(--color-progress-stopped)";
+                    case "queuedDL":
+                    case "queuedUP":
+                        return "var(--color-progress-queued)";
+                    case "checkingDL":
+                    case "checkingUP":
+                    case "queuedForChecking":
+                    case "checkingResumeData":
+                    case "moving":
+                        return "var(--color-progress-checking)";
+                    case "error":
+                    case "unknown":
+                    case "missingFiles":
+                        return "var(--color-progress-error)";
+                }
+
+                return "var(--color-background-blue)";
+            };
+
             // size, total_size
             this.columns["size"].updateTd = displaySize;
             this.columns["total_size"].updateTd = displaySize;
@@ -1493,6 +1528,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                 else {
                     td.append(new window.qBittorrent.ProgressBar.ProgressBar(progressFormatted));
                 }
+
+                const state = row.full_data.state;
+                td.firstElementChild.setDarkBackgroundColor(getProgressColor(state));
             };
             this.columns["progress"].staticWidth = 100;
 

--- a/src/webui/www/private/scripts/progressbar.js
+++ b/src/webui/www/private/scripts/progressbar.js
@@ -96,6 +96,10 @@ window.qBittorrent.ProgressBar ??= (() => {
             return this.#value;
         }
 
+        setDarkBackgroundColor(backgroundColor) {
+            this.#dark.style.backgroundColor = backgroundColor;
+        }
+
         setValue(value) {
             value = Number(value);
             if (Number.isNaN(value))

--- a/src/webui/www/test/private/dynamicTable.test.js
+++ b/src/webui/www/test/private/dynamicTable.test.js
@@ -1,0 +1,108 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Muhammad Hassan Raza <raihassanraza10@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+import { expect, test } from "vitest";
+
+window.qBittorrent ??= {};
+window.qBittorrent.LocalPreferences = {
+    LocalPreferences: class {
+        get(_key, defaultValue) {
+            return defaultValue;
+        }
+
+        set() {}
+    }
+};
+window.qBittorrent.ClientData = {
+    get: (key) => {
+        if (key === "use_virtual_list")
+            return false;
+        return null;
+    }
+};
+
+await import("../../private/scripts/misc.js");
+await import("../../private/scripts/progressbar.js");
+await import("../../private/scripts/dynamicTable.js");
+
+const createTorrentsTable = () => {
+    const table = new window.qBittorrent.DynamicTable.TorrentsTable();
+    table.dynamicTableDivId = "testTransferList";
+    table.columns = [];
+    table.colgroup = document.createElement("colgroup");
+    table.fixedTableHeader = document.createElement("tr");
+    table.fixedTableHeaderColgroup = document.createElement("colgroup");
+    table.rows = new Map();
+    table.selectedRows = [];
+    table.useVirtualList = false;
+    table.tableBody = document.createElement("tbody");
+    table.contextMenu = null;
+    table.sortedColumn = "name";
+    table.reverseSort = "0";
+    table.initColumns();
+    return table;
+};
+
+test("Test progress column recolors when only state changes", () => {
+    const table = createTorrentsTable();
+    table.updateRowData({
+        rowId: "torrent-1",
+        name: "Ubuntu ISO",
+        progress: 0.5,
+        state: "downloading"
+    });
+
+    const row = table.getRow("torrent-1");
+    const tr = table.createRowElement(row);
+    table.updateRow(tr, true);
+
+    const progressCell = tr.children[table.getColumnPos("progress")];
+    const progressBar = progressCell.firstElementChild;
+    const barElement = progressBar.shadowRoot.firstElementChild;
+
+    expect(progressBar.getValue()).toBe(50);
+    expect(barElement.style.backgroundColor).toBe("var(--color-progress-downloading)");
+
+    table.updateRowData({
+        rowId: "torrent-1",
+        state: "stalledDL"
+    });
+    table.updateRow(tr, false);
+
+    expect(progressCell.firstElementChild).toBe(progressBar);
+    expect(progressBar.getValue()).toBe(50);
+    expect(barElement.style.backgroundColor).toBe("var(--color-progress-stalled)");
+
+    table.updateRowData({
+        rowId: "torrent-1",
+        state: "notARealState"
+    });
+    table.updateRow(tr, false);
+
+    expect(barElement.style.backgroundColor).toBe("var(--color-background-blue)");
+});

--- a/src/webui/www/test/private/progressbar.test.js
+++ b/src/webui/www/test/private/progressbar.test.js
@@ -1,0 +1,47 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Muhammad Hassan Raza <raihassanraza10@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+import { expect, test } from "vitest";
+
+import "../../private/scripts/misc.js";
+import "../../private/scripts/progressbar.js";
+
+test("Test ProgressBar dark background color setter", () => {
+    const progressBar = new window.qBittorrent.ProgressBar.ProgressBar(50);
+    const barElement = progressBar.shadowRoot.firstElementChild;
+    const trackElement = progressBar.shadowRoot.lastElementChild;
+    const trackBackground = trackElement.style.background;
+
+    expect(barElement.style.background).toBe("var(--color-background-blue)");
+    expect(trackBackground).toBe("var(--color-background-default)");
+
+    progressBar.setDarkBackgroundColor("rgb(255, 0, 0)");
+
+    expect(barElement.style.backgroundColor).toBe("rgb(255, 0, 0)");
+    expect(trackElement.style.background).toBe(trackBackground);
+});


### PR DESCRIPTION
Rebuilt this branch as just the progress-bar change. The unrelated palette, icon, sorting and table work from the earlier version is gone.

The filled part of a torrent progress bar now reflects its state. The unfilled track stays theme-neutral; thats intentional, and the test checks it. State is a dependency of the progress column, so a state-only update recolors an existing bar.

Every state currently sent by the backend is handled. Unknown values keep the normal blue color.

WebUI tests and lint pass locally.