### PR TITLE
Destroy top-level widgets before destroying core components

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1373,6 +1373,28 @@ void Application::cleanup()
             m_desktopIntegration->menu()->setEnabled(false);
     }
 
+#ifdef Q_OS_MACOS
+    // Remove all accessibility interface factories before destroying widgets.
+    // On macOS, widget destruction triggers accessibility notifications via
+    // the native AX API, which can deadlock with the Qt event loop causing
+    // the app to freeze on quit.
+    // https://github.com/qbittorrent/qBittorrent/issues/23695
+    if (m_window)
+        QAccessible::cleanup();
+#endif
+
+    // Close and delete any remaining top-level widgets (e.g. parentless dialogs
+    // like AddNewTorrentDialog on macOS). These must be destroyed before core
+    // components like SettingsStorage are freed, because their destructors or
+    // done() handlers may save state via SettingValue.
+    // https://github.com/qbittorrent/qBittorrent/issues/23461
+    const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
+    for (QWidget *widget : topLevelWidgets)
+    {
+        if (widget != m_window)
+            delete widget;
+    }
+
     if (m_window)
     {
         // Hide the window and don't leave it on screen as
@@ -1387,15 +1409,6 @@ void Application::cleanup()
             , msg.c_str());
 #endif // Q_OS_WIN
 
-#ifdef Q_OS_MACOS
-        // Remove all accessibility interface factories before destroying widgets.
-        // On macOS, widget destruction triggers accessibility notifications via
-        // the native AX API, which can deadlock with the Qt event loop causing
-        // the app to freeze on quit.
-        // https://github.com/qbittorrent/qBittorrent/issues/23695
-        QAccessible::cleanup();
-#endif
-
         // Do manual cleanup in MainWindow to force widgets
         // to save their Preferences, stop all timers and
         // delete as many widgets as possible to leave only
@@ -1404,18 +1417,6 @@ void Application::cleanup()
         // otherwise the system shutdown will continue even
         // though we created a ShutdownBlockReason
         m_window->cleanup();
-    }
-
-    // Close and delete any remaining top-level widgets (e.g. parentless dialogs
-    // like AddNewTorrentDialog on macOS). These must be destroyed before core
-    // components like SettingsStorage are freed, because their destructors or
-    // done() handlers may save state via SettingValue.
-    // https://github.com/qbittorrent/qBittorrent/issues/23461
-    const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
-    for (QWidget *widget : topLevelWidgets)
-    {
-        if (widget != m_window)
-            delete widget;
     }
 #endif // DISABLE_GUI
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1405,6 +1405,18 @@ void Application::cleanup()
         // though we created a ShutdownBlockReason
         m_window->cleanup();
     }
+
+    // Close and delete any remaining top-level widgets (e.g. parentless dialogs
+    // like AddNewTorrentDialog on macOS). These must be destroyed before core
+    // components like SettingsStorage are freed, because their destructors or
+    // done() handlers may save state via SettingValue.
+    // https://github.com/qbittorrent/qBittorrent/issues/23461
+    const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
+    for (QWidget *widget : topLevelWidgets)
+    {
+        if (widget != m_window)
+            delete widget;
+    }
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI

--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -45,7 +45,9 @@ public:
 
     T get(const T &defaultValue = {}) const
     {
-        return SettingsStorage::instance()->loadValue(m_keyName, defaultValue);
+        if (auto *instance = SettingsStorage::instance()) [[likely]]
+            return instance->loadValue(m_keyName, defaultValue);
+        return defaultValue;
     }
 
     operator T() const
@@ -55,7 +57,8 @@ public:
 
     SettingValue<T> &operator=(const T &value)
     {
-        SettingsStorage::instance()->storeValue(m_keyName, value);
+        if (auto *instance = SettingsStorage::instance()) [[likely]]
+            instance->storeValue(m_keyName, value);
         return *this;
     }
 

--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -45,9 +45,7 @@ public:
 
     T get(const T &defaultValue = {}) const
     {
-        if (auto *instance = SettingsStorage::instance()) [[likely]]
-            return instance->loadValue(m_keyName, defaultValue);
-        return defaultValue;
+        return SettingsStorage::instance()->loadValue(m_keyName, defaultValue);
     }
 
     operator T() const
@@ -57,8 +55,7 @@ public:
 
     SettingValue<T> &operator=(const T &value)
     {
-        if (auto *instance = SettingsStorage::instance()) [[likely]]
-            instance->storeValue(m_keyName, value);
+        SettingsStorage::instance()->storeValue(m_keyName, value);
         return *this;
     }
 


### PR DESCRIPTION
## Summary
- Explicitly destroy all remaining top-level widgets (e.g. parentless `AddNewTorrentDialog` on macOS) in `Application::cleanup()` after `MainWindow::cleanup()` but before `SettingsStorage::freeInstance()`, ensuring proper shutdown ordering

**Root cause:** During shutdown, `Application::cleanup()` calls `MainWindow::cleanup()` which destroys child widgets. However, top-level dialogs like `AddNewTorrentDialog` (which has `parent=nullptr` on macOS, and optionally on other platforms when `isAddNewTorrentDialogAttached()` is false) are not children of `MainWindow` and survive past `SettingsStorage::freeInstance()`. When Qt's event loop later destroys these orphaned dialogs, their `done()` handler calls `saveState()` which accesses the already-freed `SettingsStorage` → SIGSEGV.

**Stack trace from issue:**
```
3# QReadWriteLock::tryLockForWrite(QDeadlineTimer)
4# SettingsStorage::storeValueImpl(QString const&, QVariant const&)
5# AddNewTorrentDialog::saveState()
6# AddNewTorrentDialog::~AddNewTorrentDialog()
```

Closes https://github.com/qbittorrent/qBittorrent/issues/23461

## Test plan
- [ ] On macOS, open the Add New Torrent dialog, then quit the app with Cmd+Q while the dialog is open — should not crash
- [ ] Verify settings are still saved correctly during normal operation
- [ ] Verify no regression on Windows and Linux