### PR TITLE
Fix macOS: file opening with special chars and renaming with illegal chars

### DIFF
--- a/src/base/bittorrent/abstractfilestorage.cpp
+++ b/src/base/bittorrent/abstractfilestorage.cpp
@@ -38,7 +38,7 @@
 
 void BitTorrent::AbstractFileStorage::renameFile(const Path &oldPath, const Path &newPath)
 {
-    if (!oldPath.isValid())
+    if (oldPath.isEmpty())
         throw RuntimeError(tr("The old path is invalid: '%1'.").arg(oldPath.toString()));
     if (!newPath.isValid())
         throw RuntimeError(tr("The new path is invalid: '%1'.").arg(newPath.toString()));
@@ -64,7 +64,7 @@ void BitTorrent::AbstractFileStorage::renameFile(const Path &oldPath, const Path
 
 void BitTorrent::AbstractFileStorage::renameFolder(const Path &oldFolderPath, const Path &newFolderPath)
 {
-    if (!oldFolderPath.isValid())
+    if (oldFolderPath.isEmpty())
         throw RuntimeError(tr("The old path is invalid: '%1'.").arg(oldFolderPath.toString()));
     if (!newFolderPath.isValid())
         throw RuntimeError(tr("The new path is invalid: '%1'.").arg(newFolderPath.toString()));

--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -44,6 +44,7 @@ namespace MacUtils
     void askForNotificationPermission();
     void displayNotification(const QString &title, const QString &message);
     void openFiles(const PathList &pathList);
+    void openPath(const Path &path);
 
     bool isMagnetLinkAssocSet();
     void setMagnetLinkAssoc();

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -144,6 +144,18 @@ namespace MacUtils
         }
     }
 
+    void openPath(const Path &path)
+    {
+        @autoreleasepool
+        {
+            NSURL *url = [NSURL fileURLWithPath:path.toString().toNSString()];
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
+            {
+                [[NSWorkspace sharedWorkspace] openURL:url];
+            });
+        }
+    }
+
     bool isMagnetLinkAssocSet()
     {
         @autoreleasepool

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -37,6 +37,10 @@
 #include <shellapi.h>
 #endif
 
+#ifdef Q_OS_MACOS
+#include "macutilities.h"
+#endif
+
 #include <QApplication>
 #include <QDesktopServices>
 #include <QPixmap>
@@ -117,11 +121,6 @@ QPoint Utils::Gui::screenCenter(const QWidget *w)
 // Open the given path with an appropriate application
 void Utils::Gui::openPath(const Path &path)
 {
-    // Hack to access samba shares with QDesktopServices::openUrl
-    const QUrl url = path.data().startsWith(u"//")
-        ? QUrl(u"file:" + path.data())
-        : QUrl::fromLocalFile(path.data());
-
 #ifdef Q_OS_WIN
     auto *thread = QThread::create([path]()
     {
@@ -137,7 +136,13 @@ void Utils::Gui::openPath(const Path &path)
     thread->setObjectName("Utils::Gui::openPath thread");
     QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
+#elif defined(Q_OS_MACOS)
+    MacUtils::openPath(path);
 #else
+    // Hack to access samba shares with QDesktopServices::openUrl
+    const QUrl url = path.data().startsWith(u"//")
+        ? QUrl(u"file:" + path.data())
+        : QUrl::fromLocalFile(path.data());
     QDesktopServices::openUrl(url);
 #endif
 }


### PR DESCRIPTION
## Summary
- **Fix file opening on macOS** (#22395): Use native `NSWorkspace openURL:` API instead of `QDesktopServices::openUrl(QUrl::fromLocalFile(...))`, which fails when paths contain spaces or brackets on Qt 6.7+ / macOS Sequoia. This is consistent with `openParentFolder()` which already uses native macOS APIs.
- **Fix renaming files with illegal characters** (#23834): Relax old path validation in `renameFile()`/`renameFolder()` from `isValid()` to `isEmpty()`. The old path comes from torrent metadata and may contain characters illegal on the host OS (e.g. `:` on macOS). The rename operation is exactly meant to fix these — blocking it defeats the purpose. The file-existence check later in the function is sufficient.

Closes #22395
Closes #23834

## Test plan
- [ ] On macOS, add a torrent and set the download folder to a path containing spaces (e.g. "Misc Files"). Double-click a file in the content tab — it should open with the default application.
- [ ] On macOS, add a torrent containing a file with brackets `[]` in the name. Double-click to open — should work.
- [ ] Add a torrent with a colon `:` in the filename (common in some torrents). Right-click → Rename should work instead of showing "The old path is invalid" error.
- [ ] Verify file opening still works on Windows and Linux (no regression).