### PR TITLE
WebUI: fix applying color scheme in framed windows

### DIFF
--- a/src/webui/www/private/scripts/color-scheme.js
+++ b/src/webui/www/private/scripts/color-scheme.js
@@ -48,6 +48,9 @@ window.qBittorrent.ColorScheme ??= (() => {
     };
 
     colorSchemeQuery.addEventListener("change", update);
+    // Apply immediately: framed windows already have parent's ClientData loaded;
+    // main window falls back to system preference until client.js calls update() after fetch
+    update();
 
     return exports();
 })();


### PR DESCRIPTION
The selected color scheme was not being applied to framed windows. This broke in #23191.

Once merged this should also be hotfixed to 5.2 (#23823).