### PR TITLE
Fix inappropriate NULL use

### DIFF
--- a/src/gui/powermanagement/inhibitorwindows.cpp
+++ b/src/gui/powermanagement/inhibitorwindows.cpp
@@ -33,10 +33,10 @@
 
 bool InhibitorWindows::requestBusy()
 {
-    return ::SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED) != NULL;
+    return ::SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED) != 0;
 }
 
 bool InhibitorWindows::requestIdle()
 {
-    return ::SetThreadExecutionState(ES_CONTINUOUS) != NULL;
+    return ::SetThreadExecutionState(ES_CONTINUOUS) != 0;
 }


### PR DESCRIPTION
## Summary

Fix a pre-existing build error in `inhibitorwindows.cpp` where `NULL` was used in pointer arithmetic comparisons. This is flagged as a hard error (`-Werror=pointer-arith`) by GCC 15.

## Changes

- Replaced `!= NULL` with `!= 0` in two comparisons in `InhibitorWindows::requestBusy()` and `InhibitorWindows::requestIdle()`

## Notes

Discovered while building on MSYS2 with GCC 15. Separated from PR #24090 as requested.