### PR TITLE
Add 'Open Destination Folder' button to toolbar

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -316,8 +316,8 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     connect(m_ui->actionStop, &QAction::triggered, m_transferListWidget, &TransferListWidget::stopSelectedTorrents);
     connect(m_ui->actionPauseSession, &QAction::triggered, m_transferListWidget, &TransferListWidget::pauseSession);
     connect(m_ui->actionResumeSession, &QAction::triggered, m_transferListWidget, &TransferListWidget::resumeSession);
-    connect(m_ui->actionDelete, &QAction::triggered, m_transferListWidget, &TransferListWidget::softDeleteSelectedTorrents);
     connect(m_ui->actionOpenDestinationFolder, &QAction::triggered, m_transferListWidget, &TransferListWidget::openSelectedTorrentsFolder);
+    connect(m_ui->actionDelete, &QAction::triggered, m_transferListWidget, &TransferListWidget::softDeleteSelectedTorrents);
     connect(m_ui->actionTopQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::topQueuePosSelectedTorrents);
     connect(m_ui->actionIncreaseQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::increaseQueuePosSelectedTorrents);
     connect(m_ui->actionDecreaseQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::decreaseQueuePosSelectedTorrents);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -187,6 +187,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     m_ui->actionManageCookies->setIcon(UIThemeManager::instance()->getIcon(u"browser-cookies"_s, u"preferences-web-browser-cookies"_s));
     m_ui->menuLog->setIcon(UIThemeManager::instance()->getIcon(u"help-contents"_s));
     m_ui->actionCheckForUpdates->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));
+    m_ui->actionOpenDestinationFolder->setIcon(UIThemeManager::instance()->getIcon(u"directory"_s));
 
     m_ui->actionPauseSession->setVisible(!BitTorrent::Session::instance()->isPaused());
     m_ui->actionResumeSession->setVisible(BitTorrent::Session::instance()->isPaused());
@@ -316,6 +317,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     connect(m_ui->actionPauseSession, &QAction::triggered, m_transferListWidget, &TransferListWidget::pauseSession);
     connect(m_ui->actionResumeSession, &QAction::triggered, m_transferListWidget, &TransferListWidget::resumeSession);
     connect(m_ui->actionDelete, &QAction::triggered, m_transferListWidget, &TransferListWidget::softDeleteSelectedTorrents);
+    connect(m_ui->actionOpenDestinationFolder, &QAction::triggered, m_transferListWidget, &TransferListWidget::openSelectedTorrentsFolder);
     connect(m_ui->actionTopQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::topQueuePosSelectedTorrents);
     connect(m_ui->actionIncreaseQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::increaseQueuePosSelectedTorrents);
     connect(m_ui->actionDecreaseQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::decreaseQueuePosSelectedTorrents);

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -152,11 +152,11 @@
    </attribute>
    <addaction name="actionOpen"/>
    <addaction name="actionDownloadFromURL"/>
-   <addaction name="actionOpenDestinationFolder"/>
    <addaction name="actionDelete"/>
    <addaction name="separator"/>
    <addaction name="actionStart"/>
    <addaction name="actionStop"/>
+   <addaction name="actionOpenDestinationFolder"/>
    <addaction name="actionTopQueuePos"/>
    <addaction name="actionIncreaseQueuePos"/>
    <addaction name="actionDecreaseQueuePos"/>

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -152,6 +152,7 @@
    </attribute>
    <addaction name="actionOpen"/>
    <addaction name="actionDownloadFromURL"/>
+   <addaction name="actionOpenDestinationFolder"/>
    <addaction name="actionDelete"/>
    <addaction name="separator"/>
    <addaction name="actionStart"/>
@@ -488,6 +489,14 @@
   <action name="actionCloseWindow">
    <property name="text">
     <string>Close Window</string>
+   </property>
+  </action>
+  <action name="actionOpenDestinationFolder">
+   <property name="iconText">
+    <string>Open Folder</string>
+   </property>
+   <property name="text">
+    <string>Open Destination Folder</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
## Summary

The `Open Destination Folder` action is currently only accessible via the right-click context menu or the double-click `Behavior` option, both requiring more steps than a direct toolbar button for a frequently used operation.

## Changes

- Added `actionOpenDestinationFolder` to `mainwindow.ui`, placed after the Stop button in the toolbar
- Connected it in `mainwindow.cpp` to the already-existing `openSelectedTorrentsFolder()` in `TransferListWidget`
- Assigned the existing `directory` icon in `mainwindow.cpp`, alongside other action icon assignments

## Notes

No new logic was introduced. `openSelectedTorrentsFolder()` already existed in `TransferListWidget` and was already connected to the right-click context menu via a local `QAction`. This PR simply creates a named action in `mainwindow.ui` and connects it to the same function in `mainwindow.cpp`, following the exact same pattern used by all other existing toolbar buttons (e.g. `actionDelete`, `actionStart`, `actionStop`).