### PR TITLE
Fix crash on macOS when deleting torrents

### DIFF
--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -304,7 +304,12 @@ void TrackersFilterWidget::decreaseTorrentsCount(const QString &trackerHost)
     {
         if (currentItem() == trackerData.item)
             setCurrentRow(0, QItemSelectionModel::SelectCurrent);
-        delete trackerData.item;
+        // Use takeItem() to detach the item from the widget before deleting.
+        // Directly deleting a QListWidgetItem triggers model's endRemoveRows()
+        // during destruction, causing QAccessibleTable::modelChange() to crash
+        // on macOS due to stale accessible interface references (issue #22657).
+        const int itemRow = row(trackerData.item);
+        delete takeItem(itemRow);
         m_trackers.erase(iter);
         updateGeometry();
     }

--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -304,12 +304,16 @@ void TrackersFilterWidget::decreaseTorrentsCount(const QString &trackerHost)
     {
         if (currentItem() == trackerData.item)
             setCurrentRow(0, QItemSelectionModel::SelectCurrent);
+#ifdef Q_OS_MACOS
         // Use takeItem() to detach the item from the widget before deleting.
         // Directly deleting a QListWidgetItem triggers model's endRemoveRows()
         // during destruction, causing QAccessibleTable::modelChange() to crash
-        // on macOS due to stale accessible interface references (issue #22657).
-        const int itemRow = row(trackerData.item);
-        delete takeItem(itemRow);
+        // on macOS due to stale accessible interface references.
+        // https://github.com/qbittorrent/qBittorrent/issues/22657
+        delete takeItem(row(trackerData.item));
+#else
+        delete trackerData.item;
+#endif
         m_trackers.erase(iter);
         updateGeometry();
     }


### PR DESCRIPTION
Closes #22657.

## Summary
- Fix SIGSEGV crash on macOS when deleting torrents from the list
- Root cause: `TrackersFilterWidget::decreaseTorrentsCount()` directly deletes `QListWidgetItem`s, which triggers `QListModel::endRemoveRows()` during the item's destructor. This causes `QAccessibleTable::modelChange()` to access stale accessible interface references → crash
- Fix: Use `takeItem()` to detach the item from the widget first (while the item is still alive and accessibility interfaces are valid), then delete the standalone item which no longer triggers model signals

The crash stack trace from the issue:
```
 3# QAccessibleTable::modelChange(QAccessibleTableModelChangeEvent*)
 4# QAccessible::updateAccessibility(QAccessibleEvent*)
 5# QAbstractItemViewPrivate::rowsRemoved(...)
 ...
 9# QListWidgetItem::~QListWidgetItem()
11# TrackersFilterWidget::removeItem(...)
12# TrackersFilterWidget::torrentAboutToBeDeleted(...)
```

## Test plan
- [ ] On macOS, add several torrents with different trackers
- [ ] Delete torrents one by one — should not crash
- [ ] Bulk delete multiple torrents at once — should not crash
- [ ] Verify tracker filter list updates correctly after deletion
- [ ] Verify no regression on Windows and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)