### PR TITLE
Fix category share limits not falling back to global limits

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -995,7 +995,15 @@ ShareLimits SessionImpl::categoryShareLimits(const QString &categoryName) const
         return shareLimits();
 
     const ShareLimits categoryShareLimits = categoryOptions(categoryName).shareLimits;
-    const ShareLimits parentCategoryShareLimits = categoryOptions(parentCategoryName(categoryName)).shareLimits;
+    const bool hasDefaults = (categoryShareLimits.ratioLimit == DEFAULT_RATIO_LIMIT)
+            || (categoryShareLimits.seedingTimeLimit == DEFAULT_SEEDING_TIME_LIMIT)
+            || (categoryShareLimits.inactiveSeedingTimeLimit == DEFAULT_SEEDING_TIME_LIMIT)
+            || (categoryShareLimits.mode == ShareLimitsMode::Default)
+            || (categoryShareLimits.action == ShareLimitAction::Default);
+    if (!hasDefaults)
+        return categoryShareLimits;
+
+    const ShareLimits parentCategoryShareLimits = this->categoryShareLimits(parentCategoryName(categoryName));
     return {
         .ratioLimit = (categoryShareLimits.ratioLimit != DEFAULT_RATIO_LIMIT)
             ? categoryShareLimits.ratioLimit : parentCategoryShareLimits.ratioLimit,

--- a/src/base/bittorrent/sharelimits.h
+++ b/src/base/bittorrent/sharelimits.h
@@ -81,7 +81,6 @@ namespace BitTorrent
 
         ShareLimitAction action = ShareLimitAction::Default;
 
-
         friend bool operator==(const ShareLimits &lhs, const ShareLimits &rhs) = default;
     };
 }


### PR DESCRIPTION
## Summary

- `categoryShareLimits()` was using `categoryOptions()` to retrieve parent category limits, which returns raw defaults instead of resolving the full category hierarchy
- This caused torrents in categories without explicit share limits to ignore the global limits and seed indefinitely
- Replaced with a recursive `categoryShareLimits()` call so limits are properly resolved up through parent categories until reaching the global defaults

Closes #24051