### PR TITLE
Adding the GoodSamaritan feature

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -211,6 +211,8 @@ namespace BitTorrent
 
         virtual QString getDHTBootstrapNodes() const = 0;
         virtual void setDHTBootstrapNodes(const QString &nodes) = 0;
+        virtual int goodSamaritanMinSeeders() const = 0;
+        virtual void setGoodSamaritanMinSeeders(int minSeeders) = 0;
         virtual bool isDHTEnabled() const = 0;
         virtual void setDHTEnabled(bool enabled) = 0;
         virtual bool isLSDEnabled() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -441,6 +441,7 @@ QStringList Session::expandCategory(const QString &category)
 SessionImpl::SessionImpl(QObject *parent)
     : Session(parent)
     , m_DHTBootstrapNodes(BITTORRENT_SESSION_KEY(u"DHTBootstrapNodes"_s), DEFAULT_DHT_BOOTSTRAP_NODES)
+    , m_goodSamaritanMinSeeders(BITTORRENT_SESSION_KEY(u"GoodSamaritanMinSeeders"_s), 15)
     , m_isDHTEnabled(BITTORRENT_SESSION_KEY(u"DHTEnabled"_s), true)
     , m_isLSDEnabled(BITTORRENT_SESSION_KEY(u"LSDEnabled"_s), true)
     , m_isPeXEnabled(BITTORRENT_SESSION_KEY(u"PeXEnabled"_s), true)
@@ -759,6 +760,24 @@ void SessionImpl::setDHTBootstrapNodes(const QString &nodes)
 
     m_DHTBootstrapNodes = nodes;
     configureDeferred();
+}
+
+int SessionImpl::goodSamaritanMinSeeders() const
+{
+    return m_goodSamaritanMinSeeders;
+}
+
+void SessionImpl::setGoodSamaritanMinSeeders(int minSeeders)
+{
+    if (minSeeders != m_goodSamaritanMinSeeders)
+    {
+        m_goodSamaritanMinSeeders = minSeeders;
+        if (minSeeders <= 0)
+            LogMsg(tr("[GoodSamaritan] Disabled."), Log::INFO);
+        else
+            LogMsg(tr("[GoodSamaritan] Threshold set to %1 seeder(s).").arg(minSeeders), Log::INFO);
+        updateSeedingLimitTimer();
+    }
 }
 
 bool SessionImpl::isDHTEnabled() const
@@ -2379,6 +2398,31 @@ void SessionImpl::processTorrentShareLimits(TorrentImpl *torrent)
     if (!torrent->isFinished() || torrent->isForced())
         return;
 
+    // GoodSamaritan: for stopped finished torrents, scrape the tracker so
+    // num_complete stays fresh, then resume if the swarm is below the threshold.
+    // Active torrents get fresh data via normal announces so only stopped ones need scraping.
+    const int gsThreshold = goodSamaritanMinSeeders();
+    if (gsThreshold > 0 && torrent->isStopped())
+    {
+        const int totalSeeders = torrent->totalSeedsCount();
+        // Fire a scrape; the reply will update num_complete for the next evaluation.
+        torrent->nativeHandle().scrape_tracker();
+
+        if (totalSeeders < 0)
+        {
+            // No scrape reply yet — will have data next tick.
+            return;
+        }
+        if (totalSeeders < gsThreshold)
+        {
+            LogMsg(tr("[GoodSamaritan] Resuming \"%1\" — swarm has only %2 seeder(s), below the minimum threshold of %3. (ratio: %4)")
+                .arg(torrent->name()).arg(totalSeeders).arg(gsThreshold)
+                .arg(QString::number(torrent->realRatio(), 'f', 2)));
+            torrent->start();
+        }
+        return;
+    }
+
     const qreal ratioLimit = torrent->effectiveRatioLimit();
     const int seedingTimeLimit = torrent->effectiveSeedingTimeLimit();
     const int inactiveSeedingTimeLimit = torrent->effectiveInactiveSeedingTimeLimit();
