### PR TITLE
Make disabled speed graphs warning clickable

### DIFF
--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -209,6 +209,11 @@ AdvancedSettings::AdvancedSettings(IGUIApplication *app, QWidget *parent)
     horizontalHeader()->setStretchLastSection(true);
 }
 
+void AdvancedSettings::showSpeedWidgetSetting()
+{
+    showSetting(ENABLE_SPEED_WIDGET);
+}
+
 void AdvancedSettings::saveAdvancedSettings() const
 {
     Preferences *const pref = Preferences::instance();
@@ -1053,4 +1058,13 @@ void AdvancedSettings::addRow(const int row, const QString &text, T *widget)
         connect(widget, qOverload<int>(&QComboBox::currentIndexChanged), this, &AdvancedSettings::settingsChanged);
     else if constexpr (std::is_same_v<T, QLineEdit>)
         connect(widget, &QLineEdit::textChanged, this, &AdvancedSettings::settingsChanged);
+}
+
+void AdvancedSettings::showSetting(const int row)
+{
+    scrollTo(model()->index(row, PROPERTY), QAbstractItemView::PositionAtCenter);
+
+    QWidget *const widget = cellWidget(row, VALUE);
+    if (widget)
+        widget->setFocus();
 }

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -48,6 +48,7 @@ public:
     explicit AdvancedSettings(IGUIApplication *app, QWidget *parent = nullptr);
 
 public slots:
+    void showSpeedWidgetSetting();
     void saveAdvancedSettings() const;
 
 signals:
@@ -66,6 +67,7 @@ private slots:
 
 private:
     void loadAdvancedSettings();
+    void showSetting(int row);
     template <typename T> void addRow(int row, const QString &text, T *widget);
 
     QSpinBox m_spinBoxSaveResumeDataInterval, m_spinBoxSaveStatisticsInterval, m_spinBoxTorrentFileSizeLimit, m_spinBoxBdecodeDepthLimit, m_spinBoxBdecodeTokenLimit,

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -268,6 +268,11 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     m_transferListWidget = new TransferListWidget(app, this);
     m_propertiesWidget = new PropertiesWidget(hSplitter);
     connect(m_transferListWidget, &TransferListWidget::currentTorrentChanged, m_propertiesWidget, &PropertiesWidget::loadTorrentInfos);
+    connect(m_propertiesWidget, &PropertiesWidget::openAdvancedSettingsLinkActivated, this, [this]
+    {
+        on_actionOptions_triggered();
+        m_options->showSpeedWidgetSetting();
+    });
     hSplitter->addWidget(m_transferListWidget);
     hSplitter->addWidget(m_propertiesWidget);
     m_splitter->addWidget(hSplitter);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -2233,6 +2233,12 @@ void OptionsDialog::showConnectionTab()
     m_ui->tabSelection->setCurrentRow(TAB_CONNECTION);
 }
 
+void OptionsDialog::showSpeedWidgetSetting()
+{
+    m_ui->tabSelection->setCurrentRow(TAB_ADVANCED);
+    m_advancedSettings->showSpeedWidgetSetting();
+}
+
 #ifndef DISABLE_WEBUI
 void OptionsDialog::on_registerDNSBtn_clicked()
 {

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -81,6 +81,7 @@ public:
 
 public slots:
     void showConnectionTab();
+    void showSpeedWidgetSetting();
 
 private slots:
     void adjustProxyOptions();

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -33,6 +33,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QFuture>
+#include <QLabel>
 #include <QListWidgetItem>
 #include <QMenu>
 #include <QMessageBox>
@@ -593,10 +594,16 @@ void PropertiesWidget::configure()
                 delete m_speedWidget;
             }
 
-            const auto displayText = u"<center><b>%1</b><p>%2</p></center>"_s
-                .arg(tr("Speed graphs are disabled"), tr("You can enable it in Advanced Options"));
+            const auto displayText = u"<html><head/><body><p align=\"center\">"
+                u"<b>%1</b><br/>"
+                u"<a href=\"#\">%2</a>"
+                u"</p></body></html>"_s
+                .arg(tr("Speed graphs are disabled"), tr("Open Advanced Options to enable them"));
             auto *label = new QLabel(displayText, this);
             label->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+            label->setTextInteractionFlags(Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
+            label->setToolTip(tr("Open Advanced Options"));
+            connect(label, &QLabel::linkActivated, this, &PropertiesWidget::openAdvancedSettingsLinkActivated);
             m_speedWidget = label;
             m_ui->speedLayout->addWidget(m_speedWidget);
         }

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -77,6 +77,9 @@ public:
     PropTabBar *tabBar() const;
     LineEdit *contentFilterLine() const;
 
+signals:
+    void openAdvancedSettingsLinkActivated();
+
 public slots:
     void setVisibility(bool visible);
     void loadTorrentInfos(BitTorrent::Torrent *torrent);


### PR DESCRIPTION
The disabled speed graph message now has a link. It opens Options on the Advanced page and focuses the Enable speed graphs row.

PropertiesWidget only reports the click; MainWindow opens Options, while OptionsDialog and AdvancedSettings handle their own navigation. I kept that split so this does not add a generic settings-routing API.

The latest pass also removes the empty-link and hover paths, inlines the one-off MainWindow handler, uses plain setFocus(), and leaves link coloring to QLabel so live theme changes still work.

Built against current master. All 19 Qt tests and the repo checks pass locally.