### PR TITLE
WebUI: Add share limit controls to RSS auto-downloader

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -35,6 +35,7 @@
     <script defer src="scripts/lib/clipboard-copy.js"></script>
     <script defer src="scripts/filesystem.js?v=${CACHEID}"></script>
     <script defer src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/rss-rule-share-limit.js?v=${CACHEID}"></script>
     <script defer src="scripts/progressbar.js?v=${CACHEID}"></script>
     <script defer src="scripts/piecesbar.js?v=${CACHEID}"></script>
     <script defer src="scripts/file-tree.js?v=${CACHEID}"></script>

--- a/src/webui/www/private/scripts/rss-rule-share-limit.js
+++ b/src/webui/www/private/scripts/rss-rule-share-limit.js
@@ -1,0 +1,378 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Muhammad Hassan Raza <raihassanraza10@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+"use strict";
+
+window.qBittorrent ??= {};
+window.qBittorrent.RssRuleShareLimit ??= (() => {
+    const UseGlobalLimit = -2;
+    const NoLimit = -1;
+
+    const Mode = Object.freeze({
+        Default: "default",
+        Set: "set",
+        Unlimited: "unlimited"
+    });
+
+    const Action = Object.freeze({
+        Default: "Default",
+        EnableSuperSeeding: "EnableSuperSeeding",
+        Remove: "Remove",
+        RemoveWithContent: "RemoveWithContent",
+        Stop: "Stop"
+    });
+
+    const ShareLimitsMode = Object.freeze({
+        Default: "Default",
+        MatchAll: "MatchAll",
+        MatchAny: "MatchAny"
+    });
+
+    const exports = () => {
+        return {
+            Action: Action,
+            Controller: Controller,
+            Mode: Mode,
+            NoLimit: NoLimit,
+            ShareLimitsMode: ShareLimitsMode,
+            UseGlobalLimit: UseGlobalLimit,
+            actionFromGlobalPreference: actionFromGlobalPreference,
+            defaultValueText: defaultValueText,
+            effectiveShareLimits: effectiveShareLimits,
+            limitFromMode: limitFromMode,
+            modeFromLimit: modeFromLimit,
+            parentCategoryName: parentCategoryName
+        };
+    };
+
+    const actionFromGlobalPreference = (preferenceValue) => {
+        switch (Number(preferenceValue)) {
+            case 0:
+                return Action.Stop;
+            case 1:
+                return Action.Remove;
+            case 2:
+                return Action.EnableSuperSeeding;
+            case 3:
+                return Action.RemoveWithContent;
+        }
+
+        return Action.Default;
+    };
+
+    const defaultValueText = ({ categoryName, effectiveValue, defaultValue, valueText, defaultText, fromCategoryText, defaultWithValueText, fromCategoryWithValueText }) => {
+        const normalizedCategoryName = String(categoryName ?? "");
+        if (effectiveValue === defaultValue)
+            return (normalizedCategoryName === "") ? defaultText : fromCategoryText;
+
+        const effectiveValueText = valueText(effectiveValue);
+
+        if (normalizedCategoryName === "")
+            return effectiveValueText ? defaultWithValueText.replace("%1", effectiveValueText) : defaultText;
+
+        return effectiveValueText ? fromCategoryWithValueText.replace("%1", effectiveValueText) : fromCategoryText;
+    };
+
+    const effectiveShareLimits = (categoryList, categoryName, globalShareLimits) => {
+        const result = { ...globalShareLimits };
+        const categoryNames = [];
+        for (let currentCategoryName = String(categoryName ?? ""); currentCategoryName !== ""; currentCategoryName = parentCategoryName(currentCategoryName))
+            categoryNames.push(currentCategoryName);
+
+        const fields = [
+            ["ratio_limit", UseGlobalLimit],
+            ["seeding_time_limit", UseGlobalLimit],
+            ["inactive_seeding_time_limit", UseGlobalLimit],
+            ["share_limits_mode", ShareLimitsMode.Default],
+            ["share_limit_action", Action.Default]
+        ];
+
+        for (const currentCategoryName of categoryNames.reverse()) {
+            const category = categoryList[currentCategoryName];
+            if (category === undefined)
+                continue;
+
+            for (const [field, defaultValue] of fields) {
+                const value = category[field];
+                if ((value !== undefined) && (value !== defaultValue))
+                    result[field] = value;
+            }
+        }
+
+        return result;
+    };
+
+    const limitFromMode = (mode, value) => {
+        switch (mode) {
+            case Mode.Default:
+                return UseGlobalLimit;
+            case Mode.Unlimited:
+                return NoLimit;
+            case Mode.Set:
+                return Number(value);
+        }
+
+        return UseGlobalLimit;
+    };
+
+    const modeFromLimit = (limitValue) => {
+        if (limitValue === UseGlobalLimit)
+            return Mode.Default;
+        if (limitValue === NoLimit)
+            return Mode.Unlimited;
+
+        return Mode.Set;
+    };
+
+    const parentCategoryName = (categoryName) => {
+        const separatorIndex = categoryName.lastIndexOf("/");
+        return (separatorIndex >= 0) ? categoryName.slice(0, separatorIndex) : "";
+    };
+
+    class Controller {
+        constructor(document, getPreferences, texts) {
+            this.getPreferences = getPreferences;
+            this.texts = texts;
+            this.categoryList = {};
+
+            this.actionElement = document.getElementById("ruleShareLimitAction");
+            this.inactiveMinutesElement = document.getElementById("ruleShareLimitInactiveMinutes");
+            this.inactiveMinutesModeElement = document.getElementById("ruleShareLimitInactiveMinutesMode");
+            this.ratioElement = document.getElementById("ruleShareLimitRatio");
+            this.ratioModeElement = document.getElementById("ruleShareLimitRatioMode");
+            this.totalMinutesElement = document.getElementById("ruleShareLimitTotalMinutes");
+            this.totalMinutesModeElement = document.getElementById("ruleShareLimitTotalMinutesMode");
+            this.shareLimitsModeElement = document.getElementById("ruleShareLimitsMode");
+            this.saveButton = document.getElementById("saveButton");
+            this.defaultText = this.ratioModeElement.options[0].text;
+
+            this.limitControls = [{
+                    assignedValue: "1.00",
+                    field: "ratio_limit",
+                    formatter: (value) => Number(value).toFixed(2),
+                    initialAssignedValue: "1.00",
+                    modeElement: this.ratioModeElement,
+                    previousMode: Mode.Default,
+                    valueElement: this.ratioElement
+                },
+                {
+                    assignedValue: "1440",
+                    field: "seeding_time_limit",
+                    formatter: String,
+                    initialAssignedValue: "1440",
+                    modeElement: this.totalMinutesModeElement,
+                    previousMode: Mode.Default,
+                    valueElement: this.totalMinutesElement
+                },
+                {
+                    assignedValue: "1440",
+                    field: "inactive_seeding_time_limit",
+                    formatter: String,
+                    initialAssignedValue: "1440",
+                    modeElement: this.inactiveMinutesModeElement,
+                    previousMode: Mode.Default,
+                    valueElement: this.inactiveMinutesElement
+                }
+            ];
+
+            for (const control of this.limitControls) {
+                control.modeElement.addEventListener("change", () => {
+                    if (control.previousMode === Mode.Set)
+                        control.assignedValue = control.valueElement.value;
+                    control.previousMode = control.modeElement.value;
+                    this.displayLimitValue(control);
+                    this.updateState();
+                });
+            }
+
+            this.ratioElement.addEventListener("input", () => this.updateState());
+            this.totalMinutesElement.addEventListener("input", () => this.updateState());
+            this.inactiveMinutesElement.addEventListener("input", () => this.updateState());
+
+            this.setEnabled(false);
+            this.reset();
+        }
+
+        defaultValueText(categoryName, effectiveValue, defaultValue, selectElement) {
+            return defaultValueText({
+                categoryName: categoryName,
+                effectiveValue: effectiveValue,
+                defaultValue: defaultValue,
+                valueText: (value) => this.selectValueText(selectElement, value),
+                defaultText: this.defaultText,
+                fromCategoryText: this.texts.fromCategory,
+                defaultWithValueText: this.texts.defaultWithValue,
+                fromCategoryWithValueText: this.texts.fromCategoryWithValue
+            });
+        }
+
+        displayLimitValue(control) {
+            if (control.modeElement.value === Mode.Set)
+                control.valueElement.value = control.assignedValue;
+            else if ((control.modeElement.value === Mode.Default) && (this.defaultShareLimits[control.field] >= 0))
+                control.valueElement.value = control.formatter(this.defaultShareLimits[control.field]);
+            else
+                control.valueElement.value = "";
+        }
+
+        globalShareLimits() {
+            const preferences = this.getPreferences();
+            return {
+                ratio_limit: Number(preferences.max_ratio),
+                seeding_time_limit: Number(preferences.max_seeding_time),
+                inactive_seeding_time_limit: Number(preferences.max_inactive_seeding_time),
+                share_limits_mode: String(preferences.share_limits_mode),
+                share_limit_action: actionFromGlobalPreference(preferences.max_ratio_act)
+            };
+        }
+
+        isValid() {
+            return this.isValidMode(this.ratioModeElement, this.ratioElement)
+                && this.isValidMode(this.totalMinutesModeElement, this.totalMinutesElement)
+                && this.isValidMode(this.inactiveMinutesModeElement, this.inactiveMinutesElement);
+        }
+
+        isValidMode(modeElement, valueElement) {
+            if (modeElement.value !== Mode.Set)
+                return true;
+
+            return (valueElement.value !== "") && valueElement.validity.valid;
+        }
+
+        load(torrentParams) {
+            const categoryName = String(torrentParams.category ?? "");
+            const ratioLimit = Number(torrentParams.ratio_limit ?? UseGlobalLimit);
+            const seedingTimeLimit = Number(torrentParams.seeding_time_limit ?? UseGlobalLimit);
+            const inactiveSeedingTimeLimit = Number(torrentParams.inactive_seeding_time_limit ?? UseGlobalLimit);
+            const shareLimitsMode = String(torrentParams.share_limits_mode ?? ShareLimitsMode.Default);
+
+            this.reset();
+            this.updateDefaults(categoryName);
+            this.loadLimit(this.limitControls[0], ratioLimit);
+            this.loadLimit(this.limitControls[1], seedingTimeLimit);
+            this.loadLimit(this.limitControls[2], inactiveSeedingTimeLimit);
+
+            this.shareLimitsModeElement.value = shareLimitsMode;
+            if (this.shareLimitsModeElement.value === "")
+                this.shareLimitsModeElement.value = ShareLimitsMode.Default;
+
+            this.actionElement.value = (torrentParams.share_limit_action ?? Action.Default);
+            if (this.actionElement.value === "")
+                this.actionElement.value = Action.Default;
+
+            this.updateState();
+        }
+
+        loadLimit(control, limitValue) {
+            control.modeElement.value = modeFromLimit(limitValue);
+            control.previousMode = control.modeElement.value;
+            if (control.modeElement.value === Mode.Set)
+                control.assignedValue = control.formatter(limitValue);
+            this.displayLimitValue(control);
+        }
+
+        reset() {
+            for (const control of this.limitControls) {
+                control.assignedValue = control.initialAssignedValue;
+                control.modeElement.value = Mode.Default;
+                control.previousMode = Mode.Default;
+            }
+            this.shareLimitsModeElement.value = ShareLimitsMode.Default;
+            this.actionElement.value = Action.Default;
+
+            this.updateDefaults("");
+            this.updateState();
+        }
+
+        save(torrentParams) {
+            if (!this.isValid())
+                return false;
+
+            torrentParams.ratio_limit = limitFromMode(this.ratioModeElement.value, this.ratioElement.value);
+            torrentParams.seeding_time_limit = limitFromMode(this.totalMinutesModeElement.value, this.totalMinutesElement.value);
+            torrentParams.inactive_seeding_time_limit = limitFromMode(this.inactiveMinutesModeElement.value, this.inactiveMinutesElement.value);
+            torrentParams.share_limits_mode = this.shareLimitsModeElement.value;
+            torrentParams.share_limit_action = this.actionElement.value;
+
+            return true;
+        }
+
+        selectValueText(selectElement, value) {
+            for (const option of selectElement.options) {
+                if (option.value === value)
+                    return option.text;
+            }
+
+            return "";
+        }
+
+        setCategories(categoryList) {
+            this.categoryList = categoryList;
+        }
+
+        setEnabled(enabled) {
+            this.ratioModeElement.disabled = !enabled;
+            this.totalMinutesModeElement.disabled = !enabled;
+            this.inactiveMinutesModeElement.disabled = !enabled;
+            this.shareLimitsModeElement.disabled = !enabled;
+
+            this.updateState();
+        }
+
+        updateDefaults(categoryName) {
+            const normalizedCategoryName = String(categoryName ?? "");
+            const defaultModeText = (normalizedCategoryName === "") ? this.defaultText : this.texts.fromCategory;
+            this.defaultShareLimits = effectiveShareLimits(this.categoryList, normalizedCategoryName, this.globalShareLimits());
+
+            this.ratioModeElement.options[0].text = defaultModeText;
+            this.totalMinutesModeElement.options[0].text = defaultModeText;
+            this.inactiveMinutesModeElement.options[0].text = defaultModeText;
+            this.shareLimitsModeElement.options[0].text = this.defaultValueText(normalizedCategoryName, this.defaultShareLimits.share_limits_mode, ShareLimitsMode.Default, this.shareLimitsModeElement);
+            this.actionElement.options[0].text = this.defaultValueText(normalizedCategoryName, this.defaultShareLimits.share_limit_action, Action.Default, this.actionElement);
+
+            for (const control of this.limitControls) {
+                if (control.modeElement.value === Mode.Default)
+                    this.displayLimitValue(control);
+            }
+        }
+
+        updateState() {
+            const controlsEnabled = !this.ratioModeElement.disabled;
+
+            this.ratioElement.disabled = this.ratioModeElement.disabled || (this.ratioModeElement.value !== Mode.Set);
+            this.totalMinutesElement.disabled = this.totalMinutesModeElement.disabled || (this.totalMinutesModeElement.value !== Mode.Set);
+            this.inactiveMinutesElement.disabled = this.inactiveMinutesModeElement.disabled || (this.inactiveMinutesModeElement.value !== Mode.Set);
+            this.actionElement.disabled = !controlsEnabled;
+
+            this.saveButton.disabled = !controlsEnabled || !this.isValid();
+        }
+    }
+
+    return exports();
+})();
+Object.freeze(window.qBittorrent.RssRuleShareLimit);

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -126,6 +126,18 @@
         background-image: url('images/edit-clear.svg');
     }
 
