### PR TITLE
Add "Copy path" in Content tab

### DIFF
--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -427,7 +427,7 @@ void TorrentContentWidget::displayContextMenu()
             menu->addAction(UIThemeManager::instance()->getIcon(u"directory"_s), tr("Open containing folder")
                             , this, [this, index]() { openParentFolder(index); });
             menu->addAction(UIThemeManager::instance()->getIcon(u"edit-copy"_s), tr("Copy path")
-                            , this, [this, index]() { copyContentPath(index); });
+                            , this, [this, index]() { copyFullPath(index); });
         }
         menu->addAction(UIThemeManager::instance()->getIcon(u"edit-rename"_s), tr("Rename...")
                         , this, &TorrentContentWidget::renameSelectedFile);
@@ -507,7 +507,7 @@ void TorrentContentWidget::openParentFolder(const QModelIndex &index)
 #endif
 }
 
-void TorrentContentWidget::copyContentPath(const QModelIndex &index)
+void TorrentContentWidget::copyFullPath(const QModelIndex &index)
 {
     const Path path = getFullPath(index);
     QApplication::clipboard()->setText(path.toString());

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -114,7 +114,7 @@ private:
     void displayContextMenu();
     void openItem(const QModelIndex &index) const;
     void openParentFolder(const QModelIndex &index);
-    void copyContentPath(const QModelIndex &index);
+    void copyFullPath(const QModelIndex &index);
     void openSelectedFile();
     void renameSelectedFile();
     void applyPriorities(BitTorrent::DownloadPriority priority);


### PR DESCRIPTION
Add a new "Copy content path" menu item in the Contents tab in the native UI 

<img width="568" height="407" alt="Screenshot from 2026-03-22 13-46-42" src="https://github.com/user-attachments/assets/fc39c987-84b0-4bf6-a9a2-5f74b6d61fb5" />

