### PR TITLE
Conditionally exclude the code incompatible with libtorrent-2.1

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2044,7 +2044,7 @@ lt::settings_pack SessionImpl::loadLTSettings() const
     settingsPack.set_int(lt::settings_pack::num_outgoing_ports, (outgoingPortsMax() - outgoingPortsMin()));
     // UPnP lease duration
     settingsPack.set_int(lt::settings_pack::upnp_lease_duration, UPnPLeaseDuration());
-#if LIBTORRENT_VERSION_NUM >= 20013
+#if (LIBTORRENT_VERSION_NUM >= 20013) && (LIBTORRENT_VERSION_NUM < 20100)
     settingsPack.set_int(lt::settings_pack::natpmp_lease_duration, UPnPLeaseDuration());
 #endif
     // Type of service


### PR DESCRIPTION
`lt::settings_pack::natpmp_lease_duration` isn't ported to `libtorrent` master for now.