+    .rssRuleShareLimitHeader {
+        margin-top: 5px;
+    }
+
+    #ruleShareLimitTable td {
+        padding-bottom: 5px;
+    }
+
+    #ruleShareLimitTable input[type="number"] {
+        width: 6em;
+    }
+
 </style>
 
 <div id="RssDownloader" class="RssDownloader">
@@ -281,6 +293,84 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     </tr>
                 </tbody>
             </table>
+            <div class="formRow rssRuleShareLimitHeader">
+                <b>QBT_TR(Torrent Upload/Download Ratio Limiting)QBT_TR[CONTEXT=UpDownRatioDialog]</b>
+            </div>
+            <table class="fullWidth" id="ruleShareLimitTable">
+                <tbody>
+                    <tr>
+                        <td>
+                            <label class="noWrap" id="ruleShareLimitRatioLabel" for="ruleShareLimitRatioMode">QBT_TR(Ratio:)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+                        </td>
+                        <td>
+                            <select disabled id="ruleShareLimitRatioMode">
+                                <option value="default">QBT_TR(Default)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="unlimited">QBT_TR(Unlimited)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="set">QBT_TR(Set to)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                            </select>
+                        </td>
+                        <td>
+                            <input disabled type="number" id="ruleShareLimitRatio" value="1.00" step=".01" min="0" aria-labelledby="ruleShareLimitRatioLabel">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label class="noWrap" id="ruleShareLimitTotalMinutesLabel" for="ruleShareLimitTotalMinutesMode">QBT_TR(Seeding time:)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+                        </td>
+                        <td>
+                            <select disabled id="ruleShareLimitTotalMinutesMode">
+                                <option value="default">QBT_TR(Default)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="unlimited">QBT_TR(Unlimited)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="set">QBT_TR(Set to)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                            </select>
+                        </td>
+                        <td>
+                            <input disabled type="number" id="ruleShareLimitTotalMinutes" value="1440" step="1" min="0" aria-labelledby="ruleShareLimitTotalMinutesLabel">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label class="noWrap" id="ruleShareLimitInactiveMinutesLabel" for="ruleShareLimitInactiveMinutesMode">QBT_TR(Inactive seeding time:)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+                        </td>
+                        <td>
+                            <select disabled id="ruleShareLimitInactiveMinutesMode">
+                                <option value="default">QBT_TR(Default)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="unlimited">QBT_TR(Unlimited)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="set">QBT_TR(Set to)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                            </select>
+                        </td>
+                        <td>
+                            <input disabled type="number" id="ruleShareLimitInactiveMinutes" value="1440" step="1" min="0" aria-labelledby="ruleShareLimitInactiveMinutesLabel">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label class="noWrap" for="ruleShareLimitsMode">QBT_TR(Mode:)QBT_TR[CONTEXT=TorrentShareLimitsWidget]</label>
+                        </td>
+                        <td colspan="2" class="fullWidth">
+                            <select disabled id="ruleShareLimitsMode" class="fullWidth">
+                                <option value="Default">QBT_TR(Default)QBT_TR[CONTEXT=TorrentShareLimitsWidget]</option>
+                                <option value="MatchAny">QBT_TR(Match any limit)QBT_TR[CONTEXT=TorrentShareLimitsWidget]</option>
+                                <option value="MatchAll">QBT_TR(Match all the limits)QBT_TR[CONTEXT=TorrentShareLimitsWidget]</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label class="noWrap" id="ruleShareLimitActionLabel" for="ruleShareLimitAction">QBT_TR(Action when the limit is reached)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+                        </td>
+                        <td colspan="2" class="fullWidth">
+                            <select disabled id="ruleShareLimitAction" class="fullWidth" aria-labelledby="ruleShareLimitActionLabel">
+                                <option value="Default">QBT_TR(Default)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="Stop">QBT_TR(Stop torrent)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="Remove">QBT_TR(Remove torrent)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="RemoveWithContent">QBT_TR(Remove torrent and its content)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                                <option value="EnableSuperSeeding">QBT_TR(Enable super seeding for torrent)QBT_TR[CONTEXT=UpDownRatioDialog]</option>
+                            </select>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </fieldset>
         <fieldset class="settings" id="rssDownloaderFeeds">
             <legend>QBT_TR(Apply Rule to Feeds:)QBT_TR[CONTEXT=AutomatedRssDownloader]</legend>
