### PR TITLE
Fix crash when closing app with AddNewTorrentDialog opened

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1383,17 +1383,9 @@ void Application::cleanup()
         QAccessible::cleanup();
 #endif
 
-    // Close and delete any remaining top-level widgets (e.g. parentless dialogs
-    // like AddNewTorrentDialog on macOS). These must be destroyed before core
-    // components like SettingsStorage are freed, because their destructors or
-    // done() handlers may save state via SettingValue.
-    // https://github.com/qbittorrent/qBittorrent/issues/23461
-    const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
-    for (QWidget *widget : topLevelWidgets)
-    {
-        if (widget != m_window)
-            delete widget;
-    }
+    // AddTorrentManager should be deleted before cleanup MainWindow
+    // in order to properly delete currently opened AddNewTorrentDialog instances
+    delete m_addTorrentManager;
 
     if (m_window)
     {
@@ -1428,7 +1420,9 @@ void Application::cleanup()
     delete RSS::Session::instance();
 
     TorrentFilesWatcher::freeInstance();
+#ifdef DISABLE_GUI
     delete m_addTorrentManager;
+#endif
     BitTorrent::Session::freeInstance();
     Net::ReverseResolution::freeInstance();
     Net::GeoIPManager::freeInstance();

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015-2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -87,6 +87,9 @@ GUIAddTorrentManager::~GUIAddTorrentManager()
     {
         dialog->disconnect(this);
         dialog->reject();
+        // `dialog` should be deleted here in order to avoid accessing 
+        // already deleted core components whwn deleting later
+        delete dialog;
     }
 }
 

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -88,7 +88,7 @@ GUIAddTorrentManager::~GUIAddTorrentManager()
         dialog->disconnect(this);
         dialog->reject();
         // `dialog` should be deleted here in order to avoid accessing 
-        // already deleted core components whwn deleting later
+        // already deleted core components when deleting later
         delete dialog;
     }
 }


### PR DESCRIPTION
Destruct `GUIAddTorrentManager` instance in proper place.
Delete `AddNewTorrentDialog` instances in `GUIAddTorrentManager` directly.

Abolishes #24071.

Closes #23461.
Closes #24104.
Closes #24105.