### PR TITLE
Add tooltips to email notification Options fields

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -666,8 +666,18 @@ void OptionsDialog::loadDownloadsTabOptions()
 
     m_ui->groupMailNotification->setChecked(pref->isMailNotificationEnabled());
     m_ui->senderEmailTxt->setText(pref->getMailNotificationSender());
+    m_ui->senderEmailTxt->setToolTip(tr("Provide the sending email address"));
     m_ui->lineEditDestEmail->setText(pref->getMailNotificationEmail());
+    m_ui->lineEditDestEmail->setToolTip(u"<html><body><p style='white-space:nowrap'>"
+        + tr("Provide the recipient email address") + u"</p><p style='white-space:nowrap'><b>"
+        + tr("Note: ") + u"</b>" + tr("only a single recipient email address can be specified") + u"</p></body></html>");
     m_ui->lineEditSmtpServer->setText(pref->getMailNotificationSMTP());
+    m_ui->lineEditSmtpServer->setToolTip(u"<html><body><p style='white-space:nowrap'>"
+        + tr("Provide the SMTP server address for sending email notifications") + u"</p><p style='white-space:nowrap'>"
+        + tr("The server address can either be entered as a DNS name ") + u"<b>" + tr("(recommended)") + u"</b>" + tr(" or IP address") + u" <br>"
+        + tr("To manually specify the server port, add a colon and then the port number to the end of the server address") + u"<br><b>"
+        + tr("Example:") + u"</b><br>"
+        + tr("smtp.example.com:465 - connect to server ") + u"<b>" + tr("smtp.example.com") + u"</b>" + tr(" on port ") + u"<b>" + tr("465") + u"</b></p></body></html>");
     m_ui->checkSmtpSSL->setChecked(pref->getMailNotificationSMTPSSL());
     m_ui->groupMailNotifAuth->setChecked(pref->getMailNotificationSMTPAuth());
     m_ui->mailNotifUsername->setText(pref->getMailNotificationSMTPUsername());

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -667,8 +667,26 @@ void OptionsDialog::loadDownloadsTabOptions()
 
     m_ui->groupMailNotification->setChecked(pref->isMailNotificationEnabled());
     m_ui->senderEmailTxt->setText(pref->getMailNotificationSender());
+    m_ui->senderEmailTxt->setToolTip(u"<html><body>"
+        + u"<p style='white-space:nowrap'>%1.</p>"_s.arg(tr("Provide the sending email address"))
+        + u"</body></html>");
     m_ui->lineEditDestEmail->setText(pref->getMailNotificationEmail());
+    m_ui->lineEditDestEmail->setToolTip(u"<html><body>"
+        + u"<p style='white-space:nowrap'>%1.</p>"_s.arg(tr("Provide the recipient email address"))
+        + u"<p style='white-space:nowrap'><b>%1</b>: %2.</p>"_s.arg(tr("Note"), tr("only a single recipient email address can be specified"))
+        + u"</body></html>");
     m_ui->lineEditSMTPServer->setText(pref->getMailNotificationSMTP());
