### PR TITLE
Add "Time Since Added" column to transfer list

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -29,9 +29,12 @@
 
 #include "transferlistmodel.h"
 
+#include <algorithm>
+
 #include <QApplication>
 #include <QDateTime>
 #include <QDebug>
+#include <QTimer>
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
@@ -48,6 +51,44 @@ using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
+    constexpr int ADDED_AGE_REFRESH_INTERVAL = 15 * 1000;
+    constexpr qint64 MINUTE = 60;
+    constexpr qint64 HOUR = 60 * MINUTE;
+    constexpr qint64 DAY = 24 * HOUR;
+    constexpr qint64 MONTH = 30 * DAY;
+    constexpr qint64 YEAR = 12 * MONTH;
+
+    qint64 elapsedSecondsSince(const QDateTime &dateTime, const QDateTime &currentDateTime)
+    {
+        if (!dateTime.isValid())
+            return -1;
+
+        return std::max<qint64>(0, dateTime.secsTo(currentDateTime));
+    }
+
+    QString singleUnitAddedAgeString(const qint64 seconds)
+    {
+        if (seconds < 0)
+            return {};
+
+        if (seconds < HOUR)
+        {
+            const qint64 minutes = std::max<qint64>(1, (seconds / MINUTE));
+            return u"%1 m"_s.arg(QString::number(minutes));
+        }
+
+        if (seconds <= (72 * HOUR))
+            return u"%1 h"_s.arg(QString::number(seconds / HOUR));
+
+        if (seconds <= (90 * DAY))
+            return u"%1 d"_s.arg(QString::number(seconds / DAY));
+
+        if (seconds <= (24 * MONTH))
+            return u"%1 mo"_s.arg(QString::number(seconds / MONTH));
+
+        return u"%1 y"_s.arg(QString::number(seconds / YEAR));
+    }
+
     QHash<BitTorrent::TorrentState, QColor> torrentStateColorsFromUITheme()
     {
         struct TorrentStateColorDescriptor
@@ -115,6 +156,11 @@ TransferListModel::TransferListModel(QObject *parent)
     configure();
     connect(Preferences::instance(), &Preferences::changed, this, &TransferListModel::configure);
 
+    m_addedAgeRefreshTimer = new QTimer(this);
+    m_addedAgeRefreshTimer->setInterval(ADDED_AGE_REFRESH_INTERVAL);
+    connect(m_addedAgeRefreshTimer, &QTimer::timeout, this, &TransferListModel::refreshAddedAgeColumn);
+    m_addedAgeRefreshTimer->start();
+
     loadUIThemeResources();
     connect(UIThemeManager::instance(), &UIThemeManager::themeChanged, this, [this]
     {
@@ -174,6 +220,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_TAGS: return tr("Tags");
             case TR_CREATE_DATE: return tr("Created On", "Torrent was initially created on 01/01/2010 08:00");
             case TR_ADD_DATE: return tr("Added On", "Torrent was added to transfer list on 01/01/2010 08:00");
+            case TR_TIME_SINCE_ADDED: return tr("Time Since Added", "Time elapsed since torrent was added to transfer list");
             case TR_SEED_DATE: return tr("Completed On", "Torrent was completed on 01/01/2010 08:00");
             case TR_TRACKER: return tr("Tracker");
             case TR_DLLIMIT: return tr("Down Limit", "i.e: Download limit");
@@ -232,6 +279,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_QUEUE_POSITION:
             case TR_LAST_ACTIVITY:
             case TR_AVAILABILITY:
+            case TR_TIME_SINCE_ADDED:
             case TR_REANNOUNCE:
                 return QVariant(Qt::AlignRight | Qt::AlignVCenter);
             default:
@@ -245,6 +293,8 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
 
 QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, const int column) const
 {
+    const QDateTime currentDateTime = QDateTime::currentDateTimeUtc();
+
     bool hideValues = false;
     if (m_hideZeroValuesMode == HideZeroValuesMode::Always)
         hideValues = true;
@@ -369,6 +419,14 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return tr("N/A");
     };
 
+    const auto addedAgeString = [&currentDateTime](const QDateTime &addedTime) -> QString
+    {
+        if (const qint64 elapsedTime = elapsedSecondsSince(addedTime, currentDateTime); elapsedTime >= 0)
+            return singleUnitAddedAgeString(elapsedTime);
+
+        return {};
+    };
+
     switch (column)
     {
     case TR_NAME:
@@ -405,6 +463,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return QLocale().toString(torrent->creationDate().toLocalTime(), QLocale::ShortFormat);
     case TR_ADD_DATE:
         return QLocale().toString(torrent->addedTime().toLocalTime(), QLocale::ShortFormat);
+    case TR_TIME_SINCE_ADDED:
+        return addedAgeString(torrent->addedTime());
     case TR_SEED_DATE:
         return QLocale().toString(torrent->completedTime().toLocalTime(), QLocale::ShortFormat);
     case TR_TRACKER:
@@ -454,6 +514,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
 
 QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, const int column, const bool alt) const
 {
+    const QDateTime currentDateTime = QDateTime::currentDateTimeUtc();
+
     switch (column)
     {
     case TR_NAME:
@@ -488,6 +550,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->creationDate();
     case TR_ADD_DATE:
         return torrent->addedTime();
+    case TR_TIME_SINCE_ADDED:
+        return elapsedSecondsSince(torrent->addedTime(), currentDateTime);
     case TR_SEED_DATE:
         return torrent->completedTime();
     case TR_TRACKER:
@@ -570,11 +634,14 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
         case TR_CATEGORY:
         case TR_TAGS:
         case TR_TRACKER:
+        case TR_TIME_SINCE_ADDED:
         case TR_SAVE_PATH:
         case TR_DOWNLOAD_PATH:
         case TR_INFOHASH_V1:
         case TR_INFOHASH_V2:
-            return displayValue(torrent, index.column());
+            return (index.column() == TR_TIME_SINCE_ADDED)
+                ? displayValue(torrent, TR_ADD_DATE)
+                : displayValue(torrent, index.column());
         }
         break;
     case Qt::TextAlignmentRole:
@@ -601,6 +668,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
         case TR_QUEUE_POSITION:
         case TR_LAST_ACTIVITY:
         case TR_AVAILABILITY:
+        case TR_TIME_SINCE_ADDED:
         case TR_REANNOUNCE:
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
         }
@@ -714,6 +782,14 @@ void TransferListModel::handleTorrentsUpdated(const QList<BitTorrent::Torrent *>
         // save the overhead when more than half of the torrent list needs update
         emit dataChanged(index(0, 0), index((rowCount() - 1), columns));
     }
+}
+
+void TransferListModel::refreshAddedAgeColumn()
+{
+    if (rowCount() <= 0)
+        return;
+
+    emit dataChanged(index(0, TR_TIME_SINCE_ADDED), index((rowCount() - 1), TR_TIME_SINCE_ADDED), {Qt::DisplayRole});
 }
 
 void TransferListModel::configure()

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -42,6 +42,8 @@ namespace BitTorrent
     class InfoHash;
 }
 
