### PR TITLE
Refactor ProxyType enum into proxytype.h

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(qbt_base STATIC
     net/geoipmanager.h
     net/portforwarder.h
     net/proxyconfigurationmanager.h
+    net/proxytype.h
     net/reverseresolution.h
     net/smtp.h
     orderedset.h

--- a/src/base/net/proxyconfigurationmanager.h
+++ b/src/base/net/proxyconfigurationmanager.h
@@ -32,20 +32,10 @@
 
 #include "base/global.h"
 #include "base/settingvalue.h"
+#include "proxytype.h"
 
 namespace Net
 {
-    Q_NAMESPACE
-
-    enum class ProxyType
-    {
-        None = 0,
-        HTTP = 1,
-        SOCKS5 = 2,
-        SOCKS4 = 5
-    };
-    Q_ENUM_NS(ProxyType)
-
     struct ProxyConfiguration
     {
         ProxyType type = ProxyType::None;

--- a/src/base/net/proxytype.h
+++ b/src/base/net/proxytype.h
@@ -1,0 +1,48 @@
+/*
+* Bittorrent Client using Qt and libtorrent.
+* Copyright (C) 2016-2026  Vladimir Golovnev <glassez@yandex.ru>
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*
+* In addition, as a special exception, the copyright holders give permission to
+* link this program with the OpenSSL project's "OpenSSL" library (or with
+* modified versions of it that use the same license as the "OpenSSL" library),
+* and distribute the linked executables. You must obey the GNU General Public
+* License in all respects for all of the code used other than "OpenSSL".  If you
+* modify file(s), you may extend this exception to your version of the file(s),
+* but you are not obligated to do so. If you do not wish to do so, delete this
+* exception statement from your version.
+*/
+
+#pragma once
+
+#include <QObject>
+
+namespace Net
+{
+    inline namespace ProxyTypeNS
+    {
+        Q_NAMESPACE
+
+        enum class ProxyType
+        {
+            None = 0,
+            HTTP = 1,
+            SOCKS5 = 2,
+            SOCKS4 = 5
+        };
+        Q_ENUM_NS(ProxyType)
+    }
+}

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -31,6 +31,7 @@
 
 #include <QDialog>
 
+#include "base/net/proxytype.h"
 #include "base/pathfwd.h"
 #include "base/settingvalue.h"
 #include "guiapplicationcomponent.h"
@@ -48,11 +49,6 @@ enum DoubleClickAction
     NO_ACTION = 3,
     SHOW_OPTIONS = 4
 };
-
-namespace Net
-{
-    enum class ProxyType;
-}
 
 namespace Ui
 {


### PR DESCRIPTION
From #23838 conversations and allows the use of Q_ENUM_NS in other parts of the Net namespace by circumventing a limitation in Qt's Q_ENUM_NS macro that limits having multiple references in different files within the same namespace.

Centralizes the ProxyType enum and related Qt macros into a new proxytype.h header for better modularity. Updates CMakeLists.txt and replaces previous inline definitions and includes in proxyconfigurationmanager.h and optionsdialog.h. This improves code organization and reusability.

Refactors the ProxyType enum and its Q_ENUM_NS macro into a new inline namespace ProxyTypeNS within the Net namespace. This prepares for future extensibility and helps prevent naming conflicts while maintaining accessibility.