### PR TITLE
Add scroll bars to Statistics dialog

### DIFF
--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -54,7 +54,7 @@ StatsDialog::StatsDialog(QWidget *parent)
     m_ui->labelCacheHits->hide();
 #endif
 
-    connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &StatsDialog::close);
+    connect(m_ui->buttonBox, &QDialogButtonBox::clicked, this, &StatsDialog::close);
 
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::statsUpdated
             , this, &StatsDialog::update);

--- a/src/gui/statsdialog.ui
+++ b/src/gui/statsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>288</width>
-    <height>489</height>
+    <width>330</width>
+    <height>510</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,240 +15,262 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="groupUser">
-     <property name="title">
-      <string>User statistics</string>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelAlltimeULText">
-        <property name="text">
-         <string>All-time upload:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelAlltimeUL">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelAlltimeDLText">
-        <property name="text">
-         <string>All-time download:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelAlltimeDL">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelGlobalRatioText">
-        <property name="text">
-         <string>All-time share ratio:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelGlobalRatio">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="labelWasteText">
-        <property name="text">
-         <string>Session waste:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelWaste">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="labelPeersText">
-        <property name="text">
-         <string>Connected peers:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelPeers">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>310</width>
+        <height>460</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="groupUser">
+         <property name="title">
+          <string>User statistics</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelAlltimeULText">
+            <property name="text">
+             <string>All-time upload:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelAlltimeUL">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelAlltimeDLText">
+            <property name="text">
+             <string>All-time download:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelAlltimeDL">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelGlobalRatioText">
+            <property name="text">
+             <string>All-time share ratio:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelGlobalRatio">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelWasteText">
+            <property name="text">
+             <string>Session waste:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelWaste">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelPeersText">
+            <property name="text">
+             <string>Connected peers:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelPeers">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupCache">
+         <property name="title">
+          <string>Cache statistics</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelCacheHitsText">
+            <property name="text">
+             <string>Read cache hits:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelCacheHits">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelTotalBufText">
+            <property name="text">
+             <string>Total buffer size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelTotalBuf">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupPerf">
+         <property name="title">
+          <string>Performance statistics</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelWriteStarveText">
+            <property name="text">
+             <string>Write cache overload:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelWriteStarve">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelReadStarveText">
+            <property name="text">
+             <string>Read cache overload:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelReadStarve">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelQueuedJobsText">
+            <property name="text">
+             <string>Queued I/O jobs:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelQueuedJobs">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelJobsTimeText">
+            <property name="text">
+             <string>Average time in queue:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelJobsTime">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelQueuedBytesText">
+            <property name="text">
+             <string>Total queued size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelQueuedBytes">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupTracker">
+         <property name="title">
+          <string>Tracker statistics</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelQueuedTrackerAnnouncesText_2">
+            <property name="text">
+             <string>Queued tracker announces:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelQueuedTrackerAnnounces">
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupCache">
-     <property name="title">
-      <string>Cache statistics</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelCacheHitsText">
-        <property name="text">
-         <string>Read cache hits:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelCacheHits">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelTotalBufText">
-        <property name="text">
-         <string>Total buffer size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelTotalBuf">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupPerf">
-     <property name="title">
-      <string>Performance statistics</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelWriteStarveText">
-        <property name="text">
-         <string>Write cache overload:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelWriteStarve">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelReadStarveText">
-        <property name="text">
-         <string>Read cache overload:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelReadStarve">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelQueuedJobsText">
-        <property name="text">
-         <string>Queued I/O jobs:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelQueuedJobs">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="labelJobsTimeText">
-        <property name="text">
-         <string>Average time in queue:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelJobsTime">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="labelQueuedBytesText">
-        <property name="text">
-         <string>Total queued size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelQueuedBytes">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupTracker">
-     <property name="title">
-      <string>Tracker statistics</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelQueuedTrackerAnnouncesText_2">
-        <property name="text">
-         <string>Queued tracker announces:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelQueuedTrackerAnnounces">
-        <property name="text">
-         <string>TextLabel</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Otherwise the metrics won't fit on screen when there are many of it. The scroll bars will automatically hidden when all metrics can be shown on screen.
Also change the button from `OK` to `Close`.

Now it is possible to do this:
<img width="185" height="231" alt="screenshot" src="https://github.com/user-attachments/assets/767523b2-0a04-49f4-9c52-b4e02c70841c" />


