### PR TITLE
Add "Queued tracker announces" session metric

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1827,6 +1827,10 @@ void SessionImpl::initMetrics()
             .hashJobs = findMetricIndex("disk.num_blocks_hashed"),
             .queuedDiskJobs = findMetricIndex("disk.queued_disk_jobs"),
             .diskJobTime = findMetricIndex("disk.disk_job_time")
+        },
+        .tracker =
+        {
+            .numQueuedTrackerAnnounces = findMetricIndex("tracker.num_queued_tracker_announces")
         }
     };
 }
@@ -6229,6 +6233,8 @@ void SessionImpl::handleSessionStatsAlert(const lt::session_stats_alert *alert)
     m_status.diskReadQueue = stats[m_metricIndices.peer.numPeersUpDisk];
     m_status.diskWriteQueue = stats[m_metricIndices.peer.numPeersDownDisk];
     m_status.peersCount = stats[m_metricIndices.peer.numPeersConnected];
+
+    m_status.queuedTrackerAnnounces = stats[m_metricIndices.tracker.numQueuedTrackerAnnounces];
 
     if (totalDownload > m_status.totalDownload)
     {

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -132,6 +132,11 @@ namespace BitTorrent
             int queuedDiskJobs = -1;
             int diskJobTime = -1;
         } disk;
+
+        struct
+        {
+            int numQueuedTrackerAnnounces = -1;
+        } tracker;
     };
 
     class SessionImpl final : public Session

--- a/src/base/bittorrent/sessionstatus.h
+++ b/src/base/bittorrent/sessionstatus.h
@@ -73,5 +73,7 @@ namespace BitTorrent
         qint64 diskWriteQueue = 0;
         qint64 dhtNodes = 0;
         qint64 peersCount = 0;
+
+        qint64 queuedTrackerAnnounces = 0;
     };
 }

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -49,16 +49,16 @@ StatsDialog::StatsDialog(QWidget *parent)
 {
     m_ui->setupUi(this);
 
-    connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &StatsDialog::close);
-
-    update();
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::statsUpdated
-            , this, &StatsDialog::update);
-
 #ifdef QBT_USES_LIBTORRENT2
     m_ui->labelCacheHitsText->hide();
     m_ui->labelCacheHits->hide();
 #endif
+
+    connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &StatsDialog::close);
+
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::statsUpdated
+            , this, &StatsDialog::update);
+    update();
 
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
         resize(dialogSize);
@@ -114,4 +114,7 @@ void StatsDialog::update()
 
     // Total connected peers
     m_ui->labelPeers->setText(QString::number(ss.peersCount));
+
+    // Tracker statistics
+    m_ui->labelQueuedTrackerAnnounces->setText(QString::number(ss.queuedTrackerAnnounces));
 }

--- a/src/gui/statsdialog.ui
+++ b/src/gui/statsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>286</width>
-    <height>401</height>
+    <width>288</width>
+    <height>489</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -203,6 +203,29 @@
        <widget class="QLabel" name="labelQueuedBytes">
         <property name="text">
          <string notr="true">TextLabel</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupTracker">
+     <property name="title">
+      <string>Tracker statistics</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelQueuedTrackerAnnouncesText_2">
+        <property name="text">
+         <string>Queued tracker announces:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QLabel" name="labelQueuedTrackerAnnounces">
+        <property name="text">
+         <string>TextLabel</string>
         </property>
        </widget>
       </item>

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -107,6 +107,7 @@ namespace
     const QString KEY_TRANSFER_TOTAL_QUEUED_SIZE = u"total_queued_size"_s;
     const QString KEY_TRANSFER_TOTAL_WASTE_SESSION = u"total_wasted_session"_s;
     const QString KEY_TRANSFER_WRITE_CACHE_OVERLOAD = u"write_cache_overload"_s;
+    const QString KEY_TRANSFER_QUEUED_TRACKER_ANNOUNCES = u"queued_tracker_announces"_s;
 
     const QString KEY_SUFFIX_REMOVED = u"_removed"_s;
 
@@ -192,6 +193,9 @@ namespace
         map[KEY_TRANSFER_CONNECTION_STATUS] = session->isListening()
             ? (sessionStatus.hasIncomingConnections ? u"connected"_s : u"firewalled"_s)
             : u"disconnected"_s;
+
+        // Tracker statistics
+        map[KEY_TRANSFER_QUEUED_TRACKER_ANNOUNCES] = sessionStatus.queuedTrackerAnnounces;
 
         return map;
     }

--- a/src/webui/www/private/scripts/statistics.js
+++ b/src/webui/www/private/scripts/statistics.js
@@ -45,6 +45,8 @@ window.qBittorrent.Statistics ??= (() => {
         queuedIOJobs: 0,
         averageTimeInQueue: 0,
         totalQueuedSize: 0,
+        // Tracker statistics
+        queuedTrackerAnnounces: 0
     };
 
     const save = (serverState) => {
@@ -60,6 +62,8 @@ window.qBittorrent.Statistics ??= (() => {
         statistics.queuedIOJobs = serverState.queued_io_jobs;
         statistics.averageTimeInQueue = serverState.average_time_queue;
         statistics.totalQueuedSize = serverState.total_queued_size;
+        // Tracker statistics
+        statistics.queuedTrackerAnnounces = serverState.queued_tracker_announces;
     };
 
     const render = () => {
@@ -78,6 +82,8 @@ window.qBittorrent.Statistics ??= (() => {
         document.getElementById("QueuedIOJobs").textContent = statistics.queuedIOJobs;
         document.getElementById("AverageTimeInQueue").textContent = `${statistics.averageTimeInQueue} ms`;
         document.getElementById("TotalQueuedSize").textContent = window.qBittorrent.Misc.friendlyUnit(statistics.totalQueuedSize, false);
+        // Tracker statistics
+        document.getElementById("queuedTrackerAnnounces").textContent = statistics.queuedTrackerAnnounces;
     };
 
     return exports();

--- a/src/webui/www/private/views/statistics.html
+++ b/src/webui/www/private/views/statistics.html
@@ -62,4 +62,13 @@
             </tr>
         </tbody>
     </table>
+    <h3>QBT_TR(Tracker statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <table style="width:100%">
+        <tbody>
+            <tr>
+                <td>QBT_TR(Queued tracker announces:)QBT_TR[CONTEXT=StatsDialog]</td>
+                <td id="queuedTrackerAnnounces" class="statisticsValue"></td>
+            </tr>
+        </tbody>
+    </table>
 </div>


### PR DESCRIPTION
It shows the number of currently queued tracker announces.
This can guide the user to set a reasonable value for "Max concurrent HTTP announces" setting.

Screenshots:
<img width="298" height="498" alt="screenshot" src="https://github.com/user-attachments/assets/8b072160-7264-4c70-8e7e-037a638d44e4" />