@@ -356,13 +446,19 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const rssDownloaderFeedSelectionTable = new window.qBittorrent.DynamicTable.RssDownloaderFeedSelectionTable();
         const rssDownloaderArticlesTable = new window.qBittorrent.DynamicTable.RssDownloaderArticlesTable();
 
-        let rulesList = {};
         let feedList = [];
+        let rulesList = {};
+
+        const ruleShareLimit = new window.qBittorrent.RssRuleShareLimit.Controller(
+            document,
+            () => window.parent.qBittorrent.Cache.preferences.get(), {
+                fromCategory: "QBT_TR(From category)QBT_TR[CONTEXT=TorrentShareLimitsWidget]",
+                defaultWithValue: "QBT_TR(Default (%1))QBT_TR[CONTEXT=TorrentShareLimitsWidget]",
+                fromCategoryWithValue: "QBT_TR(From category (%1))QBT_TR[CONTEXT=TorrentShareLimitsWidget]"
+            });
 
         const setup = () => {
-            const pref = window.parent.qBittorrent.Cache.preferences.get();
-
-            if (!pref.rss_auto_downloading_enabled)
+            if (!window.parent.qBittorrent.Cache.preferences.get().rss_auto_downloading_enabled)
                 document.getElementById("rssDownloaderDisabled").classList.remove("invisible");
 
             // recalculate height
@@ -434,6 +530,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                         return;
 
                     const responseJSON = await response.json();
+                    ruleShareLimit.setCategories(responseJSON);
 
                     const combobox = document.getElementById("assignCategoryCombobox");
                     for (const cat in responseJSON) {
@@ -444,6 +541,17 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                         option.text = option.value = cat;
                         combobox.add(option);
                     }
+
+                    const lastSelectedRow = rssDownloaderRulesTable.selectedRows.at(-1);
+                    if (lastSelectedRow === undefined)
+                        return;
+
+                    const ruleName = rssDownloaderRulesTable.getRow(lastSelectedRow).full_data.name;
+                    if (rulesList[ruleName] === undefined)
+                        return;
+
+                    combobox.value = rulesList[ruleName].torrentParams.category ? rulesList[ruleName].torrentParams.category : "";
+                    ruleShareLimit.updateDefaults(rulesList[ruleName].torrentParams.category);
                 });
             // get all rss feed
             const url = new URL("api/v2/rss/items", window.location);
