### PR TITLE
Put Email examples in placeholder text

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -544,8 +544,7 @@ void Preferences::setMailNotificationEnabled(const bool enabled)
 
 QString Preferences::getMailNotificationSender() const
 {
-    return value<QString>(u"Preferences/MailNotification/sender"_s
-        , u"qBittorrent_notification@example.com"_s);
+    return value<QString>(u"Preferences/MailNotification/sender"_s);
 }
 
 void Preferences::setMailNotificationSender(const QString &mail)
@@ -571,7 +570,7 @@ void Preferences::setMailNotificationEmail(const QString &mail)
 
 QString Preferences::getMailNotificationSMTP() const
 {
-    return value<QString>(u"Preferences/MailNotification/smtp_server"_s, u"smtp.changeme.com"_s);
+    return value<QString>(u"Preferences/MailNotification/smtp_server"_s);
 }
 
 void Preferences::setMailNotificationSMTP(const QString &smtpServer)

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1604,7 +1604,11 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   </widget>
                  </item>
                  <item row="0" column="1">
-                  <widget class="QLineEdit" name="senderEmailTxt"/>
+                  <widget class="QLineEdit" name="senderEmailTxt">
+                   <property name="placeholderText">
+                    <string notr="true">qBittorrent_notification@example.com</string>
+                   </property>
+                  </widget>
                  </item>
                  <item row="1" column="0">
                   <widget class="QLabel" name="label_2">
@@ -1627,7 +1631,11 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   </widget>
                  </item>
                  <item row="2" column="1">
-                  <widget class="QLineEdit" name="lineEditSmtpServer"/>
+                  <widget class="QLineEdit" name="lineEditSmtpServer">
+                   <property name="placeholderText">
+                    <string notr="true">smtp.example.com:465</string>
+                   </property>
+                  </widget>
                  </item>
                 </layout>
                </item>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -332,7 +332,7 @@
                         <label for="src_email_txt">QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="src_email_txt">
+                        <input type="text" id="src_email_txt" placeholder="qBittorrent_notification@example.com">
                     </td>
                 </tr>
                 <tr>
@@ -348,7 +348,7 @@
                         <label for="smtp_server_txt">QBT_TR(SMTP server:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="smtp_server_txt">
+                        <input type="text" id="smtp_server_txt" placeholder="smtp.example.com:465">
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
The examples are for demonstration purpose only and we do not wish the user to accidentally really sent an email to the prefilled server (in the case of misconfiguration).
Note that the example server (`changeme.com`) is actually registered so it is changed to `example.com`. See: https://en.wikipedia.org/wiki/Example.com#Purpose

Before:
<img width="602" height="116" alt="before" src="https://github.com/user-attachments/assets/485a573a-8aaf-4063-8131-e6c20e8a3bea" />

After:
<img width="600" height="116" alt="after" src="https://github.com/user-attachments/assets/a2912858-5a00-4421-989d-9cc55736b47a" />

