### PR TITLE
Fix filter fields staying focused after click-away

### DIFF
--- a/src/gui/lineedit.cpp
+++ b/src/gui/lineedit.cpp
@@ -32,9 +32,13 @@
 #include <chrono>
 
 #include <QAction>
+#include <QApplication>
+#include <QEvent>
+#include <QFocusEvent>
 #include <QKeyEvent>
 #include <QPalette>
 #include <QTimer>
+#include <QWidget>
 
 #include "base/global.h"
 #include "uithememanager.h"
@@ -71,6 +75,32 @@ LineEdit::LineEdit(QWidget *parent)
     {
         m_delayedTextChangedTimer->start(FILTER_INPUT_DELAY);
     });
+}
+
+bool LineEdit::eventFilter(QObject *watched, QEvent *event)
+{
+    if (event->type() != QEvent::MouseButtonPress)
+        return false;
+
+    if (const auto *watchedWidget = qobject_cast<QWidget *>(watched))
+    {
+        if ((watchedWidget != this) && !isAncestorOf(watchedWidget))
+            clearFocus();
+    }
+
+    return false;
+}
+
+void LineEdit::focusInEvent(QFocusEvent *event)
+{
+    QLineEdit::focusInEvent(event);
+    qApp->installEventFilter(this);
+}
+
+void LineEdit::focusOutEvent(QFocusEvent *event)
+{
+    qApp->removeEventFilter(this);
+    QLineEdit::focusOutEvent(event);
 }
 
 void LineEdit::keyPressEvent(QKeyEvent *event)

--- a/src/gui/lineedit.h
+++ b/src/gui/lineedit.h
@@ -31,7 +31,10 @@
 
 #include <QLineEdit>
 
+class QEvent;
+class QFocusEvent;
 class QKeyEvent;
+class QObject;
 class QTimer;
 
 class LineEdit final : public QLineEdit
@@ -46,6 +49,9 @@ signals:
     void textChanged(const QString &text);
 
 private:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    void focusInEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
 
     QTimer *m_delayedTextChangedTimer = nullptr;


### PR DESCRIPTION
Fixes the filter fields staying focused until you click into another pane.

This moves the click-away blur behavior into the shared LineEdit used by the filter/search inputs, instead of handling it separately in different parts of the UI.

This has been bugging me for a while so i just made a PR to fix this problem. 