### PR TITLE
Set NAT-PMP lease duration correctly

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2089,6 +2089,9 @@ lt::settings_pack SessionImpl::loadLTSettings() const
     settingsPack.set_int(lt::settings_pack::num_outgoing_ports, (outgoingPortsMax() - outgoingPortsMin()));
     // UPnP lease duration
     settingsPack.set_int(lt::settings_pack::upnp_lease_duration, UPnPLeaseDuration());
+#if LIBTORRENT_VERSION_NUM >= 20013
+    settingsPack.set_int(lt::settings_pack::natpmp_lease_duration, UPnPLeaseDuration());
+#endif
     // Type of service
     settingsPack.set_int(lt::settings_pack::peer_dscp, peerDSCP());
     // Include overhead in transfer limits


### PR DESCRIPTION
This setting is added in libtorrent > 2.0.12.
Historically, qbt doesn't separate UPnP and NAT-PMP settings so they share the same setting.

ps. If there is such need to separate them then it should be done in another PR.