+class QTimer;
+
 class TransferListModel final : public QAbstractListModel
 {
     Q_OBJECT
@@ -66,6 +68,7 @@ public:
         TR_CATEGORY,
         TR_TAGS,
         TR_ADD_DATE,
+        TR_TIME_SINCE_ADDED,
         TR_SEED_DATE,
         TR_TRACKER,
         TR_DLLIMIT,
@@ -114,6 +117,7 @@ private slots:
     void handleTorrentAboutToBeRemoved(BitTorrent::Torrent *torrent);
     void handleTorrentStatusUpdated(BitTorrent::Torrent *torrent);
     void handleTorrentsUpdated(const QList<BitTorrent::Torrent *> &torrents);
+    void refreshAddedAgeColumn();
 
 private:
     void configure();
@@ -149,6 +153,7 @@ private:
     QIcon m_stalledDLIcon;
     QIcon m_stalledUPIcon;
     QIcon m_uploadingIcon;
+    QTimer *m_addedAgeRefreshTimer = nullptr;
 };
 
 Q_DECLARE_METATYPE(TransferListModel::Column)

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -242,6 +242,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_LAST_ACTIVITY:
     case TransferListModel::TR_REANNOUNCE:
     case TransferListModel::TR_SIZE:
+    case TransferListModel::TR_TIME_SINCE_ADDED:
     case TransferListModel::TR_TIME_ELAPSED:
     case TransferListModel::TR_TOTAL_SIZE:
         return customCompare(leftValue.toLongLong(), rightValue.toLongLong());

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -157,6 +157,7 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
     {
         setColumnHidden(TransferListModel::TR_CREATE_DATE, true);
         setColumnHidden(TransferListModel::TR_ADD_DATE, true);
+        setColumnHidden(TransferListModel::TR_TIME_SINCE_ADDED, true);
         setColumnHidden(TransferListModel::TR_SEED_DATE, true);
         setColumnHidden(TransferListModel::TR_UPLIMIT, true);
         setColumnHidden(TransferListModel::TR_DLLIMIT, true);

--- a/src/lang/qbittorrent_pl.ts
+++ b/src/lang/qbittorrent_pl.ts
@@ -12268,6 +12268,11 @@ Wybierz inną nazwę i spróbuj ponownie.</translation>
         <translation>Dodano</translation>
     </message>
     <message>
+        <source>Time Since Added</source>
+        <comment>Time elapsed since torrent was added to transfer list</comment>
+        <translation>Czas od dodania</translation>
+    </message>
+    <message>
         <location filename="../gui/transferlistmodel.cpp" line="175"/>
         <source>Completed On</source>
         <comment>Torrent was completed on 01/01/2010 08:00</comment>

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -65,6 +65,28 @@ window.qBittorrent.DynamicTable ??= (() => {
         return 0;
     };
 
+    const formatTimeSinceAdded = (seconds) => {
+        const minute = 60;
+        const hour = 60 * minute;
+        const day = 24 * hour;
+        const month = 30 * day;
+        const year = 12 * month;
+
+        if (seconds < hour)
+            return `${Math.max(1, Math.floor(seconds / minute))} m`;
+
+        if (seconds <= (72 * hour))
+            return `${Math.floor(seconds / hour)} h`;
+
+        if (seconds <= (90 * day))
+            return `${Math.floor(seconds / day)} d`;
+
+        if (seconds <= (24 * month))
+            return `${Math.floor(seconds / month)} mo`;
+
+        return `${Math.floor(seconds / year)} y`;
+    };
+
     const localPreferences = new window.qBittorrent.LocalPreferences.LocalPreferences();
     const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData;
 
@@ -1145,6 +1167,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("category", "", "QBT_TR(Category)QBT_TR[CONTEXT=TransferListModel]", 100, true);
             this.newColumn("tags", "", "QBT_TR(Tags)QBT_TR[CONTEXT=TransferListModel]", 100, true);
             this.newColumn("added_on", "", "QBT_TR(Added On)QBT_TR[CONTEXT=TransferListModel]", 100, true);
+            this.newColumn("time_since_added", "", "QBT_TR(Time Since Added)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("completion_on", "", "QBT_TR(Completed On)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("tracker", "", "QBT_TR(Tracker)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("dl_limit", "", "QBT_TR(Down Limit)QBT_TR[CONTEXT=TransferListModel]", 100, false);
@@ -1172,6 +1195,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["num_seeds"].dataProperties.push("num_complete");
             this.columns["num_leechs"].dataProperties.push("num_incomplete");
             this.columns["time_active"].dataProperties.push("seeding_time");
+            this.columns["time_since_added"].dataProperties[0] = "added_on";
 
             this.initColumnsFunctions();
         }
@@ -1450,6 +1474,18 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
                 td.textContent = date;
                 td.title = date;
+            };
+
+            // time_since_added
+            this.columns["time_since_added"].updateTd = function(td, row) {
+                const addedOn = this.getRowValue(row);
+                const duration = formatTimeSinceAdded(Math.max((Date.now() / 1000) - addedOn, 0));
+                const date = window.qBittorrent.Misc.formatDate(new Date(addedOn * 1000));
+                td.textContent = duration;
+                td.title = date;
+            };
+            this.columns["time_since_added"].compareRows = function(row1, row2) {
+                return compareNumbers(this.getRowValue(row2), this.getRowValue(row1));
             };
 
             // completion_on

--- a/src/webui/www/translations/webui_pl.ts
+++ b/src/webui/www/translations/webui_pl.ts
@@ -2931,6 +2931,11 @@ Użyj ';' do rozdzielania wielu wpisów. Można użyć wieloznacznika '*'.</tran
         <translation>Dodano</translation>
     </message>
     <message>
+        <source>Time Since Added</source>
+        <comment>Time elapsed since torrent was added to transfer list</comment>
+        <translation>Czas od dodania</translation>
+    </message>
+    <message>
         <source>Completed On</source>
         <comment>Torrent was completed on 01/01/2010 08:00</comment>
         <translation>Ukończono</translation>


### PR DESCRIPTION
## Summary
This PR adds a new "Time Since Added" column to the transfer list.

The column shows the elapsed time since a torrent was added and is available
in both the desktop UI and WebUI.

## Details
- adds the new column to the transfer list
- supports sorting by added time
- updates the displayed value periodically
- keeps the exact added date in the tooltip
- includes Polish translation updates for the new column label
- uses compact single-unit formatting

Formatting thresholds:
- below 1 hour: minutes
- up to 72 hours: hours
- up to 90 days: days
- up to 24 months: months
- beyond that: years

Examples:
- `5 m`
- `12 h`
- `7 d`
- `4 mo`
- `2 y`

## Testing
- built successfully with CMake/Ninja on Windows
- verified desktop UI build
- verified WebUI script syntax

## Screenshots:
<img width="1171" height="665" alt="qbittorrent_time_since_added" src="https://github.com/user-attachments/assets/40277c31-2d74-4753-aaea-9a8ff67bdf94" />
<img width="1230" height="836" alt="qbittorrent_time_since_added_webui" src="https://github.com/user-attachments/assets/148c421f-aaee-4ee9-8a38-5290c2eb1ac3" />
