### PR TITLE
WebUI: Fix RSS Dialog Box Title Text

### DIFF
--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -575,7 +575,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             new MochaUI.Window({
                 id: "clearRulesPage",
                 icon: "images/qbittorrent-tray.svg",
-                title: "QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]",
+                title: "QBT_TR(Clear downloaded episodes confirmation)QBT_TR[CONTEXT=AutomatedRssDownloader]",
                 loadMethod: "iframe",
                 contentURL: `confirmruleclear.html?v=${CACHEID}&rules=${encodeURIComponent(encodedRules.join("|"))}`,
                 scrollbars: false,


### PR DESCRIPTION
Correct the title of the confirmation dialog box when clearing an RSS Download Rule downloaded episodes in the Web GUI.

<img width="479" height="144" alt="image" src="https://github.com/user-attachments/assets/599cab55-49c8-458d-8c00-a8e9769d9bf1" />
