### PR TITLE
Add option to toggle speed indicator in dock

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1509,6 +1509,21 @@ void Preferences::setUpdateCheckEnabled(const bool enabled)
 }
 #endif
 
+#ifdef Q_OS_MACOS
+bool Preferences::isSpeedInDockEnabled() const
+{
+    return value(u"Preferences/Desktop/ShowSpeedInDock"_s, true);
+}
+
+void Preferences::setSpeedInDockEnabled(const bool enabled)
+{
+    if (enabled == isSpeedInDockEnabled())
+        return;
+
+    setValue(u"Preferences/Desktop/ShowSpeedInDock"_s, enabled);
+}
+#endif
+
 bool Preferences::confirmTorrentDeletion() const
 {
     return value(u"Preferences/Advanced/confirmTorrentDeletion"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -323,6 +323,10 @@ public:
     bool isUpdateCheckEnabled() const;
     void setUpdateCheckEnabled(bool enabled);
 #endif
+#ifdef Q_OS_MACOS
+    bool isSpeedInDockEnabled() const;
+    void setSpeedInDockEnabled(bool enabled);
+#endif
     bool confirmTorrentDeletion() const;
     void setConfirmTorrentDeletion(bool enabled);
     bool confirmTorrentRecheck() const;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1463,6 +1463,12 @@ void MainWindow::loadPreferences()
     }
 #endif
 
+#ifdef Q_OS_MACOS
+    // Clear dock badge immediately if speed display is disabled
+    if (!pref->isSpeedInDockEnabled())
+        m_badger->updateSpeed(0, 0);
+#endif
+
     qDebug("GUI settings loaded");
 }
 
@@ -1475,7 +1481,8 @@ void MainWindow::loadSessionStats()
 
     // update global information
 #ifdef Q_OS_MACOS
-    m_badger->updateSpeed(status.payloadDownloadRate, status.payloadUploadRate);
+    if (Preferences::instance()->isSpeedInDockEnabled())
+        m_badger->updateSpeed(status.payloadDownloadRate, status.payloadUploadRate);
     m_statusItem->updateSpeed(status.payloadDownloadRate, status.payloadUploadRate);
 #else
     refreshTrayIconTooltip();

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1057,6 +1057,12 @@ void OptionsDialog::loadSpeedTabOptions()
     m_ui->checkLimitTransportOverhead->setChecked(session->includeOverheadInLimits());
     m_ui->checkLimitLocalPeerRate->setChecked(!session->ignoreLimitsOnLAN());
 
+#ifdef Q_OS_MACOS
+    m_ui->checkShowSpeedInDock->setChecked(pref->isSpeedInDockEnabled());
+#else
+    m_ui->checkShowSpeedInDock->hide();
+#endif
+
     connect(m_ui->spinUploadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinDownloadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
 
@@ -1071,6 +1077,10 @@ void OptionsDialog::loadSpeedTabOptions()
     connect(m_ui->checkLimituTPConnections, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkLimitTransportOverhead, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkLimitLocalPeerRate, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+
+#ifdef Q_OS_MACOS
+    connect(m_ui->checkShowSpeedInDock, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+#endif
 }
 
 void OptionsDialog::saveSpeedTabOptions() const
@@ -1092,6 +1102,10 @@ void OptionsDialog::saveSpeedTabOptions() const
     session->setUTPRateLimited(m_ui->checkLimituTPConnections->isChecked());
     session->setIncludeOverheadInLimits(m_ui->checkLimitTransportOverhead->isChecked());
     session->setIgnoreLimitsOnLAN(!m_ui->checkLimitLocalPeerRate->isChecked());
+
+#ifdef Q_OS_MACOS
+    pref->setSpeedInDockEnabled(m_ui->checkShowSpeedInDock->isChecked());
+#endif
 }
 
 void OptionsDialog::loadBittorrentTabOptions()

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -716,6 +716,13 @@
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QCheckBox" name="checkShowSpeedInDock">
+                 <property name="text">
+                  <string>Show speed in Dock</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>


### PR DESCRIPTION
Add checkbox in Behavior section of Settings to disable showing speed in macOS dock.

Closes #20783.
PR #23133.