@@ -473,6 +581,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 });
             document.getElementById("savetoDifferentDir").addEventListener("click", (event) => {
                 document.getElementById("saveToText").disabled = !event.target.checked;
+            });
+            document.getElementById("assignCategoryCombobox").addEventListener("change", (event) => {
+                ruleShareLimit.updateDefaults(event.target.value);
             });
             updateRulesList();
         };
@@ -660,6 +771,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     break;
             }
 
+            if (!ruleShareLimit.save(rulesList[rule].torrentParams))
+                return;
+
             fetch("api/v2/rss/setRule", {
                     method: "POST",
                     body: new URLSearchParams({
@@ -715,7 +829,6 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const showRule = (ruleName) => {
             if (ruleName === "") {
                 // disable all
-                document.getElementById("saveButton").disabled = true;
                 document.getElementById("useRegEx").disabled = true;
                 document.getElementById("mustContainText").disabled = true;
                 document.getElementById("mustNotContainText").disabled = true;
@@ -728,6 +841,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 document.getElementById("ignoreDaysValue").disabled = true;
                 document.getElementById("addStoppedCombobox").disabled = true;
                 document.getElementById("contentLayoutCombobox").disabled = true;
+                ruleShareLimit.setEnabled(false);
 
                 // reset all boxes
                 document.getElementById("useRegEx").checked = false;
@@ -743,6 +857,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 document.getElementById("lastMatchText").textContent = "QBT_TR(Last Match: Unknown)QBT_TR[CONTEXT=AutomatedRssDownloader]";
                 document.getElementById("addStoppedCombobox").value = "default";
                 document.getElementById("contentLayoutCombobox").value = "Default";
+                ruleShareLimit.reset();
                 rssDownloaderFeedSelectionTable.clear();
                 rssDownloaderArticlesTable.clear();
 
@@ -752,7 +867,6 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             }
             else {
                 // enable all
-                document.getElementById("saveButton").disabled = false;
                 document.getElementById("useRegEx").disabled = false;
                 document.getElementById("mustContainText").disabled = false;
                 document.getElementById("mustNotContainText").disabled = false;
@@ -764,6 +878,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 document.getElementById("ignoreDaysValue").disabled = false;
                 document.getElementById("addStoppedCombobox").disabled = false;
                 document.getElementById("contentLayoutCombobox").disabled = false;
+                ruleShareLimit.setEnabled(true);
 
                 // load rule settings
                 document.getElementById("useRegEx").checked = rulesList[ruleName].useRegex;
@@ -798,6 +913,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     document.getElementById("contentLayoutCombobox").value = "Default";
                 else
                     document.getElementById("contentLayoutCombobox").value = rulesList[ruleName].torrentParams.content_layout;
+                ruleShareLimit.load(rulesList[ruleName].torrentParams);
 
                 setElementTitles();
 

--- a/src/webui/www/test/private/resource-manifest.test.js
+++ b/src/webui/www/test/private/resource-manifest.test.js
@@ -1,0 +1,41 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Muhammad Hassan Raza <raihassanraza10@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+test("Test private index scripts are bundled as resources", () => {
+    const index = readFileSync("private/index.html", "utf8");
+    const resourceManifest = readFileSync("webui.qrc", "utf8");
+    const scriptPaths = [...index.matchAll(/<script[^>]+src="([^"?]+)(?:\?[^"]*)?"/g)]
+        .map((match) => match[1]);
+
+    for (const scriptPath of scriptPaths)
+        expect(resourceManifest, `${scriptPath} is missing from webui.qrc`).toContain(`<file>private/${scriptPath}</file>`);
+});

--- a/src/webui/www/test/private/rss-rule-share-limit.test.js
+++ b/src/webui/www/test/private/rss-rule-share-limit.test.js
@@ -1,0 +1,306 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Muhammad Hassan Raza <raihassanraza10@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+import { beforeEach, expect, test } from "vitest";
+
+await import("../../private/scripts/rss-rule-share-limit.js");
+
+const helper = window.qBittorrent.RssRuleShareLimit;
+
+const preferences = {
+    max_inactive_seeding_time: 30,
+    max_ratio: 1,
+    max_ratio_act: 0,
+    max_seeding_time: 60,
+    share_limits_mode: helper.ShareLimitsMode.MatchAny
+};
+
+const createController = () => {
+    document.body.innerHTML = `
+        <select id="ruleShareLimitRatioMode">
+            <option value="default">Default</option>
+            <option value="unlimited">Unlimited</option>
+            <option value="set">Set to</option>
+        </select>
+        <input type="number" id="ruleShareLimitRatio" value="1.00" step=".01" min="0">
+        <select id="ruleShareLimitTotalMinutesMode">
+            <option value="default">Default</option>
+            <option value="unlimited">Unlimited</option>
+            <option value="set">Set to</option>
+        </select>
+        <input type="number" id="ruleShareLimitTotalMinutes" value="1440" step="1" min="0">
+        <select id="ruleShareLimitInactiveMinutesMode">
+            <option value="default">Default</option>
+            <option value="unlimited">Unlimited</option>
+            <option value="set">Set to</option>
+        </select>
+        <input type="number" id="ruleShareLimitInactiveMinutes" value="1440" step="1" min="0">
+        <select id="ruleShareLimitsMode">
+            <option value="Default">Default</option>
+            <option value="MatchAny">Match any limit</option>
+            <option value="MatchAll">Match all the limits</option>
+        </select>
+        <select id="ruleShareLimitAction">
+            <option value="Default">Default</option>
+            <option value="Stop">Stop torrent</option>
+            <option value="Remove">Remove torrent</option>
+            <option value="RemoveWithContent">Remove torrent and its content</option>
+            <option value="EnableSuperSeeding">Enable super seeding for torrent</option>
+        </select>
+        <button id="saveButton">Save</button>
+    `;
+
+    return new helper.Controller(
+        document,
+        () => preferences, {
+            fromCategory: "From category",
+            defaultWithValue: "Default (%1)",
+            fromCategoryWithValue: "From category (%1)"
+        });
+};
+
+const changeValue = (element, value) => {
+    element.value = value;
+    element.dispatchEvent(new Event("change"));
+};
+
+beforeEach(() => {
+    document.body.replaceChildren();
+    Object.assign(preferences, {
+        max_inactive_seeding_time: 30,
+        max_ratio: 1,
+        max_ratio_act: 0,
+        max_seeding_time: 60,
+        share_limits_mode: helper.ShareLimitsMode.MatchAny
+    });
+});
+
+test("Test RSS share limit mode conversion", () => {
+    expect(helper.ShareLimitsMode).toStrictEqual({
+        Default: "Default",
+        MatchAll: "MatchAll",
+        MatchAny: "MatchAny"
+    });
+
+    expect(helper.modeFromLimit(helper.UseGlobalLimit)).toBe(helper.Mode.Default);
+    expect(helper.modeFromLimit(helper.NoLimit)).toBe(helper.Mode.Unlimited);
+    expect(helper.modeFromLimit(1.5)).toBe(helper.Mode.Set);
+
+    expect(helper.limitFromMode(helper.Mode.Default, 1.5)).toBe(helper.UseGlobalLimit);
+    expect(helper.limitFromMode(helper.Mode.Unlimited, 1.5)).toBe(helper.NoLimit);
+    expect(helper.limitFromMode(helper.Mode.Set, "2.25")).toBe(2.25);
+    expect(helper.limitFromMode("invalid", "2.25")).toBe(helper.UseGlobalLimit);
+});
+
+test("Test RSS share limit action from global preference", () => {
+    expect(helper.actionFromGlobalPreference(0)).toBe(helper.Action.Stop);
+    expect(helper.actionFromGlobalPreference(1)).toBe(helper.Action.Remove);
+    expect(helper.actionFromGlobalPreference(2)).toBe(helper.Action.EnableSuperSeeding);
+    expect(helper.actionFromGlobalPreference(3)).toBe(helper.Action.RemoveWithContent);
+    expect(helper.actionFromGlobalPreference(undefined)).toBe(helper.Action.Default);
+});
+
+test("Test RSS share limit category inheritance", () => {
+    const globalShareLimits = {
+        ratio_limit: 1,
+        seeding_time_limit: 60,
+        inactive_seeding_time_limit: 30,
+        share_limits_mode: helper.ShareLimitsMode.MatchAny,
+        share_limit_action: helper.Action.Stop
+    };
+    const categoryList = {
+        "Movies": {
+            ratio_limit: 2,
+            seeding_time_limit: helper.UseGlobalLimit,
+            inactive_seeding_time_limit: helper.NoLimit,
+            share_limits_mode: helper.ShareLimitsMode.MatchAll,
+            share_limit_action: helper.Action.Default
+        },
+        "Movies/Archive": {
+            ratio_limit: helper.UseGlobalLimit,
+            seeding_time_limit: 120,
+            inactive_seeding_time_limit: helper.UseGlobalLimit,
+            share_limits_mode: helper.ShareLimitsMode.Default,
+            share_limit_action: helper.Action.Remove
+        }
+    };
+
+    expect(helper.parentCategoryName("Shows/Drama/Season 1")).toBe("Shows/Drama");
+    expect(helper.parentCategoryName("Movies")).toBe("");
+    expect(helper.effectiveShareLimits(categoryList, "Movies/Archive/Old", globalShareLimits)).toStrictEqual({
+        ratio_limit: 2,
+        seeding_time_limit: 120,
+        inactive_seeding_time_limit: helper.NoLimit,
+        share_limits_mode: helper.ShareLimitsMode.MatchAll,
+        share_limit_action: helper.Action.Remove
+    });
+    expect(helper.effectiveShareLimits(categoryList, "", globalShareLimits)).toStrictEqual(globalShareLimits);
+});
+
+test("Test RSS share limit inherited value labels", () => {
+    const labels = {
+        [helper.Action.Default]: "",
+        [helper.Action.Stop]: "Stop torrent",
+        [helper.Action.Remove]: "Remove torrent"
+    };
+    const actionText = (action) => labels[action] ?? "";
+    const labelParams = {
+        defaultValue: helper.Action.Default,
+        valueText: actionText,
+        defaultText: "Default",
+        fromCategoryText: "From category",
+        defaultWithValueText: "Default (%1)",
+        fromCategoryWithValueText: "From category (%1)"
+    };
+
+    expect(helper.defaultValueText({
+        ...labelParams,
+        categoryName: "",
+        effectiveValue: helper.Action.Stop
+    })).toBe("Default (Stop torrent)");
+
+    expect(helper.defaultValueText({
+        ...labelParams,
+        categoryName: "Movies/Archive/Old",
+        effectiveValue: helper.Action.Remove
+    })).toBe("From category (Remove torrent)");
+
+    expect(helper.defaultValueText({
+        ...labelParams,
+        categoryName: "Uncategorized",
+        effectiveValue: helper.Action.Default
+    })).toBe("From category");
+
+    expect(helper.defaultValueText({
+        ...labelParams,
+        categoryName: "Movies",
+        effectiveValue: helper.ShareLimitsMode.MatchAll,
+        defaultValue: helper.ShareLimitsMode.Default,
+        valueText: (mode) => (mode === helper.ShareLimitsMode.MatchAll) ? "Match all the limits" : ""
+    })).toBe("From category (Match all the limits)");
+});
+
+test("RSS share limit controller preserves explicitly assigned values across mode changes", () => {
+    const controller = createController();
+    controller.setEnabled(true);
+    controller.load({
+        ratio_limit: 2.25,
+        seeding_time_limit: 90,
+        inactive_seeding_time_limit: 45
+    });
+
+    const ratioMode = document.getElementById("ruleShareLimitRatioMode");
+    const ratio = document.getElementById("ruleShareLimitRatio");
+    expect(ratioMode.value).toBe(helper.Mode.Set);
+    expect(ratio.value).toBe("2.25");
+
+    changeValue(ratioMode, helper.Mode.Unlimited);
+    expect(ratio.value).toBe("");
+    expect(ratio.disabled).toBe(true);
+
+    changeValue(ratioMode, helper.Mode.Default);
+    expect(ratio.value).toBe("1.00");
+
+    changeValue(ratioMode, helper.Mode.Set);
+    expect(ratio.value).toBe("2.25");
+    expect(ratio.disabled).toBe(false);
+});
+
+test("RSS share limit controller resets assigned state between rules and displays inherited limits", () => {
+    const controller = createController();
+    controller.setEnabled(true);
+    controller.setCategories({
+        Movies: {
+            ratio_limit: helper.NoLimit,
+            seeding_time_limit: 120,
+            inactive_seeding_time_limit: helper.UseGlobalLimit,
+            share_limits_mode: helper.ShareLimitsMode.MatchAll,
+            share_limit_action: helper.Action.Remove
+        }
+    });
+
+    controller.load({ ratio_limit: 8, category: "" });
+    expect(document.getElementById("ruleShareLimitRatio").value).toBe("8.00");
+
+    controller.load({
+        category: "Movies",
+        ratio_limit: helper.UseGlobalLimit,
+        seeding_time_limit: helper.UseGlobalLimit,
+        inactive_seeding_time_limit: helper.UseGlobalLimit
+    });
+
+    const ratioMode = document.getElementById("ruleShareLimitRatioMode");
+    const ratio = document.getElementById("ruleShareLimitRatio");
+    expect(ratioMode.options[0].text).toBe("From category");
+    expect(ratio.value).toBe("");
+    expect(document.getElementById("ruleShareLimitTotalMinutes").value).toBe("120");
+    expect(document.getElementById("ruleShareLimitInactiveMinutes").value).toBe("30");
+    expect(document.getElementById("ruleShareLimitsMode").options[0].text).toBe("From category (Match all the limits)");
+    expect(document.getElementById("ruleShareLimitAction").options[0].text).toBe("From category (Remove torrent)");
+
+    changeValue(ratioMode, helper.Mode.Set);
+    expect(ratio.value).toBe("1.00");
+});
+
+test("RSS share limit controller gates invalid saves and writes canonical torrent parameters", () => {
+    const controller = createController();
+    controller.setEnabled(true);
+
+    const totalMinutesMode = document.getElementById("ruleShareLimitTotalMinutesMode");
+    const totalMinutes = document.getElementById("ruleShareLimitTotalMinutes");
+    changeValue(totalMinutesMode, helper.Mode.Set);
+    totalMinutes.value = "";
+    totalMinutes.dispatchEvent(new Event("input"));
+
+    const untouchedParams = { category: "Movies" };
+    expect(document.getElementById("saveButton").disabled).toBe(true);
+    expect(controller.save(untouchedParams)).toBe(false);
+    expect(untouchedParams).toStrictEqual({ category: "Movies" });
+
+    totalMinutes.value = "90";
+    totalMinutes.dispatchEvent(new Event("input"));
+    changeValue(document.getElementById("ruleShareLimitRatioMode"), helper.Mode.Unlimited);
+    changeValue(document.getElementById("ruleShareLimitInactiveMinutesMode"), helper.Mode.Default);
+    document.getElementById("ruleShareLimitsMode").value = helper.ShareLimitsMode.MatchAll;
+    document.getElementById("ruleShareLimitAction").value = helper.Action.RemoveWithContent;
+
+    const torrentParams = { category: "Movies", tags: ["release"] };
+    expect(totalMinutes.validity.valid).toBe(true);
+    expect(totalMinutesMode.disabled).toBe(false);
+    expect(document.getElementById("saveButton").disabled).toBe(false);
+    expect(controller.save(torrentParams)).toBe(true);
+    expect(torrentParams).toStrictEqual({
+        category: "Movies",
+        tags: ["release"],
+        ratio_limit: helper.NoLimit,
+        seeding_time_limit: 90,
+        inactive_seeding_time_limit: helper.UseGlobalLimit,
+        share_limits_mode: helper.ShareLimitsMode.MatchAll,
+        share_limit_action: helper.Action.RemoveWithContent
+    });
+});

--- a/src/webui/www/webui.qrc
+++ b/src/webui/www/webui.qrc
@@ -415,6 +415,7 @@
         <file>private/scripts/prop-trackers.js</file>
         <file>private/scripts/prop-webseeds.js</file>
         <file>private/scripts/rename-files.js</file>
+        <file>private/scripts/rss-rule-share-limit.js</file>
         <file>private/scripts/search.js</file>
         <file>private/scripts/statistics.js</file>
         <file>private/scripts/torrent-content.js</file>


### PR DESCRIPTION
Adds the missing share-limit controls to WebUI RSS rules: ratio, seeding time, inactive time, matching mode and the action taken at the limit.

The backend already accepts these AddTorrentParams fields, so the view writes them directly. Defaults follow the same global -> parent category -> child category rules as the backend, including per-field inheritance.

There was also a real packaging bug in the old branch: index.html loaded the helper, but webui.qrc did not ship it. That is fixed, with a manifest test so it shouldnt happen again.

The controller is shared with the DOM tests. They cover switching modes, changing rules, inherited and unlimited values, Save validation, and the final payload.

Closes #19944.

All 14 WebUI tests, lint and formatting checks pass locally.