### PR TITLE
Reject tracker URLs with invalid schemes

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -659,7 +659,10 @@ QList<TrackerEntryStatus> TorrentImpl::trackers() const
 
 void TorrentImpl::addTrackers(QList<TrackerEntry> trackers)
 {
-    trackers.removeIf([](const TrackerEntry &trackerEntry) { return trackerEntry.url.isEmpty(); });
+    trackers.removeIf([](const TrackerEntry &trackerEntry)
+    {
+        return trackerEntry.url.isEmpty() || !isValidTrackerUrl(trackerEntry.url);
+    });
 
     QSet<TrackerEntry> currentTrackerSet;
     currentTrackerSet.reserve(m_trackerEntryStatuses.size());
@@ -709,7 +712,10 @@ void TorrentImpl::removeTrackers(const QStringList &trackers)
 
 void TorrentImpl::replaceTrackers(QList<TrackerEntry> trackers)
 {
-    trackers.removeIf([](const TrackerEntry &trackerEntry) { return trackerEntry.url.isEmpty(); });
+    trackers.removeIf([](const TrackerEntry &trackerEntry)
+    {
+        return trackerEntry.url.isEmpty() || !isValidTrackerUrl(trackerEntry.url);
+    });
 
     // Filter out duplicate trackers
     const auto uniqueTrackers = QSet<TrackerEntry>(trackers.cbegin(), trackers.cend());

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -31,7 +31,19 @@
 
 #include <QHash>
 #include <QList>
+#include <QString>
 #include <QStringView>
+#include <QUrl>
+
+bool BitTorrent::isValidTrackerUrl(const QStringView url)
+{
+    const QUrl qurl(url.toString());
+    if (!qurl.isValid() || qurl.host().isEmpty())
+        return false;
+    const QString scheme = qurl.scheme().toLower();
+    return (scheme == u"http") || (scheme == u"https")
+        || (scheme == u"udp") || (scheme == u"wss");
+}
 
 QList<BitTorrent::TrackerEntry> BitTorrent::parseTrackerEntries(const QStringView str)
 {
@@ -52,7 +64,8 @@ QList<BitTorrent::TrackerEntry> BitTorrent::parseTrackerEntries(const QStringVie
             continue;
         }
 
-        entries.append({tracker.toString(), trackerTier});
+        if (isValidTrackerUrl(tracker))
+            entries.append({tracker.toString(), trackerTier});
     }
 
     return entries;

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -42,6 +42,7 @@ namespace BitTorrent
         int tier = 0;
     };
 
+    bool isValidTrackerUrl(QStringView url);
     QList<TrackerEntry> parseTrackerEntries(QStringView str);
 
     bool operator==(const TrackerEntry &left, const TrackerEntry &right);

--- a/test/testbittorrenttrackerentry.cpp
+++ b/test/testbittorrenttrackerentry.cpp
@@ -44,6 +44,23 @@ public:
     TestBittorrentTrackerEntry() = default;
 
 private slots:
+    void testIsValidTrackerUrl() const
+    {
+        // Valid tracker URLs
+        QVERIFY(BitTorrent::isValidTrackerUrl(u"http://tracker.example.com/announce"));
+        QVERIFY(BitTorrent::isValidTrackerUrl(u"https://tracker.example.com:8080/announce"));
+        QVERIFY(BitTorrent::isValidTrackerUrl(u"udp://tracker.opentrackr.org:1337/announce"));
+        QVERIFY(BitTorrent::isValidTrackerUrl(u"wss://tracker.webtorrent.io"));
+
+        // Invalid tracker URLs
+        QVERIFY(!BitTorrent::isValidTrackerUrl(u""));
+        QVERIFY(!BitTorrent::isValidTrackerUrl(u"ftp://tracker.example.com/announce"));
+        QVERIFY(!BitTorrent::isValidTrackerUrl(u"magnet:?xt=urn:btih:abc123"));
+        QVERIFY(!BitTorrent::isValidTrackerUrl(u"http://"));  // no host
+        QVERIFY(!BitTorrent::isValidTrackerUrl(u"<!DOCTYPE html><html>"));
+        QVERIFY(!BitTorrent::isValidTrackerUrl(u"just plain text"));
+    }
+
     void testParseTrackerEntries() const
     {
         using Entries = QList<BitTorrent::TrackerEntry>;


### PR DESCRIPTION
When a magnet link's `tr=` parameter contains garbage (e.g. URL-encoded HTML), qBittorrent was silently adding those strings as tracker entries, showing "Unsupported URL protocol" in the Trackers tab.

Filter out any tracker URL whose scheme is not one of the valid BitTorrent tracker protocols: http, https, udp, wss.

Closes #23937.