### PR TITLE
GHA CI: use EditorConfig to check for code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,9 +6,38 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 4
+indent_size = unset  # set it specifically for each language
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[**.yml]
+[**.css]
+indent_size = 4
+
+[**.json]
 indent_size = 2
+
+[**.plist]
+indent_style = tab
+
+[**.{yaml,yml}]
+indent_size = 2
+
+[dist/windows/license.txt]
+end_of_line = crlf
+
+[test/testdata/crlf.txt]
+end_of_line = crlf
+
+# ignore paths
+[dist/windows/3rdparty/*,
+  src/base/3rdparty/*,
+  src/lang/*.ts,
+  src/webui/www/private/css/lib/*,
+  src/webui/www/private/scripts/lib/*,
+  src/webui/www/translations/*.ts]
+charset = unset
+end_of_line = unset
+indent_style = unset
+indent_size = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,30 +27,10 @@ repos:
     - id: check-yaml
       name: Check YAML files
 
-    - id: fix-byte-order-marker
-      name: Check file encoding (UTF-8 without BOM)
-      exclude: |
-        (?x)^(
-          src/base/unicodestrings.h
-        )$
-
-    - id: mixed-line-ending
-      name: Check line ending character (LF)
-      args: ["--fix=lf"]
-      exclude: |
-        (?x)^(
-          src/base/3rdparty/expected.hpp |
-          src/webui/www/private/css/lib/.* |
-          src/webui/www/private/scripts/lib/.* |
-          dist/windows/license.txt |
-          test/testdata/crlf.txt
-        )$
-
     - id: end-of-file-fixer
       name: Check trailing newlines
       exclude: |
         (?x)^(
-          configure |
           src/webui/www/private/css/lib/.* |
           src/webui/www/private/scripts/lib/.* |
           test/testdata/crlf.txt
@@ -59,15 +39,11 @@ repos:
         - svg
         - ts
 
-    - id: trailing-whitespace
-      name: Check trailing whitespaces
-      exclude: |
-        (?x)^(
-          src/webui/www/private/css/lib/.* |
-          src/webui/www/private/scripts/lib/.*
-        )$
-      exclude_types:
-        - ts
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python.git
+    rev: 3.6.1
+    hooks:
+    - id: editorconfig-checker
+      name: Check code formatting (EditorConfig)
 
   - repo: https://github.com/codespell-project/codespell.git
     rev: v2.4.2


### PR DESCRIPTION
And remove some pre-commit hooks that has duplicate functionality with the EditorConfig checker.