+    m_ui->lineEditSMTPServer->setToolTip(u"<html><body>"
+        + u"<p style='white-space:nowrap'>%1.</p>"_s.arg(tr("Provide the SMTP server address for sending email notifications"))
+        + u"<p style='white-space:nowrap'>"
+        + u"%1 <b>(%2)</b>.<br>"_s.arg(tr("The server address can be entered either as a DNS name or an IP address"), tr("DNS name recommended"))
+        + u"%1."_s.arg(tr("To manually specify the server port, add a colon and then the port number to the end"))
+        + u"</p>"
+        + u"<p style='white-space:nowrap'>"
+        + u"<b>%1</b><br>"_s.arg(tr("Example:"))
+        + u"smtp.example.com:465 - %1 <b>smtp.example.com</b> %2 <b>465</b>"_s.arg(tr("connect to server"), tr("on port"))
+        + u"</p>"
+        + u"</body></html>");
     m_ui->comboSMTPEncryption->setToolTip(u"<html><body>"
         + u"<p>%1</p>"_s.arg(tr("Select the encryption type used when sending SMTP emails"))
         + u"<p>"

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -667,26 +667,21 @@ void OptionsDialog::loadDownloadsTabOptions()
 
     m_ui->groupMailNotification->setChecked(pref->isMailNotificationEnabled());
     m_ui->senderEmailTxt->setText(pref->getMailNotificationSender());
-    m_ui->senderEmailTxt->setToolTip(u"<html><body>"
-        + u"<p style='white-space:nowrap'>%1.</p>"_s.arg(tr("Provide the sending email address"))
-        + u"</body></html>");
+    m_ui->senderEmailTxt->setToolTip(tr("Provide the sending email address."));
     m_ui->lineEditDestEmail->setText(pref->getMailNotificationEmail());
-    m_ui->lineEditDestEmail->setToolTip(u"<html><body>"
-        + u"<p style='white-space:nowrap'>%1.</p>"_s.arg(tr("Provide the recipient email address"))
-        + u"<p style='white-space:nowrap'><b>%1</b>: %2.</p>"_s.arg(tr("Note"), tr("only a single recipient email address can be specified"))
-        + u"</body></html>");
+    m_ui->lineEditDestEmail->setToolTip(tr("Provide the recipient email address.")
+        + u"\n\n"
+        + tr("Note: only a single recipient email address can be specified."));
     m_ui->lineEditSMTPServer->setText(pref->getMailNotificationSMTP());
-    m_ui->lineEditSMTPServer->setToolTip(u"<html><body>"
-        + u"<p style='white-space:nowrap'>%1.</p>"_s.arg(tr("Provide the SMTP server address for sending email notifications"))
-        + u"<p style='white-space:nowrap'>"
-        + u"%1 <b>(%2)</b>.<br>"_s.arg(tr("The server address can be entered either as a DNS name or an IP address"), tr("DNS name recommended"))
-        + u"%1."_s.arg(tr("To manually specify the server port, add a colon and then the port number to the end"))
-        + u"</p>"
-        + u"<p style='white-space:nowrap'>"
-        + u"<b>%1</b><br>"_s.arg(tr("Example:"))
-        + u"smtp.example.com:465 - %1 <b>smtp.example.com</b> %2 <b>465</b>"_s.arg(tr("connect to server"), tr("on port"))
-        + u"</p>"
-        + u"</body></html>");
+    m_ui->lineEditSMTPServer->setToolTip(tr("Provide the SMTP server address for sending email notifications.")
+        + u"\n\n"
+        + tr("The server address can be entered either as a DNS name or an IP address (DNS name recommended).")
+        + u"\n"
+        + tr("To manually specify the server port, add a colon and then the port number to the end.")
+        + u"\n\n"
+        + tr("Example:")
+        + u"\n"
+        + tr("smtp.example.com:465 - connect to server smtp.example.com on port 465"));
     m_ui->comboSMTPEncryption->setToolTip(u"<html><body>"
         + u"<p>%1</p>"_s.arg(tr("Select the encryption type used when sending SMTP emails"))
         + u"<p>"

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -332,7 +332,7 @@
                         <label for="src_email_txt">QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="src_email_txt" placeholder="qBittorrent_notification@example.com">
+                        <input type="text" id="src_email_txt" placeholder="qBittorrent_notification@example.com" title="QBT_TR(Provide the sending email address)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
                 <tr>
@@ -340,7 +340,8 @@
                         <label for="dest_email_txt">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="dest_email_txt">
+                        <input type="text" id="dest_email_txt" title="QBT_TR(Provide the recipient email address
+Note: only a single recipient email address can be specified)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
                 <tr>
@@ -348,7 +349,11 @@
                         <label for="smtp_server_txt">QBT_TR(SMTP server:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="smtp_server_txt" placeholder="smtp.example.com:465">
+                        <input type="text" id="smtp_server_txt" placeholder="smtp.example.com:465" title="QBT_TR(Provide the SMTP server address for sending email notifications
+The server address can either be entered as a DNS name (recommended) or IP address
+To manually specify the server port, add a colon and then the port number to the end of the server address
+Example:
+smtp.example.com:465 - connect to server smtp.example.com on port 465)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
             </tbody>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -332,7 +332,7 @@
                         <label for="src_email_txt">QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="src_email_txt" placeholder="qBittorrent_notification@example.com" style="width: 40em;">
+                        <input type="text" id="src_email_txt" placeholder="qBittorrent_notification@example.com" style="width: 40em;" title="QBT_TR(Provide the sending email address)QBT_TR[CONTEXT=OptionsDialog].">
                     </td>
                 </tr>
                 <tr>
@@ -340,7 +340,9 @@
                         <label for="dest_email_txt">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="dest_email_txt" style="width: 40em;">
+                        <input type="text" id="dest_email_txt" style="width: 40em;" title="QBT_TR(Provide the recipient email address)QBT_TR[CONTEXT=OptionsDialog].
+
+QBT_TR(Note)QBT_TR[CONTEXT=OptionsDialog]: QBT_TR(only a single recipient email address can be specified)QBT_TR[CONTEXT=OptionsDialog].">
                     </td>
                 </tr>
                 <tr>
@@ -348,7 +350,13 @@
                         <label for="smtp_server_txt">QBT_TR(SMTP server:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="smtp_server_txt" placeholder="smtp.example.com:465" style="width: 40em;">
+                        <input type="text" id="smtp_server_txt" placeholder="smtp.example.com:465" style="width: 40em;" title="QBT_TR(Provide the SMTP server address for sending email notifications)QBT_TR[CONTEXT=OptionsDialog].
+
+QBT_TR(The server address can be entered either as a DNS name or an IP address)QBT_TR[CONTEXT=OptionsDialog] (QBT_TR(DNS name recommended)QBT_TR[CONTEXT=OptionsDialog]).
+QBT_TR(To manually specify the server port, add a colon and then the port number to the end)QBT_TR[CONTEXT=OptionsDialog].
+
+QBT_TR(Example)QBT_TR[CONTEXT=OptionsDialog]:
+smtp.example.com:465 - QBT_TR(connect to server)QBT_TR[CONTEXT=OptionsDialog] smtp.example.com QBT_TR(on port)QBT_TR[CONTEXT=OptionsDialog] 465">
                     </td>
                 </tr>
                 <tr>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -332,7 +332,7 @@
                         <label for="src_email_txt">QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="src_email_txt" placeholder="qBittorrent_notification@example.com" style="width: 40em;" title="QBT_TR(Provide the sending email address)QBT_TR[CONTEXT=OptionsDialog].">
+                        <input type="text" id="src_email_txt" placeholder="qBittorrent_notification@example.com" style="width: 40em;" title="QBT_TR(Provide the sending email address.)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
                 <tr>
@@ -340,9 +340,9 @@
                         <label for="dest_email_txt">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="dest_email_txt" style="width: 40em;" title="QBT_TR(Provide the recipient email address)QBT_TR[CONTEXT=OptionsDialog].
+                        <input type="text" id="dest_email_txt" style="width: 40em;" title="QBT_TR(Provide the recipient email address.)QBT_TR[CONTEXT=OptionsDialog]
 
-QBT_TR(Note)QBT_TR[CONTEXT=OptionsDialog]: QBT_TR(only a single recipient email address can be specified)QBT_TR[CONTEXT=OptionsDialog].">
+QBT_TR(Note: only a single recipient email address can be specified.)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
                 <tr>
@@ -350,13 +350,13 @@ QBT_TR(Note)QBT_TR[CONTEXT=OptionsDialog]: QBT_TR(only a single recipient email 
                         <label for="smtp_server_txt">QBT_TR(SMTP server:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="smtp_server_txt" placeholder="smtp.example.com:465" style="width: 40em;" title="QBT_TR(Provide the SMTP server address for sending email notifications)QBT_TR[CONTEXT=OptionsDialog].
+                        <input type="text" id="smtp_server_txt" placeholder="smtp.example.com:465" style="width: 40em;" title="QBT_TR(Provide the SMTP server address for sending email notifications.)QBT_TR[CONTEXT=OptionsDialog]
 
-QBT_TR(The server address can be entered either as a DNS name or an IP address)QBT_TR[CONTEXT=OptionsDialog] (QBT_TR(DNS name recommended)QBT_TR[CONTEXT=OptionsDialog]).
-QBT_TR(To manually specify the server port, add a colon and then the port number to the end)QBT_TR[CONTEXT=OptionsDialog].
+QBT_TR(The server address can be entered either as a DNS name or an IP address (DNS name recommended).)QBT_TR[CONTEXT=OptionsDialog]
+QBT_TR(To manually specify the server port, add a colon and then the port number to the end.)QBT_TR[CONTEXT=OptionsDialog]
 
-QBT_TR(Example)QBT_TR[CONTEXT=OptionsDialog]:
-smtp.example.com:465 - QBT_TR(connect to server)QBT_TR[CONTEXT=OptionsDialog] smtp.example.com QBT_TR(on port)QBT_TR[CONTEXT=OptionsDialog] 465">
+QBT_TR(Example:)QBT_TR[CONTEXT=OptionsDialog]
+QBT_TR(smtp.example.com:465 - connect to server smtp.example.com on port 465)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Improve the Options dialogs (Qt and WebUI) by adding tooltips to the sender email, recipient email, and SMTP server fields. These tooltips provide guidance, usage notes, and examples to help users correctly configure email notifications and reduce input errors.

### Background
There is very little information about how the email notifications should be configured, particularly around the ability to add a custom port to the server's address.
There can currently only be a single recipient address, so documenting that is useful.
I believe that adding these tooltips will help guide users as to how to properly configure the options.
Similar text has been added to the Wiki.

### GUI

<img width="474" height="230" alt="image" src="https://github.com/user-attachments/assets/a5a9fb37-a097-4365-86d8-a849fdb8c009" />
&nbsp;
<img width="474" height="230" alt="image" src="https://github.com/user-attachments/assets/ced76907-29f5-4efa-b130-e5426bffee82" />
&nbsp;
<img width="474" height="230" alt="image" src="https://github.com/user-attachments/assets/914542db-0fe5-423c-a02f-a5f89c85d539" />

### WebUI

<img width="549" height="234" alt="image" src="https://github.com/user-attachments/assets/bd929f7e-e458-4501-8e4a-868405840295" />
&nbsp;
<img width="549" height="234" alt="image" src="https://github.com/user-attachments/assets/b8c669fa-9783-4f8e-8228-b56016f5ced4" />
&nbsp;
<img width="549" height="234" alt="image" src="https://github.com/user-attachments/assets/7c20945b-d7e7-408f-94ab-479ab5ab6772" />
