### PR TITLE
Add 'Do not download + Delete' button for each file in UI

### DIFF
--- a/src/base/bittorrent/torrentcontenthandler.h
+++ b/src/base/bittorrent/torrentcontenthandler.h
@@ -57,6 +57,7 @@ namespace BitTorrent
         virtual QFuture<QList<qreal>> fetchAvailableFileFractions() const = 0;
 
         virtual void prioritizeFiles(const QList<DownloadPriority> &priorities) = 0;
+        virtual void deleteFiles(const QList<int> &fileIndexes) = 0;
         virtual void flushCache() const = 0;
     };
 }

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2950,6 +2950,19 @@ void TorrentImpl::prioritizeFiles(const QList<DownloadPriority> &priorities)
     manageActualFilePaths();
 }
 
+void TorrentImpl::deleteFiles(const QList<int> &fileIndexes)
+{
+    flushCache();
+    const Path storageLocation = actualStorageLocation();
+    for (const int index : fileIndexes)
+    {
+        const Path filePath = storageLocation / actualFilePath(index);
+        const auto result = Utils::Fs::removeFile(filePath);
+        if (!result)
+            LogMsg(tr("Failed to delete file \"%1\". Error: %2").arg(filePath.toString(), result.error()), Log::WARNING);
+    }
+}
+
 template <typename Func>
 QFuture<std::invoke_result_t<Func>> TorrentImpl::invokeAsync(Func &&func) const
 {

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2952,15 +2952,46 @@ void TorrentImpl::prioritizeFiles(const QList<DownloadPriority> &priorities)
 
 void TorrentImpl::deleteFiles(const QList<int> &fileIndexes)
 {
+    if (fileIndexes.isEmpty() || !hasMetadata())
+        return;
+
     flushCache();
     const Path storageLocation = actualStorageLocation();
     for (const int index : fileIndexes)
     {
         const Path filePath = storageLocation / actualFilePath(index);
-        const auto result = Utils::Fs::removeFile(filePath);
-        if (!result)
+        if (const auto result = Utils::Fs::removeFile(filePath); !result)
             LogMsg(tr("Failed to delete file \"%1\". Error: %2").arg(filePath.toString(), result.error()), Log::WARNING);
+
+        // Zero per-file progress directly.  These are the fields filesProgress()
+        // reads for the GUI.  updateProgress() only ever *increments* m_filesProgress
+        // (on newly-acquired pieces) and handleFileCompleted() only ever *sets*
+        // m_completedFiles — neither fires for an Ignored file, so these zeroes stick.
+        m_filesProgress[index] = 0;
+        m_completedFiles.clearBit(index);
     }
+
+    // Best-effort: clear the affected pieces from the resume-data bitfield so that
+    // on the next qBittorrent start libtorrent loads without stale "have" bits for
+    // the deleted files.
+    //
+    // TODO: prepareResumeData() may overwrite these when libtorrent asynchronously returns its save_resume_data response.
+    if (!m_ltAddTorrentParams.have_pieces.empty())
+    {
+        for (const int fileIndex : fileIndexes)
+        {
+            for (const int pieceIndex : m_torrentInfo.filePieces(fileIndex)) {
+                m_ltAddTorrentParams.have_pieces.clear_bit(lt::piece_index_t {pieceIndex});
+
+                m_pieces.clearBit(pieceIndex);
+            }
+        }
+    }
+
+    deferredRequestResumeData();
+    flushCache(); // TODO: Maybe unnecessary.
+
+    // FIXME: This function is not quite right. It seems that libtorrent is never fully informed of the removed file(s).
 }
 
 template <typename Func>

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -221,6 +221,7 @@ namespace BitTorrent
         void forceRecheck() override;
         void renameFile(int index, const Path &path) override;
         void prioritizeFiles(const QList<DownloadPriority> &priorities) override;
+        void deleteFiles(const QList<int> &fileIndexes) override;
         void setUploadLimit(int limit) override;
         void setDownloadLimit(int limit) override;
         void setSuperSeeding(bool enable) override;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -271,6 +271,11 @@ public:
         return {};
     }
 
+    void deleteFiles([[maybe_unused]] const QList<int> &fileIndexes) override
+    {
+        // No files exist on disk yet when adding a torrent; deletion is a no-op.
+    }
+
     void flushCache() const override
     {
     }

--- a/src/gui/torrentcontentitemdelegate.cpp
+++ b/src/gui/torrentcontentitemdelegate.cpp
@@ -76,6 +76,7 @@ QWidget *TorrentContentItemDelegate::createEditor(QWidget *parent, const QStyleO
     auto *editor = new QComboBox(parent);
     editor->setAutoFillBackground(true);
     editor->setFocusPolicy(Qt::StrongFocus);
+    editor->addItem(tr("Do not download + Delete", "Do not download + Delete (priority)"));
     editor->addItem(tr("Do not download", "Do not download (priority)"));
     editor->addItem(tr("Normal", "Normal (priority)"));
     editor->addItem(tr("High", "High (priority)"));

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -439,6 +439,11 @@ void TorrentContentWidget::displayContextMenu()
         {
             applyPriorities(BitTorrent::DownloadPriority::Ignored);
         });
