### PR TITLE
WebUI: Fix sync using wrong key for full update check

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -925,7 +925,7 @@ window.addEventListener("DOMContentLoaded", async (event) => {
                         let updateTags = false;
                         let updateTrackers = false;
                         let updateTorrents = false;
-                        const fullUpdate = (responseJSON["fullUpdate"] === true);
+                        const fullUpdate = (responseJSON["full_update"] === true);
                         if (fullUpdate) {
                             torrentsTableSelectedRows = torrentsTable.selectedRowsIds();
                             updateStatuses = true;


### PR DESCRIPTION
I was adding torrents with a stopped status with multiple tabs (middle clicking magnet links) and got into a state where I couldn't remove a torrent by right clicking and clicking "remove". It turns out that the server sends snake case keys but the client was looking for camel case. It's a one line fix.

### AI below

### Problem

When multiple WebUI tabs are open, the sync poller occasionally receives a full-update response from the server (full_update: true). The client was checking for this flag using responseJSON["fullUpdate"] (camelCase), but the server always sends it as full_update (snake_case), as defined by KEY_FULL_UPDATE in synccontroller.cpp.

Because the key never matched, fullUpdate was always false. This meant torrentsTable.clear() was never called before repopulating, leaving stale UI state across tabs. A visible symptom was that torrent action buttons (e.g. Remove) remained enabled for torrents added in a separate tab with a stopped status, since the table was never properly reset and rebuilt.

### Fix

Change the key lookup from "fullUpdate" to "full_update" to match the actual server response format.

### Change

src/webui/www/private/scripts/client.js:

```js
  // Before
  const fullUpdate = (responseJSON["fullUpdate"] === true);
  // After
  const fullUpdate = (responseJSON["full_update"] === true);
```

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
