### PR TITLE
WebUI: Refactor handling of shared column update methods in DynamicTable

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1301,10 +1301,10 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayInfohash = function(td, row) {
-                const sourceInfohashV1 = this.getRowValue(row);
-                const infohashV1 = (sourceInfohashV1 !== "") ? sourceInfohashV1 : "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
-                td.textContent = infohashV1;
-                td.title = infohashV1;
+                const sourceInfohash = this.getRowValue(row);
+                const infohash = (sourceInfohash !== "") ? sourceInfohash : "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
+                td.textContent = infohash;
+                td.title = infohash;
             };
 
             // state_icon

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1282,17 +1282,17 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = string;
                 td.title = string;
             };
-            const displayCompletion = function(td, row) {
+            const displayDate = function(td, row) {
+                const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
+                td.textContent = date;
+                td.title = date;
+            };
+            const displayDateOrBlank = function(td, row) {
                 const val = this.getRowValue(row);
-                if ((val === 0xffffffff) || (val < 0)) {
-                    td.textContent = "";
-                    td.title = "";
-                }
-                else {
-                    const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
-                    td.textContent = date;
-                    td.title = date;
-                }
+                const useBlank = (val === 0xffffffff) || (val < 0);
+                const date = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(val * 1000));
+                td.textContent = date;
+                td.title = date;
             };
             const displayInfohash = function(td, row) {
                 const sourceInfohashV1 = this.getRowValue(row);
@@ -1482,17 +1482,13 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["popularity"].updateTd = displayRatio;
 
             // creation_date
-            this.columns["creation_date"].updateTd = displayCompletion;
+            this.columns["creation_date"].updateTd = displayDateOrBlank;
 
             // added on
-            this.columns["added_on"].updateTd = function(td, row) {
-                const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
-                td.textContent = date;
-                td.title = date;
-            };
+            this.columns["added_on"].updateTd = displayDate;
 
 			// completion_on
-            this.columns["completion_on"].updateTd = displayCompletion;
+            this.columns["completion_on"].updateTd = displayDateOrBlank;
 
             // tracker
             this.columns["tracker"].updateTd = function(td, row) {
@@ -1533,7 +1529,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["max_ratio"].updateTd = displayRatio;
 
             // seen_complete
-            this.columns["seen_complete"].updateTd = displayCompletion;
+            this.columns["seen_complete"].updateTd = displayDateOrBlank;
 
             // last_activity
             this.columns["last_activity"].updateTd = function(td, row) {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -2624,7 +2624,7 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         initColumnsFunctions() {
             const that = this;
-            
+
             const displaySize = function(td, row) {
                 const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
                 td.textContent = size;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -65,7 +65,7 @@ window.qBittorrent.DynamicTable ??= (() => {
         return 0;
     };
 
-    const formatValueAsDate = (value) => {
+    const toDateString = (value) => {
         return (value > 0) ? window.qBittorrent.Misc.formatDate(new Date(value * 1000)) : "";
     };
 
@@ -1293,7 +1293,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const date = formatValueAsDate(this.getRowValue(row));
+                const date = toDateString(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -1980,7 +1980,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const date = formatValueAsDate(this.getRowValue(row));
+                const date = toDateString(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -3422,7 +3422,7 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         initColumnsFunctions() {
             this.columns["timestamp"].updateTd = function(td, row) {
-                const date = formatValueAsDate(this.getRowValue(row));
+                const date = toDateString(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -3500,7 +3500,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("reason", "", "QBT_TR(Reason)QBT_TR[CONTEXT=ExecutionLogWidget]", 150, true);
 
             this.columns["timestamp"].updateTd = function(td, row) {
-                const date = formatValueAsDate(this.getRowValue(row));
+                const date = toDateString(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -3718,7 +3718,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const date = formatValueAsDate(this.getRowValue(row));
+                const date = toDateString(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1363,22 +1363,26 @@ window.qBittorrent.DynamicTable ??= (() => {
                 return compareNumbers(row1_val, row2_val);
             };
 
-            // name, category, tags
-            this.columns["name"].compareRows = function(row1, row2) {
+            const compareNames = function(row1, row2) {
                 const row1Val = this.getRowValue(row1);
                 const row2Val = this.getRowValue(row2);
                 return row1Val.localeCompare(row2Val, undefined, { numeric: true, sensitivity: "base" });
             };
-            this.columns["category"].compareRows = this.columns["name"].compareRows;
-            this.columns["tags"].compareRows = this.columns["name"].compareRows;
 
-            // size, total_size
-            this.columns["size"].updateTd = function(td, row) {
+			// name, category, tags
+            this.columns["name"].compareRows = compareNames;
+            this.columns["category"].compareRows = compareNames;
+            this.columns["tags"].compareRows = compareNames;
+
+            const displaySize = function(td, row) {
                 const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
                 td.textContent = size;
                 td.title = size;
             };
-            this.columns["total_size"].updateTd = this.columns["size"].updateTd;
+
+            // size, total_size
+            this.columns["size"].updateTd = displaySize;
+            this.columns["total_size"].updateTd = displaySize;
 
             // progress
             this.columns["progress"].updateTd = function(td, row) {
@@ -1396,8 +1400,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
             this.columns["progress"].staticWidth = 100;
 
-            // num_seeds
-            this.columns["num_seeds"].updateTd = function(td, row) {
+            const displaySeeds = function(td, row) {
                 const num_seeds = this.getRowValue(row, 0);
                 const num_complete = this.getRowValue(row, 1);
                 let value = num_seeds;
@@ -1406,7 +1409,8 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = value;
                 td.title = value;
             };
-            this.columns["num_seeds"].compareRows = function(row1, row2) {
+
+			const compareSeeds = function(row1, row2) {
                 const num_seeds1 = this.getRowValue(row1, 0);
                 const num_complete1 = this.getRowValue(row1, 1);
 
@@ -1419,19 +1423,23 @@ window.qBittorrent.DynamicTable ??= (() => {
                 return compareNumbers(num_seeds1, num_seeds2);
             };
 
-            // num_leechs
-            this.columns["num_leechs"].updateTd = this.columns["num_seeds"].updateTd;
-            this.columns["num_leechs"].compareRows = this.columns["num_seeds"].compareRows;
+            // num_seeds
+            this.columns["num_seeds"].updateTd = displaySeeds;
+            this.columns["num_seeds"].compareRows = compareSeeds;
 
-            // dlspeed
-            this.columns["dlspeed"].updateTd = function(td, row) {
+            // num_leechs
+            this.columns["num_leechs"].updateTd = displaySeeds;
+            this.columns["num_leechs"].compareRows = compareSeeds;
+
+            const displaySpeed = function(td, row) {
                 const speed = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), true);
                 td.textContent = speed;
                 td.title = speed;
             };
 
-            // upspeed
-            this.columns["upspeed"].updateTd = this.columns["dlspeed"].updateTd;
+			// dlspeed, upspeed
+            this.columns["dlspeed"].updateTd = displaySpeed;
+            this.columns["upspeed"].updateTd = displaySpeed;
 
             // eta
             this.columns["eta"].updateTd = function(td, row) {
@@ -1440,24 +1448,20 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = eta;
             };
 
-            // ratio
-            this.columns["ratio"].updateTd = function(td, row) {
+			const displayRatio = function(td, row) {
                 const ratio = this.getRowValue(row);
                 const string = (ratio === -1) ? "∞" : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
                 td.textContent = string;
                 td.title = string;
             };
 
-            // popularity
-            this.columns["popularity"].updateTd = function(td, row) {
-                const value = this.getRowValue(row);
-                const popularity = (value === -1) ? "∞" : window.qBittorrent.Misc.toFixedPointString(value, 2);
-                td.textContent = popularity;
-                td.title = popularity;
-            };
+			// ratio
+            this.columns["ratio"].updateTd = displayRatio;
 
-            // creation_date
-            this.columns["creation_date"].updateTd = function(td, row) {
+            // popularity
+            this.columns["popularity"].updateTd = displayRatio;
+
+            const displayCompletion = function(td, row) {
                 const val = this.getRowValue(row);
                 if ((val === 0xffffffff) || (val < 0)) {
                     td.textContent = "";
@@ -1469,6 +1473,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = date;
                 }
             };
+
+            // creation_date
+            this.columns["creation_date"].updateTd = displayCompletion;
 
             // added on
             this.columns["added_on"].updateTd = function(td, row) {
@@ -1477,19 +1484,8 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = date;
             };
 
-            // completion_on
-            this.columns["completion_on"].updateTd = function(td, row) {
-                const val = this.getRowValue(row);
-                if ((val === 0xffffffff) || (val < 0)) {
-                    td.textContent = "";
-                    td.title = "";
-                }
-                else {
-                    const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
-                    td.textContent = date;
-                    td.title = date;
-                }
-            };
+			// completion_on
+            this.columns["completion_on"].updateTd = displayCompletion;
 
             // tracker
             this.columns["tracker"].updateTd = function(td, row) {
@@ -1499,8 +1495,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = value;
             };
 
-            //  dl_limit, up_limit
-            this.columns["dl_limit"].updateTd = function(td, row) {
+			const displayLimit = function(td, row) {
                 const speed = this.getRowValue(row);
                 if (speed === 0) {
                     td.textContent = "∞";
@@ -1513,14 +1508,16 @@ window.qBittorrent.DynamicTable ??= (() => {
                 }
             };
 
-            this.columns["up_limit"].updateTd = this.columns["dl_limit"].updateTd;
+            //  dl_limit, up_limit
+            this.columns["dl_limit"].updateTd = displayLimit;
+            this.columns["up_limit"].updateTd = displayLimit;
 
             // downloaded, uploaded, downloaded_session, uploaded_session, amount_left
-            this.columns["downloaded"].updateTd = this.columns["size"].updateTd;
-            this.columns["uploaded"].updateTd = this.columns["size"].updateTd;
-            this.columns["downloaded_session"].updateTd = this.columns["size"].updateTd;
-            this.columns["uploaded_session"].updateTd = this.columns["size"].updateTd;
-            this.columns["amount_left"].updateTd = this.columns["size"].updateTd;
+            this.columns["downloaded"].updateTd = displaySize;
+            this.columns["uploaded"].updateTd = displaySize;
+            this.columns["downloaded_session"].updateTd = displaySize;
+            this.columns["uploaded_session"].updateTd = displaySize;
+            this.columns["amount_left"].updateTd = displaySize;
 
             // time active
             this.columns["time_active"].updateTd = function(td, row) {
@@ -1536,13 +1533,13 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             // completed
-            this.columns["completed"].updateTd = this.columns["size"].updateTd;
+            this.columns["completed"].updateTd = displaySize;
 
             // max_ratio
-            this.columns["max_ratio"].updateTd = this.columns["ratio"].updateTd;
+            this.columns["max_ratio"].updateTd = displayRatio;
 
             // seen_complete
-            this.columns["seen_complete"].updateTd = this.columns["completion_on"].updateTd;
+            this.columns["seen_complete"].updateTd = displayCompletion;
 
             // last_activity
             this.columns["last_activity"].updateTd = function(td, row) {
@@ -1565,21 +1562,16 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = value;
             };
 
-            // infohash_v1
-            this.columns["infohash_v1"].updateTd = function(td, row) {
+            const displayInfohash = function(td, row) {
                 const sourceInfohashV1 = this.getRowValue(row);
                 const infohashV1 = (sourceInfohashV1 !== "") ? sourceInfohashV1 : "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
                 td.textContent = infohashV1;
                 td.title = infohashV1;
             };
 
-            // infohash_v2
-            this.columns["infohash_v2"].updateTd = function(td, row) {
-                const sourceInfohashV2 = this.getRowValue(row);
-                const infohashV2 = (sourceInfohashV2 !== "") ? sourceInfohashV2 : "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
-                td.textContent = infohashV2;
-                td.title = infohashV2;
-            };
+			// infohash_v1, infohash_v2
+            this.columns["infohash_v1"].updateTd = displayInfohash;
+            this.columns["infohash_v2"].updateTd = displayInfohash;
 
             // reannounce
             this.columns["reannounce"].updateTd = function(td, row) {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -66,7 +66,7 @@ window.qBittorrent.DynamicTable ??= (() => {
     };
 
     const formatValueAsDate = (value) => {
-        const useValue = value > 0 && value !== 0xffffffff;
+        const useValue = (value > 0) && (value !== 0xffffffff);
         return !useValue ? "" : window.qBittorrent.Misc.formatDate(new Date(value * 1000));
     };
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -3718,9 +3718,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const value = this.getRowValue(row);
-                const epoch = Date.parse(value) / 1000;
-                const date = toDateString(epoch);
+                const date = toDateString(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1920,16 +1920,17 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = this.getRowValue(row, 1);
             };
 
-            // progress
-            this.columns["progress"].updateTd = function(td, row) {
+            const displayProgress = function(td, row) {
                 const progress = this.getRowValue(row);
                 const progressFormatted = `${window.qBittorrent.Misc.toFixedPointString((progress * 100), 1)}%`;
                 td.textContent = progressFormatted;
                 td.title = progressFormatted;
             };
 
-            // dl_speed, up_speed
-            this.columns["dl_speed"].updateTd = function(td, row) {
+			// progress
+            this.columns["progress"].updateTd = displayProgress;
+
+            const displaySpeed = function(td, row) {
                 const speed = this.getRowValue(row);
                 if (speed === 0) {
                     td.textContent = "";
@@ -1941,18 +1942,23 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = formattedSpeed;
                 }
             };
-            this.columns["up_speed"].updateTd = this.columns["dl_speed"].updateTd;
+
+			// dl_speed, up_speed
+            this.columns["dl_speed"].updateTd = displaySpeed;
+            this.columns["up_speed"].updateTd = displaySpeed;
+
+            const displaySize = function(td, row) {
+                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
+                td.textContent = size;
+                td.title = size;
+            };
 
             // downloaded, uploaded
-            this.columns["downloaded"].updateTd = function(td, row) {
-                const downloaded = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
-                td.textContent = downloaded;
-                td.title = downloaded;
-            };
-            this.columns["uploaded"].updateTd = this.columns["downloaded"].updateTd;
+            this.columns["downloaded"].updateTd = displaySize;
+            this.columns["uploaded"].updateTd = displaySize;
 
             // relevance
-            this.columns["relevance"].updateTd = this.columns["progress"].updateTd;
+            this.columns["relevance"].updateTd = displayProgress;
             this.columns["relevance"].staticWidth = 100;
 
             // files

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1239,6 +1239,74 @@ window.qBittorrent.DynamicTable ??= (() => {
                 return `stateIcon ${stateClass}`;
             };
 
+            const displaySize = function(td, row) {
+                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
+                td.textContent = size;
+                td.title = size;
+            };
+            const displaySeeds = function(td, row) {
+                const num_seeds = this.getRowValue(row, 0);
+                const num_complete = this.getRowValue(row, 1);
+                let value = num_seeds;
+                if (num_complete !== -1)
+                    value += ` (${num_complete})`;
+                td.textContent = value;
+                td.title = value;
+            };
+			const compareSeeds = function(row1, row2) {
+                const num_seeds1 = this.getRowValue(row1, 0);
+                const num_complete1 = this.getRowValue(row1, 1);
+
+                const num_seeds2 = this.getRowValue(row2, 0);
+                const num_complete2 = this.getRowValue(row2, 1);
+
+                const result = compareNumbers(num_complete1, num_complete2);
+                if (result !== 0)
+                    return result;
+                return compareNumbers(num_seeds1, num_seeds2);
+            };
+            const displaySpeed = function(td, row) {
+                const speed = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), true);
+                td.textContent = speed;
+                td.title = speed;
+            };
+			const displayRatio = function(td, row) {
+                const ratio = this.getRowValue(row);
+                const string = (ratio === -1) ? "∞" : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
+                td.textContent = string;
+                td.title = string;
+            };
+            const displayCompletion = function(td, row) {
+                const val = this.getRowValue(row);
+                if ((val === 0xffffffff) || (val < 0)) {
+                    td.textContent = "";
+                    td.title = "";
+                }
+                else {
+                    const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
+                    td.textContent = date;
+                    td.title = date;
+                }
+            };
+			const displayLimit = function(td, row) {
+                const speed = this.getRowValue(row);
+                if (speed === 0) {
+                    td.textContent = "∞";
+                    td.title = "∞";
+                }
+                else {
+                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
+                    td.textContent = formattedSpeed;
+                    td.title = formattedSpeed;
+                }
+            };
+            const displayInfohash = function(td, row) {
+                const sourceInfohashV1 = this.getRowValue(row);
+                const infohashV1 = (sourceInfohashV1 !== "") ? sourceInfohashV1 : "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
+                td.textContent = infohashV1;
+                td.title = infohashV1;
+            };
+
             // state_icon
             this.columns["state_icon"].updateTd = function(td, row) {
                 const state = this.getRowValue(row);
@@ -1374,12 +1442,6 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["category"].compareRows = compareNames;
             this.columns["tags"].compareRows = compareNames;
 
-            const displaySize = function(td, row) {
-                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
-                td.textContent = size;
-                td.title = size;
-            };
-
             // size, total_size
             this.columns["size"].updateTd = displaySize;
             this.columns["total_size"].updateTd = displaySize;
@@ -1400,29 +1462,6 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
             this.columns["progress"].staticWidth = 100;
 
-            const displaySeeds = function(td, row) {
-                const num_seeds = this.getRowValue(row, 0);
-                const num_complete = this.getRowValue(row, 1);
-                let value = num_seeds;
-                if (num_complete !== -1)
-                    value += ` (${num_complete})`;
-                td.textContent = value;
-                td.title = value;
-            };
-
-			const compareSeeds = function(row1, row2) {
-                const num_seeds1 = this.getRowValue(row1, 0);
-                const num_complete1 = this.getRowValue(row1, 1);
-
-                const num_seeds2 = this.getRowValue(row2, 0);
-                const num_complete2 = this.getRowValue(row2, 1);
-
-                const result = compareNumbers(num_complete1, num_complete2);
-                if (result !== 0)
-                    return result;
-                return compareNumbers(num_seeds1, num_seeds2);
-            };
-
             // num_seeds
             this.columns["num_seeds"].updateTd = displaySeeds;
             this.columns["num_seeds"].compareRows = compareSeeds;
@@ -1430,12 +1469,6 @@ window.qBittorrent.DynamicTable ??= (() => {
             // num_leechs
             this.columns["num_leechs"].updateTd = displaySeeds;
             this.columns["num_leechs"].compareRows = compareSeeds;
-
-            const displaySpeed = function(td, row) {
-                const speed = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), true);
-                td.textContent = speed;
-                td.title = speed;
-            };
 
 			// dlspeed, upspeed
             this.columns["dlspeed"].updateTd = displaySpeed;
@@ -1448,31 +1481,11 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = eta;
             };
 
-			const displayRatio = function(td, row) {
-                const ratio = this.getRowValue(row);
-                const string = (ratio === -1) ? "∞" : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
-                td.textContent = string;
-                td.title = string;
-            };
-
 			// ratio
             this.columns["ratio"].updateTd = displayRatio;
 
             // popularity
             this.columns["popularity"].updateTd = displayRatio;
-
-            const displayCompletion = function(td, row) {
-                const val = this.getRowValue(row);
-                if ((val === 0xffffffff) || (val < 0)) {
-                    td.textContent = "";
-                    td.title = "";
-                }
-                else {
-                    const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
-                    td.textContent = date;
-                    td.title = date;
-                }
-            };
 
             // creation_date
             this.columns["creation_date"].updateTd = displayCompletion;
@@ -1493,19 +1506,6 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const tracker = displayFullURLTrackerColumn ? value : window.qBittorrent.Misc.getHost(value);
                 td.textContent = tracker;
                 td.title = value;
-            };
-
-			const displayLimit = function(td, row) {
-                const speed = this.getRowValue(row);
-                if (speed === 0) {
-                    td.textContent = "∞";
-                    td.title = "∞";
-                }
-                else {
-                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
-                    td.textContent = formattedSpeed;
-                    td.title = formattedSpeed;
-                }
             };
 
             //  dl_limit, up_limit
@@ -1560,13 +1560,6 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const value = window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 3);
                 td.textContent = value;
                 td.title = value;
-            };
-
-            const displayInfohash = function(td, row) {
-                const sourceInfohashV1 = this.getRowValue(row);
-                const infohashV1 = (sourceInfohashV1 !== "") ? sourceInfohashV1 : "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
-                td.textContent = infohashV1;
-                td.title = infohashV1;
             };
 
 			// infohash_v1, infohash_v2
@@ -1882,6 +1875,30 @@ window.qBittorrent.DynamicTable ??= (() => {
         }
 
         initColumnsFunctions() {
+            const displayProgress = function(td, row) {
+                const progress = this.getRowValue(row);
+                const progressFormatted = `${window.qBittorrent.Misc.toFixedPointString((progress * 100), 1)}%`;
+                td.textContent = progressFormatted;
+                td.title = progressFormatted;
+            };
+            const displaySpeed = function(td, row) {
+                const speed = this.getRowValue(row);
+                if (speed === 0) {
+                    td.textContent = "";
+                    td.title = "";
+                }
+                else {
+                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
+                    td.textContent = formattedSpeed;
+                    td.title = formattedSpeed;
+                }
+            };
+            const displaySize = function(td, row) {
+                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
+                td.textContent = size;
+                td.title = size;
+            };
+
             // country
             this.columns["country"].updateTd = function(td, row) {
                 const country = this.getRowValue(row, 0);
@@ -1920,38 +1937,12 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = this.getRowValue(row, 1);
             };
 
-            const displayProgress = function(td, row) {
-                const progress = this.getRowValue(row);
-                const progressFormatted = `${window.qBittorrent.Misc.toFixedPointString((progress * 100), 1)}%`;
-                td.textContent = progressFormatted;
-                td.title = progressFormatted;
-            };
-
 			// progress
             this.columns["progress"].updateTd = displayProgress;
-
-            const displaySpeed = function(td, row) {
-                const speed = this.getRowValue(row);
-                if (speed === 0) {
-                    td.textContent = "";
-                    td.title = "";
-                }
-                else {
-                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
-                    td.textContent = formattedSpeed;
-                    td.title = formattedSpeed;
-                }
-            };
 
 			// dl_speed, up_speed
             this.columns["dl_speed"].updateTd = displaySpeed;
             this.columns["up_speed"].updateTd = displaySpeed;
-
-            const displaySize = function(td, row) {
-                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
-                td.textContent = size;
-                td.title = size;
-            };
 
             // downloaded, uploaded
             this.columns["downloaded"].updateTd = displaySize;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1253,7 +1253,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = value;
                 td.title = value;
             };
-			const compareSeeds = function(row1, row2) {
+            const compareSeeds = function(row1, row2) {
                 const num_seeds1 = this.getRowValue(row1, 0);
                 const num_complete1 = this.getRowValue(row1, 1);
 
@@ -1270,13 +1270,13 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = speed;
                 td.title = speed;
             };
-			const displaySpeedOrInfinity = function(td, row) {
+            const displaySpeedOrInfinity = function(td, row) {
                 const speed = this.getRowValue(row);
                 const formattedSpeed = (speed === 0) ? "∞" : window.qBittorrent.Misc.friendlyUnit(speed, true);
                 td.textContent = formattedSpeed;
                 td.title = formattedSpeed;
             };
-			const displayRatio = function(td, row) {
+            const displayRatio = function(td, row) {
                 const ratio = this.getRowValue(row);
                 const string = (ratio === -1) ? "∞" : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
                 td.textContent = string;
@@ -1432,7 +1432,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 return row1Val.localeCompare(row2Val, undefined, { numeric: true, sensitivity: "base" });
             };
 
-			// name, category, tags
+            // name, category, tags
             this.columns["name"].compareRows = compareNames;
             this.columns["category"].compareRows = compareNames;
             this.columns["tags"].compareRows = compareNames;
@@ -1465,7 +1465,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["num_leechs"].updateTd = displaySeeds;
             this.columns["num_leechs"].compareRows = compareSeeds;
 
-			// dlspeed, upspeed
+            // dlspeed, upspeed
             this.columns["dlspeed"].updateTd = displaySpeed;
             this.columns["upspeed"].updateTd = displaySpeed;
 
@@ -1476,7 +1476,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = eta;
             };
 
-			// ratio
+            // ratio
             this.columns["ratio"].updateTd = displayRatio;
 
             // popularity
@@ -1488,7 +1488,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             // added on
             this.columns["added_on"].updateTd = displayDate;
 
-			// completion_on
+            // completion_on
             this.columns["completion_on"].updateTd = displayDateOrBlank;
 
             // tracker
@@ -1553,7 +1553,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = value;
             };
 
-			// infohash_v1, infohash_v2
+            // infohash_v1, infohash_v2
             this.columns["infohash_v1"].updateTd = displayInfohash;
             this.columns["infohash_v2"].updateTd = displayInfohash;
 
@@ -1928,10 +1928,10 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = this.getRowValue(row, 1);
             };
 
-			// progress
+            // progress
             this.columns["progress"].updateTd = displayProgress;
 
-			// dl_speed, up_speed
+            // dl_speed, up_speed
             this.columns["dl_speed"].updateTd = displaySpeed;
             this.columns["up_speed"].updateTd = displaySpeed;
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -3718,7 +3718,9 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const date = toDateString(this.getRowValue(row));
+                const value = this.getRowValue(row);
+                const epoch = Date.parse(value) / 1000;
+                const date = toDateString(epoch);
                 td.textContent = date;
                 td.title = date;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1270,6 +1270,12 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = speed;
                 td.title = speed;
             };
+			const displaySpeedOrInfinity = function(td, row) {
+                const speed = this.getRowValue(row);
+                const formattedSpeed = (speed === 0) ? "∞" : window.qBittorrent.Misc.friendlyUnit(speed, true);
+                td.textContent = formattedSpeed;
+                td.title = formattedSpeed;
+            };
 			const displayRatio = function(td, row) {
                 const ratio = this.getRowValue(row);
                 const string = (ratio === -1) ? "∞" : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
@@ -1286,18 +1292,6 @@ window.qBittorrent.DynamicTable ??= (() => {
                     const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
                     td.textContent = date;
                     td.title = date;
-                }
-            };
-			const displayLimit = function(td, row) {
-                const speed = this.getRowValue(row);
-                if (speed === 0) {
-                    td.textContent = "∞";
-                    td.title = "∞";
-                }
-                else {
-                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
-                    td.textContent = formattedSpeed;
-                    td.title = formattedSpeed;
                 }
             };
             const displayInfohash = function(td, row) {
@@ -1509,8 +1503,8 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             //  dl_limit, up_limit
-            this.columns["dl_limit"].updateTd = displayLimit;
-            this.columns["up_limit"].updateTd = displayLimit;
+            this.columns["dl_limit"].updateTd = displaySpeedOrInfinity;
+            this.columns["up_limit"].updateTd = displaySpeedOrInfinity;
 
             // downloaded, uploaded, downloaded_session, uploaded_session, amount_left
             this.columns["downloaded"].updateTd = displaySize;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1874,15 +1874,9 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
             const displaySpeed = function(td, row) {
                 const speed = this.getRowValue(row);
-                if (speed === 0) {
-                    td.textContent = "";
-                    td.title = "";
-                }
-                else {
-                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
-                    td.textContent = formattedSpeed;
-                    td.title = formattedSpeed;
-                }
+                const formattedSpeed = (speed === 0) ? "" : window.qBittorrent.Misc.friendlyUnit(speed, true);
+                td.textContent = formattedSpeed;
+                td.title = formattedSpeed;
             };
             const displaySize = function(td, row) {
                 const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -66,8 +66,7 @@ window.qBittorrent.DynamicTable ??= (() => {
     };
 
     const formatValueAsDate = (value) => {
-        const useValue = (value > 0) && (value !== 0xffffffff);
-        return !useValue ? "" : window.qBittorrent.Misc.formatDate(new Date(value * 1000));
+        return (value > 0) ? window.qBittorrent.Misc.formatDate(new Date(value * 1000)) : "";
     };
 
     const localPreferences = new window.qBittorrent.LocalPreferences.LocalPreferences();

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1244,6 +1244,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = size;
                 td.title = size;
             };
+
             const displaySeeds = function(td, row) {
                 const num_seeds = this.getRowValue(row, 0);
                 const num_complete = this.getRowValue(row, 1);
@@ -1253,6 +1254,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = value;
                 td.title = value;
             };
+
             const compareSeeds = function(row1, row2) {
                 const num_seeds1 = this.getRowValue(row1, 0);
                 const num_complete1 = this.getRowValue(row1, 1);
@@ -1265,29 +1267,34 @@ window.qBittorrent.DynamicTable ??= (() => {
                     return result;
                 return compareNumbers(num_seeds1, num_seeds2);
             };
+
             const displaySpeed = function(td, row) {
                 const speed = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), true);
                 td.textContent = speed;
                 td.title = speed;
             };
+
             const displaySpeedOrInfinity = function(td, row) {
                 const speed = this.getRowValue(row);
                 const formattedSpeed = (speed === 0) ? "∞" : window.qBittorrent.Misc.friendlyUnit(speed, true);
                 td.textContent = formattedSpeed;
                 td.title = formattedSpeed;
             };
+
             const displayRatio = function(td, row) {
                 const ratio = this.getRowValue(row);
                 const string = (ratio === -1) ? "∞" : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
                 td.textContent = string;
                 td.title = string;
             };
+
             const displayDate = function(td, row) {
                 const value = this.getRowValue(row);
                 const date = window.qBittorrent.Misc.formatDate(new Date(value * 1000));
                 td.textContent = date;
                 td.title = date;
             };
+
             const displayDateOrBlank = function(td, row) {
                 const value = this.getRowValue(row);
                 const useBlank = (value === 0xffffffff) || (value < 0);
@@ -1295,6 +1302,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = date;
                 td.title = date;
             };
+
             const displayInfohash = function(td, row) {
                 const sourceInfohashV1 = this.getRowValue(row);
                 const infohashV1 = (sourceInfohashV1 !== "") ? sourceInfohashV1 : "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
@@ -1872,12 +1880,14 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = progressFormatted;
                 td.title = progressFormatted;
             };
+
             const displaySpeed = function(td, row) {
                 const speed = this.getRowValue(row);
                 const formattedSpeed = (speed === 0) ? "" : window.qBittorrent.Misc.friendlyUnit(speed, true);
                 td.textContent = formattedSpeed;
                 td.title = formattedSpeed;
             };
+
             const displaySize = function(td, row) {
                 const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
                 td.textContent = size;
@@ -1966,12 +1976,14 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = size;
                 td.title = size;
             };
+
             const displayNum = function(td, row) {
                 const value = this.getRowValue(row);
                 const formattedValue = (value === "-1") ? "Unknown" : value;
                 td.textContent = formattedValue;
                 td.title = formattedValue;
             };
+
             const displayDate = function(td, row) {
                 const value = this.getRowValue(row) * 1000;
                 const useBlank = (Number.isNaN(value) || (value <= 0));
@@ -2616,11 +2628,13 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         initColumnsFunctions() {
             const that = this;
+            
             const displaySize = function(td, row) {
                 const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
                 td.textContent = size;
                 td.title = size;
             };
+
             const displayPercentage = function(td, row) {
                 const value = window.qBittorrent.Misc.friendlyPercentage(this.getRowValue(row));
                 td.textContent = value;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1294,8 +1294,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const value = this.getRowValue(row);
-                const date = formatValueAsDate(value);
+                const date = formatValueAsDate(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -1982,8 +1981,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const value = this.getRowValue(row);
-                const date = formatValueAsDate(value);
+                const date = formatValueAsDate(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -3425,8 +3423,7 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         initColumnsFunctions() {
             this.columns["timestamp"].updateTd = function(td, row) {
-                const value = this.getRowValue(row);
-                const date = formatValueAsDate(value);
+                const date = formatValueAsDate(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -3504,8 +3501,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("reason", "", "QBT_TR(Reason)QBT_TR[CONTEXT=ExecutionLogWidget]", 150, true);
 
             this.columns["timestamp"].updateTd = function(td, row) {
-                const value = this.getRowValue(row);
-                const date = formatValueAsDate(value);
+                const date = formatValueAsDate(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };
@@ -3723,9 +3719,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const value = this.getRowValue(row);
-                const date = formatValueAsDate(value);
-)
+                const date = formatValueAsDate(this.getRowValue(row));
                 td.textContent = date;
                 td.title = date;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -65,6 +65,11 @@ window.qBittorrent.DynamicTable ??= (() => {
         return 0;
     };
 
+    const formatValueAsDate = (value) => {
+        const useValue = value > 0 && value !== 0xffffffff;
+        return !useValue ? "" : window.qBittorrent.Misc.formatDate(new Date(value * 1000));
+    };
+
     const localPreferences = new window.qBittorrent.LocalPreferences.LocalPreferences();
     const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData;
 
@@ -1290,15 +1295,7 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             const displayDate = function(td, row) {
                 const value = this.getRowValue(row);
-                const date = window.qBittorrent.Misc.formatDate(new Date(value * 1000));
-                td.textContent = date;
-                td.title = date;
-            };
-
-            const displayDateOrBlank = function(td, row) {
-                const value = this.getRowValue(row);
-                const useBlank = (value === 0xffffffff) || (value < 0);
-                const date = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(value * 1000));
+                const date = formatValueAsDate(value);
                 td.textContent = date;
                 td.title = date;
             };
@@ -1491,13 +1488,13 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["popularity"].updateTd = displayRatio;
 
             // creation_date
-            this.columns["creation_date"].updateTd = displayDateOrBlank;
+            this.columns["creation_date"].updateTd = displayDate;
 
             // added on
             this.columns["added_on"].updateTd = displayDate;
 
             // completion_on
-            this.columns["completion_on"].updateTd = displayDateOrBlank;
+            this.columns["completion_on"].updateTd = displayDate;
 
             // tracker
             this.columns["tracker"].updateTd = function(td, row) {
@@ -1538,7 +1535,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["max_ratio"].updateTd = displayRatio;
 
             // seen_complete
-            this.columns["seen_complete"].updateTd = displayDateOrBlank;
+            this.columns["seen_complete"].updateTd = displayDate;
 
             // last_activity
             this.columns["last_activity"].updateTd = function(td, row) {
@@ -1985,11 +1982,10 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const value = this.getRowValue(row) * 1000;
-                const useBlank = (Number.isNaN(value) || (value <= 0));
-                const formattedValue = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(value));
-                td.textContent = formattedValue;
-                td.title = formattedValue;
+                const value = this.getRowValue(row);
+                const date = formatValueAsDate(value);
+                td.textContent = date;
+                td.title = date;
             };
 
             this.columns["fileSize"].updateTd = displaySize;
@@ -3428,14 +3424,12 @@ window.qBittorrent.DynamicTable ??= (() => {
         }
 
         initColumnsFunctions() {
-            const displayDate = function(td, row) {
+            this.columns["timestamp"].updateTd = function(td, row) {
                 const value = this.getRowValue(row);
-                const date = window.qBittorrent.Misc.formatDate(new Date(value * 1000));
+                const date = formatValueAsDate(value);
                 td.textContent = date;
                 td.title = date;
             };
-
-            this.columns["timestamp"].updateTd = displayDate;
 
             this.columns["type"].updateTd = function(td, row) {
                 // Type of the message: Log::NORMAL: 1, Log::INFO: 2, Log::WARNING: 4, Log::CRITICAL: 8
@@ -3509,14 +3503,12 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("blocked", "", "QBT_TR(Status)QBT_TR[CONTEXT=ExecutionLogWidget]", 150, true);
             this.newColumn("reason", "", "QBT_TR(Reason)QBT_TR[CONTEXT=ExecutionLogWidget]", 150, true);
 
-            const displayDate = function(td, row) {
+            this.columns["timestamp"].updateTd = function(td, row) {
                 const value = this.getRowValue(row);
-                const date = window.qBittorrent.Misc.formatDate(new Date(value * 1000));
+                const date = formatValueAsDate(value);
                 td.textContent = date;
                 td.title = date;
             };
-
-            this.columns["timestamp"].updateTd = displayDate;
 
             this.columns["blocked"].updateTd = function(td, row) {
                 let status, addClass;
@@ -3732,8 +3724,8 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             const displayDate = function(td, row) {
                 const value = this.getRowValue(row);
-                const useBlank = !value;
-                const date = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(value * 1000));
+                const date = formatValueAsDate(value);
+)
                 td.textContent = date;
                 td.title = date;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1283,14 +1283,15 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = string;
             };
             const displayDate = function(td, row) {
-                const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
+                const value = this.getRowValue(row);
+                const date = window.qBittorrent.Misc.formatDate(new Date(value * 1000));
                 td.textContent = date;
                 td.title = date;
             };
             const displayDateOrBlank = function(td, row) {
-                const val = this.getRowValue(row);
-                const useBlank = (val === 0xffffffff) || (val < 0);
-                const date = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(val * 1000));
+                const value = this.getRowValue(row);
+                const useBlank = (value === 0xffffffff) || (value < 0);
+                const date = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(value * 1000));
                 td.textContent = date;
                 td.title = date;
             };
@@ -1979,7 +1980,8 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
             const displayDate = function(td, row) {
                 const value = this.getRowValue(row) * 1000;
-                const formattedValue = (Number.isNaN(value) || (value <= 0)) ? "" : window.qBittorrent.Misc.formatDate(new Date(value));
+                const useBlank = (Number.isNaN(value) || (value <= 0));
+                const formattedValue = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(value));
                 td.textContent = formattedValue;
                 td.title = formattedValue;
             };
@@ -3418,11 +3420,14 @@ window.qBittorrent.DynamicTable ??= (() => {
         }
 
         initColumnsFunctions() {
-            this.columns["timestamp"].updateTd = function(td, row) {
-                const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
+            const displayDate = function(td, row) {
+                const value = this.getRowValue(row);
+                const date = window.qBittorrent.Misc.formatDate(new Date(value * 1000));
                 td.textContent = date;
                 td.title = date;
             };
+
+            this.columns["timestamp"].updateTd = displayDate;
 
             this.columns["type"].updateTd = function(td, row) {
                 // Type of the message: Log::NORMAL: 1, Log::INFO: 2, Log::WARNING: 4, Log::CRITICAL: 8
@@ -3496,11 +3501,14 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("blocked", "", "QBT_TR(Status)QBT_TR[CONTEXT=ExecutionLogWidget]", 150, true);
             this.newColumn("reason", "", "QBT_TR(Reason)QBT_TR[CONTEXT=ExecutionLogWidget]", 150, true);
 
-            this.columns["timestamp"].updateTd = function(td, row) {
-                const date = window.qBittorrent.Misc.formatDate(new Date(this.getRowValue(row) * 1000));
+            const displayDate = function(td, row) {
+                const value = this.getRowValue(row);
+                const date = window.qBittorrent.Misc.formatDate(new Date(value * 1000));
                 td.textContent = date;
                 td.title = date;
             };
+
+            this.columns["timestamp"].updateTd = displayDate;
 
             this.columns["blocked"].updateTd = function(td, row) {
                 let status, addClass;
@@ -3715,16 +3723,11 @@ window.qBittorrent.DynamicTable ??= (() => {
             };
 
             const displayDate = function(td, row) {
-                const val = this.getRowValue(row);
-                if (!val) {
-                    td.textContent = "";
-                    td.title = "";
-                }
-                else {
-                    const date = window.qBittorrent.Misc.formatDate(new Date(val * 1000));
-                    td.textContent = date;
-                    td.title = date;
-                }
+                const value = this.getRowValue(row);
+                const useBlank = !value;
+                const date = useBlank ? "" : window.qBittorrent.Misc.formatDate(new Date(value * 1000));
+                td.textContent = date;
+                td.title = date;
             };
 
             // added_on, start_on, completion_on


### PR DESCRIPTION
These changes aim to add more consistent handling of the column update methods in `dynamicTable.js`.

I recently submitted changes doing something similar based on this code:
https://github.com/qbittorrent/qBittorrent/blob/3477ee03991fc2cbc6c542c1744718dd7d2639a4/src/webui/www/private/scripts/dynamicTable.js#L1530

I was asked not to reuse other columns' code like this.

After some review, I found some code avoids doing this by duplicating the logic:
https://github.com/qbittorrent/qBittorrent/blob/3477ee03991fc2cbc6c542c1744718dd7d2639a4/src/webui/www/private/scripts/dynamicTable.js#L1553-L1567

Other code uses constants:
https://github.com/qbittorrent/qBittorrent/blob/3477ee03991fc2cbc6c542c1744718dd7d2639a4/src/webui/www/private/scripts/dynamicTable.js#L1986-L1996

These changes update things so that all shared logic should now be using constants. This also includes some changes to make some of the existing constants a little more consistent.

I realize that these changes may not be perfect and things could still probably use some further improvement, but the goal was to get things in a better place to at least address some of the inconsistency. Ideally, there probably wouldn't be six different `const displayDate` variations, but these changes make it easier to identify them and their differences and to make further changes later.

Note for reviewers: it might be easier to look at the individual commits for a clearer picture of the changes made. I committed things incrementally to try to keep the "diff noise" down.