+        subMenu->addAction(tr("Do not download + Delete"), this, [this]
+        {
+            applyPriorities(BitTorrent::DownloadPriority::Ignored);
+            printf("TODO: delete file (single)");
+        });
         subMenu->addAction(tr("Normal"), this, [this]
         {
             applyPriorities(BitTorrent::DownloadPriority::Normal);
@@ -459,6 +464,11 @@ void TorrentContentWidget::displayContextMenu()
         menu->addAction(tr("Do not download"), this, [this]
         {
             applyPriorities(BitTorrent::DownloadPriority::Ignored);
+        });
+        menu->addAction(tr("Do not download + Delete"), this, [this]
+        {
+            applyPriorities(BitTorrent::DownloadPriority::Ignored);
+            printf("TODO: delete files (many)");
         });
         menu->addAction(tr("Normal priority"), this, [this]
         {

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -294,6 +294,34 @@ void TorrentContentWidget::renameSelectedFile()
     model()->setData(modelIndex, newName);
 }
 
+void TorrentContentWidget::collectFileIndexes(const QModelIndex &index, QList<int> &fileIndexes) const
+{
+    const int fileIdx = getFileIndex(index);
+    if (fileIdx >= 0)
+    {
+        fileIndexes.append(fileIdx);
+        return;
+    }
+
+    // Folder: recurse into children
+    const int childCount = model()->rowCount(index);
+    for (int i = 0; i < childCount; ++i)
+        collectFileIndexes(model()->index(i, 0, index), fileIndexes);
+}
+
+void TorrentContentWidget::deleteSelectedFiles()
+{
+    QList<int> fileIndexes;
+    const QModelIndexList selectedRows = selectionModel()->selectedRows(0);
+    for (const QModelIndex &index : selectedRows)
+        collectFileIndexes(index, fileIndexes);
+
+    if (fileIndexes.isEmpty())
+        return;
+
+    contentHandler()->deleteFiles(fileIndexes);
+}
+
 void TorrentContentWidget::applyPriorities(const BitTorrent::DownloadPriority priority)
 {
     const QList<QPersistentModelIndex> selectedRows = toPersistentIndexes(selectionModel()->selectedRows(Priority));
@@ -442,7 +470,7 @@ void TorrentContentWidget::displayContextMenu()
         subMenu->addAction(tr("Do not download + Delete"), this, [this]
         {
             applyPriorities(BitTorrent::DownloadPriority::Ignored);
-            printf("TODO: delete file (single)");
+            deleteSelectedFiles();
         });
         subMenu->addAction(tr("Normal"), this, [this]
         {
@@ -468,7 +496,7 @@ void TorrentContentWidget::displayContextMenu()
         menu->addAction(tr("Do not download + Delete"), this, [this]
         {
             applyPriorities(BitTorrent::DownloadPriority::Ignored);
-            printf("TODO: delete files (many)");
+            deleteSelectedFiles();
         });
         menu->addAction(tr("Normal priority"), this, [this]
         {

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -467,11 +467,17 @@ void TorrentContentWidget::displayContextMenu()
         {
             applyPriorities(BitTorrent::DownloadPriority::Ignored);
         });
-        subMenu->addAction(tr("Do not download + Delete"), this, [this]
+
+        // Only show "Do not download + Delete" in the normal window when torrent is already added.
+        // Avoid showing it in the window for adding a new torrent.
+        if (!contentHandler()->actualStorageLocation().isEmpty())
         {
-            applyPriorities(BitTorrent::DownloadPriority::Ignored);
-            deleteSelectedFiles();
-        });
+            subMenu->addAction(tr("Do not download + Delete"), this, [this]
+            {
+                applyPriorities(BitTorrent::DownloadPriority::Ignored);
+                deleteSelectedFiles();
+            });
+        }
         subMenu->addAction(tr("Normal"), this, [this]
         {
             applyPriorities(BitTorrent::DownloadPriority::Normal);
@@ -493,11 +499,17 @@ void TorrentContentWidget::displayContextMenu()
         {
             applyPriorities(BitTorrent::DownloadPriority::Ignored);
         });
-        menu->addAction(tr("Do not download + Delete"), this, [this]
+
+        // Only show "Do not download + Delete" in the normal window when torrent is already added.
+        // Avoid showing it in the window for adding a new torrent.
+        if (!contentHandler()->actualStorageLocation().isEmpty())
         {
-            applyPriorities(BitTorrent::DownloadPriority::Ignored);
-            deleteSelectedFiles();
-        });
+            menu->addAction(tr("Do not download + Delete"), this, [this]
+            {
+                applyPriorities(BitTorrent::DownloadPriority::Ignored);
+                deleteSelectedFiles();
+            });
+        }
         menu->addAction(tr("Normal priority"), this, [this]
         {
             applyPriorities(BitTorrent::DownloadPriority::Normal);

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -119,6 +119,8 @@ private:
     void renameSelectedFile();
     void applyPriorities(BitTorrent::DownloadPriority priority);
     void applyPrioritiesByOrder();
+    void collectFileIndexes(const QModelIndex &index, QList<int> &fileIndexes) const;
+    void deleteSelectedFiles();
     Path getFullPath(const QModelIndex &index) const;
     void onItemDoubleClicked(const QModelIndex &index);
     // Expand single-item folders recursively.


### PR DESCRIPTION
Related to #24102

I don't think this implementation is quite there yet. It seems there are issues with managing the internal state with libtorrent (informing libtorrent which pieces are available) in `src/base/bittorrent/torrentimpl.cpp`. I invite anyone more familiar with this project to help suggest a fix.