### PR TITLE
Replace QObject include with QMetaEnum in proxytype.h

### DIFF
--- a/src/base/net/proxytype.h
+++ b/src/base/net/proxytype.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <QObject>
+#include <QMetaEnum>
 
 namespace Net
 {


### PR DESCRIPTION
Removed QObject dependency and included QMetaEnum instead, as only enum meta-information required rather than QObject features.

An optimisation to #24103 