### PR TITLE
Fix app freezing on quit due to Qt accessibility deadlock on macOS

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -60,6 +60,7 @@
 #include <QSessionManager>
 #endif // Q_OS_WIN
 #ifdef Q_OS_MACOS
+#include <QAccessible>
 #include <QFileOpenEvent>
 #endif // Q_OS_MACOS
 #endif
@@ -1371,6 +1372,12 @@ void Application::cleanup()
         if (m_desktopIntegration->menu())
             m_desktopIntegration->menu()->setEnabled(false);
     }
+
+#ifdef Q_OS_MACOS
+    // Disable Qt accessibility bridge before destroying widgets to prevent
+    // deadlocks with macOS accessibility API during shutdown (issue #23695)
+    QAccessible::cleanup();
+#endif
 
     if (m_window)
     {

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1373,12 +1373,6 @@ void Application::cleanup()
             m_desktopIntegration->menu()->setEnabled(false);
     }
 
-#ifdef Q_OS_MACOS
-    // Disable Qt accessibility bridge before destroying widgets to prevent
-    // deadlocks with macOS accessibility API during shutdown (issue #23695)
-    QAccessible::cleanup();
-#endif
-
     if (m_window)
     {
         // Hide the window and don't leave it on screen as
@@ -1392,6 +1386,15 @@ void Application::cleanup()
         ::ShutdownBlockReasonCreate(reinterpret_cast<HWND>(m_window->effectiveWinId())
             , msg.c_str());
 #endif // Q_OS_WIN
+
+#ifdef Q_OS_MACOS
+        // Remove all accessibility interface factories before destroying widgets.
+        // On macOS, widget destruction triggers accessibility notifications via
+        // the native AX API, which can deadlock with the Qt event loop causing
+        // the app to freeze on quit.
+        // https://github.com/qbittorrent/qBittorrent/issues/23695
+        QAccessible::cleanup();
+#endif
 
         // Do manual cleanup in MainWindow to force widgets
         // to save their Preferences, stop all timers and


### PR DESCRIPTION
Closes #23695.
Closes #23604.

## Summary
- Disable Qt's accessibility bridge (`QAccessible::cleanup()`) before destroying widgets during shutdown on macOS
- Qt sends accessibility notifications via the native AX API when widgets are deleted, which can cause deadlocks between the Qt event loop and macOS accessibility framework
- This results in the app freezing indefinitely on quit — users must force-quit
- The fix removes all accessibility factories and bridges before widget destruction, preventing these notifications from reaching the macOS AX API during shutdown

See also #16763.

## Test plan
- [ ] On macOS, add several torrents and let them run for a while, then quit with Cmd+Q — should exit cleanly without freezing
- [ ] Repeat quit/relaunch cycle multiple times to verify consistency
- [ ] Verify screen readers still work during normal operation (accessibility is only disabled during shutdown)
- [ ] Verify no regression on Windows and Linux quit behavior