### PR TITLE
WebUI: Add "Created On" column to transfer list

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1456,6 +1456,20 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = popularity;
             };
 
+            // creation_date
+            this.columns["creation_date"].updateTd = function(td, row) {
+                const val = this.getRowValue(row);
+                if ((val === 0xffffffff) || (val < 0)) {
+                    td.textContent = "";
+                    td.title = "";
+                }
+                else {
+                    const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
+                    td.textContent = date;
+                    td.title = date;
+                }
+            };
+
             // added on
             this.columns["added_on"].updateTd = function(td, row) {
                 const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
@@ -1476,9 +1490,6 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = date;
                 }
             };
-
-            // creation_date
-            this.columns["creation_date"].updateTd = this.columns["completion_on"].updateTd;
 
             // tracker
             this.columns["tracker"].updateTd = function(td, row) {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1154,6 +1154,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("popularity", "", "QBT_TR(Popularity)QBT_TR[CONTEXT=TransferListModel]", 100, true);
             this.newColumn("category", "", "QBT_TR(Category)QBT_TR[CONTEXT=TransferListModel]", 100, true);
             this.newColumn("tags", "", "QBT_TR(Tags)QBT_TR[CONTEXT=TransferListModel]", 100, true);
+            this.newColumn("creation_date", "", "QBT_TR(Created On)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("added_on", "", "QBT_TR(Added On)QBT_TR[CONTEXT=TransferListModel]", 100, true);
             this.newColumn("completion_on", "", "QBT_TR(Completed On)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("tracker", "", "QBT_TR(Tracker)QBT_TR[CONTEXT=TransferListModel]", 100, false);
@@ -1475,6 +1476,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = date;
                 }
             };
+
+            // creation_date
+            this.columns["creation_date"].updateTd = this.columns["completion_on"].updateTd;
 
             // tracker
             this.columns["tracker"].updateTd = function(td, row) {


### PR DESCRIPTION
Updates WebUI to add a column with the torrent's "Created On" date/time to the main transfer list (hidden by default).

This probably should have been included in qbittorrent/qBittorrent#23647.

Screenshot:

<img width="482" height="609" alt="image" src="https://github.com/user-attachments/assets/818f3ee1-e9b4-43ba-85f2-21bd3e74d8be" />