@@ -2407,6 +2451,19 @@ void SessionImpl::processTorrentShareLimits(TorrentImpl *torrent)
 
     if (reached)
     {
+        // GoodSamaritan: keep contributing past share limits if the swarm still
+        // needs seeders. Only log when we actually override the action.
+        if (gsThreshold > 0)
+        {
+            const int totalSeeders = torrent->totalSeedsCount();
+            if (totalSeeders >= 0 && totalSeeders < gsThreshold)
+            {
+                LogMsg(tr("[GoodSamaritan] Overriding share limit for \"%1\": swarm has only %2 seeder(s) (threshold: %3).")
+                    .arg(torrent->name()).arg(totalSeeders).arg(gsThreshold));
+                return;
+            }
+        }
+
         const QString torrentName = tr("Torrent: \"%1\".").arg(torrent->name());
         const ShareLimitAction shareLimitAction = torrent->effectiveShareLimitAction();
 
@@ -5242,7 +5299,8 @@ void SessionImpl::updateSeedingLimitTimer()
 {
     if ((globalMaxRatio() == NO_RATIO_LIMIT) && !hasPerTorrentRatioLimit()
         && (globalMaxSeedingMinutes() == NO_SEEDING_TIME_LIMIT) && !hasPerTorrentSeedingTimeLimit()
-        && (globalMaxInactiveSeedingMinutes() == NO_SEEDING_TIME_LIMIT) && !hasPerTorrentInactiveSeedingTimeLimit())
+        && (globalMaxInactiveSeedingMinutes() == NO_SEEDING_TIME_LIMIT) && !hasPerTorrentInactiveSeedingTimeLimit()
+        && (goodSamaritanMinSeeders() <= 0))
     {
         if (m_seedingLimitTimer->isActive())
             m_seedingLimitTimer->stop();

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -191,6 +191,8 @@ namespace BitTorrent
 
         QString getDHTBootstrapNodes() const override;
         void setDHTBootstrapNodes(const QString &nodes) override;
+        int goodSamaritanMinSeeders() const override;
+        void setGoodSamaritanMinSeeders(int minSeeders) override;
         bool isDHTEnabled() const override;
         void setDHTEnabled(bool enabled) override;
         bool isLSDEnabled() const override;
@@ -653,6 +655,7 @@ namespace BitTorrent
         void updateTrackersFromFile();
 
         CachedSettingValue<QString> m_DHTBootstrapNodes;
+        CachedSettingValue<int> m_goodSamaritanMinSeeders;
         CachedSettingValue<bool> m_isDHTEnabled;
         CachedSettingValue<bool> m_isLSDEnabled;
         CachedSettingValue<bool> m_isPeXEnabled;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -172,6 +172,7 @@ namespace
         PEER_TURNOVER_INTERVAL,
         REQUEST_QUEUE_SIZE,
         DHT_BOOTSTRAP_NODES,
+        GOOD_SAMARITAN_MIN_SEEDERS,
 #if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
         I2P_INBOUND_QUANTITY,
         I2P_OUTBOUND_QUANTITY,
@@ -372,6 +373,8 @@ void AdvancedSettings::saveAdvancedSettings() const
     session->setRequestQueueSize(m_spinBoxRequestQueueSize.value());
     // DHT bootstrap nodes
     session->setDHTBootstrapNodes(m_lineEditDHTBootstrapNodes.text());
+    // Good Samaritan
+    session->setGoodSamaritanMinSeeders(m_spinBoxGoodSamaritanMinSeeders.value());
 #if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     // I2P session options
     session->setI2PInboundQuantity(m_spinBoxI2PInboundQuantity.value());
@@ -978,6 +981,12 @@ void AdvancedSettings::loadAdvancedSettings()
     m_lineEditDHTBootstrapNodes.setText(session->getDHTBootstrapNodes());
     addRow(DHT_BOOTSTRAP_NODES, (tr("DHT bootstrap nodes") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#dht_bootstrap_nodes", u"(?)"))
         , &m_lineEditDHTBootstrapNodes);
+    // Good Samaritan
+    m_spinBoxGoodSamaritanMinSeeders.setMinimum(0);
+    m_spinBoxGoodSamaritanMinSeeders.setMaximum(std::numeric_limits<int>::max());
+    m_spinBoxGoodSamaritanMinSeeders.setSpecialValueText(tr("Disabled"));
+    m_spinBoxGoodSamaritanMinSeeders.setValue(session->goodSamaritanMinSeeders());
+    addRow(GOOD_SAMARITAN_MIN_SEEDERS, tr("Good Samaritan minimum seeders (0 = disabled)"), &m_spinBoxGoodSamaritanMinSeeders);
 #if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     // I2P session options
     m_spinBoxI2PInboundQuantity.setMinimum(1);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -74,7 +74,8 @@ private:
              m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxConnectionSpeed, m_spinBoxSocketSendBufferSize, m_spinBoxSocketReceiveBufferSize, m_spinBoxSocketBacklogSize,
              m_spinBoxAnnouncePort, m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout, m_spinBoxSessionShutdownTimeout,
-             m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize;
+             m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize,
+             m_spinBoxGoodSamaritanMinSeeders;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxReannounceWhenAddressChanged, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
               m_checkBoxTrackerPortForwarding, m_checkBoxIgnoreSSLErrors, m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers,

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -296,6 +296,7 @@ void AppController::preferencesAction()
 
     // Bittorrent
     // Privacy
+    data[u"good_samaritan_min_seeders"_s] = session->goodSamaritanMinSeeders();
     data[u"dht"_s] = session->isDHTEnabled();
     data[u"pex"_s] = session->isPeXEnabled();
     data[u"lsd"_s] = session->isLSDEnabled();
@@ -815,6 +816,8 @@ void AppController::setPreferencesAction()
 
     // Bittorrent
     // Privacy
+    if (hasKey(u"good_samaritan_min_seeders"_s))
+        session->setGoodSamaritanMinSeeders(it.value().toInt());
     if (hasKey(u"dht"_s))
         session->setDHTEnabled(it.value().toBool());
     if (hasKey(u"pex"_s))

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1373,6 +1373,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         <input type="text" id="pythonExecutablePath" class="pathFile" placeholder="QBT_TR((Auto detect if empty))QBT_TR[CONTEXT=OptionsDialog]" style="width: 15em;">
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <label for="goodSamaritanMinSeeders">QBT_TR(Good Samaritan minimum seeders (0 = disabled):)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="number" id="goodSamaritanMinSeeders" min="0" style="width: 6em;">
+                    </td>
+                </tr>
             </tbody>
         </table>
     </fieldset>
@@ -2688,6 +2696,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("appInstanceName").value = pref.app_instance_name;
                     document.getElementById("refreshInterval").value = pref.refresh_interval;
                     document.getElementById("resolvePeerHostNames").checked = pref.resolve_peer_host_names;
+                    document.getElementById("goodSamaritanMinSeeders").value = pref.good_samaritan_min_seeders;
                     document.getElementById("resolvePeerCountries").checked = pref.resolve_peer_countries;
                     document.getElementById("reannounceWhenAddressChanged").checked = pref.reannounce_when_address_changed;
                     document.getElementById("enableEmbeddedTracker").checked = pref.enable_embedded_tracker;
@@ -3176,6 +3185,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["app_instance_name"] = document.getElementById("appInstanceName").value;
             settings["refresh_interval"] = Number(document.getElementById("refreshInterval").value);
             settings["resolve_peer_host_names"] = document.getElementById("resolvePeerHostNames").checked;
+            settings["good_samaritan_min_seeders"] = Number(document.getElementById("goodSamaritanMinSeeders").value);
             settings["resolve_peer_countries"] = document.getElementById("resolvePeerCountries").checked;
             settings["reannounce_when_address_changed"] = document.getElementById("reannounceWhenAddressChanged").checked;
             settings["enable_embedded_tracker"] = document.getElementById("enableEmbeddedTracker").checked;


### PR DESCRIPTION
This is a feature for those of us who want to contribute back to other nice people that seeded when we needed them.

Its enabled by default and using default setting of 15.
This means that if you have a torrent in your possession that has less than 15 seeders, you will be good member of the community and automatically step in (even if you reached your global seed ratio).

If because of Good Samaritans like you the torrent has more than 15 seeders, then you treat it as any other torrent (so your global seed ratio or any other conditions apply).

IMO this is common sense default behavior that all of us should use. I had many torrents that i wanted that were dead, I'd keep them in the client for days in hopes for someone to seed... and sometimes that one guy who turned his computer helped me out and seeded the content i wanted. Its only fair to contribute back.

I'm convinced most people are nice and would do it if they knew someone needed the torrent they had, but we all have busy lives and don't micromanage what torrents seed which ones don't. 
<img width="723" height="410" alt="Screenshot 2026-03-13 at 21 30 59" src="https://github.com/user-attachments/assets/60ec940b-f29b-4305-87d8-b7c86b3f8d4e" />
