### PR TITLE
Remove redundant type alias

### DIFF
--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -408,8 +408,7 @@ void PeerListWidget::loadPeers(const BitTorrent::Torrent *torrent)
     if (!torrent)
         return;
 
-    using TorrentPtr = QPointer<const BitTorrent::Torrent>;
-    torrent->fetchPeerInfo().then(this, [this, torrent = TorrentPtr(torrent)](const QList<BitTorrent::PeerInfo> &peers)
+    torrent->fetchPeerInfo().then(this, [this, torrent = QPointer(torrent)](const QList<BitTorrent::PeerInfo> &peers)
     {
         if (const BitTorrent::Torrent *currentTorrent = m_properties->getCurrentTorrent();
             !currentTorrent || (currentTorrent != torrent))

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -480,9 +480,8 @@ void PropertiesWidget::loadDynamicData()
                     // Pieces availability
                     showPiecesAvailability(true);
 
-                    using TorrentPtr = QPointer<BitTorrent::Torrent>;
                     m_torrent->fetchPieceAvailability().then(this
-                            , [this, torrent = TorrentPtr(m_torrent)](const QList<int> &pieceAvailability)
+                            , [this, torrent = QPointer(m_torrent)](const QList<int> &pieceAvailability)
                     {
                         if (m_torrent && (m_torrent == torrent))
                             m_piecesAvailability->setAvailability(pieceAvailability);
@@ -499,9 +498,8 @@ void PropertiesWidget::loadDynamicData()
                 qreal progress = m_torrent->progress() * 100.;
                 m_ui->labelProgressVal->setText(Utils::String::fromDouble(progress, 1) + u'%');
 
-                using TorrentPtr = QPointer<BitTorrent::Torrent>;
                 m_torrent->fetchDownloadingPieces().then(this
-                        , [this, torrent = TorrentPtr(m_torrent)](const QBitArray &downloadingPieces)
+                        , [this, torrent = QPointer(m_torrent)](const QBitArray &downloadingPieces)
                 {
                     if (m_torrent && (m_torrent == torrent))
                         m_downloadedPieces->setProgress(m_torrent->pieces(), downloadingPieces);
@@ -529,8 +527,7 @@ void PropertiesWidget::loadUrlSeeds()
     if (!m_torrent)
         return;
 
-    using TorrentPtr = QPointer<BitTorrent::Torrent>;
-    m_torrent->fetchURLSeeds().then(this, [this, torrent = TorrentPtr(m_torrent)](const QList<QUrl> &urlSeeds)
+    m_torrent->fetchURLSeeds().then(this, [this, torrent = QPointer(m_torrent)](const QList<QUrl> &urlSeeds)
     {
         if (!m_torrent || (m_torrent != torrent))
             return;

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -219,9 +219,8 @@ void TorrentContentModel::updateFilesAvailability()
 {
     Q_ASSERT(m_contentHandler && m_contentHandler->hasMetadata());
 
-    using HandlerPtr = QPointer<BitTorrent::TorrentContentHandler>;
     m_contentHandler->fetchAvailableFileFractions().then(this
-            , [this, handler = HandlerPtr(m_contentHandler)](const QList<qreal> &availableFileFractions)
+            , [this, handler = QPointer(m_contentHandler)](const QList<qreal> &availableFileFractions)
     {
         if (!m_contentHandler || (m_contentHandler != handler))
             return;

--- a/src/gui/trackerlist/trackerlistmodel.cpp
+++ b/src/gui/trackerlist/trackerlistmodel.cpp
@@ -316,15 +316,14 @@ void TrackerListModel::populate()
     m_items->emplace_back(std::make_shared<Item>(u"** [PeX] **", privateTorrentMessage));
     m_items->emplace_back(std::make_shared<Item>(u"** [LSD] **", privateTorrentMessage));
 
-    using TorrentPtr = QPointer<const BitTorrent::Torrent>;
-    m_torrent->fetchPeerInfo().then(this, [this, torrent = TorrentPtr(m_torrent)](const QList<BitTorrent::PeerInfo> &peers)
+    m_torrent->fetchPeerInfo().then(this, [this, torrent = QPointer(m_torrent)](const QList<BitTorrent::PeerInfo> &peers)
     {
         if (!m_torrent || (m_torrent != torrent))
            return;
 
         // XXX: libtorrent should provide this info...
         // Count peers from DHT, PeX, LSD
-        uint seedsDHT = 0, seedsPeX = 0, seedsLSD = 0, peersDHT = 0, peersPeX = 0, peersLSD = 0;
+        qsizetype seedsDHT = 0, seedsPeX = 0, seedsLSD = 0, peersDHT = 0, peersPeX = 0, peersLSD = 0;
         for (const BitTorrent::PeerInfo &peer : peers)
         {
             if (peer.isConnecting())


### PR DESCRIPTION
`QPointer` is able to deduct the type by itself.

Also, use proper signed integer type for counters.
