### PR TITLE
WebUI: Prevent theme flash on page load

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -51,6 +51,14 @@
     <noscript id="noscript">
         <h1>QBT_TR(JavaScript Required! You must enable JavaScript for the WebUI to work properly)QBT_TR[CONTEXT=HttpServer]</h1>
     </noscript>
+    <script>
+        (function() {
+            const colorScheme = localStorage.getItem("color_scheme") || "auto";
+            const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+            const shouldUseDark = (colorScheme === "dark") || (colorScheme === "auto" && prefersDark);
+            document.documentElement.classList.toggle("dark", shouldUseDark);
+        })();
+    </script>
     <div id="desktop">
         <div id="desktopHeader">
             <div id="desktopNavbar">


### PR DESCRIPTION
# Summary

qBittorrent WebUI displays a black flash when refreshing page with light theme selected because HTML hardcodes `class="dark"` and JavaScript only applies the correct theme after DOM loads.

This PR adds inline theme initialization script in `index.html` that executes immediately during HTML parsing to fix the issue.

# Test Result:

## Before

<img width="1068" height="562" alt="old" src="https://github.com/user-attachments/assets/19d5d01f-f748-446b-b6e9-4af68ba59a4b" />

## After

**Light**
<img width="1068" height="562" alt="new" src="https://github.com/user-attachments/assets/4f36127f-33cf-4489-863d-97d7b0d85a5f" />

**Dark** (When `prefers-color-scheme` = `dark`)
<img width="1105" height="535" alt="new2" src="https://github.com/user-attachments/assets/9fb3eb46-df04-407e-b74b-6b2052cc09ba" />
