### PR TITLE
Decide system tray icon color based on Windows color scheme

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -57,6 +57,7 @@
 #include <QPixmapCache>
 #include <QProgressDialog>
 #ifdef Q_OS_WIN
+#include <QAbstractNativeEventFilter>
 #include <QSessionManager>
 #endif // Q_OS_WIN
 #ifdef Q_OS_MACOS
@@ -134,6 +135,41 @@ namespace
     const QString PARAM_SEQUENTIAL = u"@sequential"_s;
     const QString PARAM_SKIPCHECKING = u"@skipChecking"_s;
     const QString PARAM_SKIPDIALOG = u"@skipDialog"_s;
+
+#if !defined(DISABLE_GUI) && defined(Q_OS_WIN)
+    class NativeEventFilter final : public QAbstractNativeEventFilter
+    {
+    public:
+        explicit NativeEventFilter(UIThemeManager *uiThemeManager)
+            : m_uiThemeManager {uiThemeManager}
+        {
+        }
+
+        bool nativeEventFilter(const QByteArray &eventType, void *message, [[maybe_unused]] qintptr *result) override
+        {
+            if (eventType == "windows_generic_MSG")
+            {
+                auto *msg = static_cast<const MSG *>(message);
+                if (msg->message == WM_SETTINGCHANGE)
+                {
+                    // Only refresh the theme if the user changes the personalize settings
+                    if ((msg->wParam == 0) && (msg->lParam != 0) // lParam sometimes may be 0.
+                            && (wcscmp(reinterpret_cast<LPCWSTR>(msg->lParam), L"ImmersiveColorSet") == 0))
+                    {
+                        m_uiThemeManager->updateSystemColorMode();
+                    }
+                }
+            }
+
+            // We don't want to filter the message out, i.e.
+            // stop it being handled further, so return false.
+            return false;
+        }
+
+    private:
+        UIThemeManager *m_uiThemeManager = nullptr;
+    };
+#endif
 
     QString bindParamValue(const QStringView paramName, const QStringView paramValue)
     {
@@ -871,6 +907,10 @@ int Application::exec()
     BitTorrent::Session::initInstance();
 #ifndef DISABLE_GUI
     UIThemeManager::initInstance();
+
+#ifdef Q_OS_WIN
+    installNativeEventFilter(new NativeEventFilter(UIThemeManager::instance()));
+#endif
 
     m_desktopIntegration = new DesktopIntegration;
     m_desktopIntegration->setToolTip(tr("Loading torrents..."));

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2014-2024  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2014-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -67,8 +67,6 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 #include <cstdio>
 #endif // DISABLE_GUI
 
-#include "base/global.h"
-#include "base/logger.h"
 #include "base/preferences.h"
 #include "base/profile.h"
 #include "base/settingvalue.h"
@@ -80,9 +78,14 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 
 #ifndef DISABLE_GUI
 #include "gui/utils.h"
+#else
+#ifndef Q_OS_WIN
+#include "base/logger.h"
+#endif
 #endif
 
 using namespace std::chrono_literals;
+using namespace Qt::Literals::StringLiterals;
 
 namespace
 {

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -259,6 +259,10 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_compile_definitions(qbt_base PUBLIC QBT_USES_GETRANDOM)
     endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    target_sources(qbt_base PRIVATE
+        utils/reg.h
+        utils/reg.cpp
+    )
     target_link_libraries(qbt_base PRIVATE iphlpapi powrprof)
 endif()
 

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2018-2025  Mike Tzou (Chocobo1)
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
@@ -50,6 +51,7 @@
 
 #if defined(Q_OS_WIN)
 #include "base/utils/compare.h"
+#include "base/utils/reg.h"
 #endif
 
 using namespace Utils::ForeignApps;
@@ -104,53 +106,6 @@ namespace
         SYSTEM_64BIT
     };
 
-    PathList getRegSubkeys(const HKEY handle)
-    {
-        PathList keys;
-
-        DWORD cSubKeys = 0;
-        DWORD cMaxSubKeyLen = 0;
-        const LSTATUS result = ::RegQueryInfoKeyW(handle, NULL, NULL, NULL, &cSubKeys, &cMaxSubKeyLen, NULL, NULL, NULL, NULL, NULL, NULL);
-
-        if (result == ERROR_SUCCESS)
-        {
-            ++cMaxSubKeyLen; // For null character
-            LPWSTR lpName = new WCHAR[cMaxSubKeyLen] {0};
-            [[maybe_unused]] const auto lpNameGuard = qScopeGuard([&lpName] { delete[] lpName; });
-
-            keys.reserve(cSubKeys);
-
-            for (DWORD i = 0; i < cSubKeys; ++i)
-            {
-                DWORD cName = cMaxSubKeyLen;
-                const LSTATUS res = ::RegEnumKeyExW(handle, i, lpName, &cName, NULL, NULL, NULL, NULL);
-                if (res == ERROR_SUCCESS)
-                    keys.append(Path(QString::fromWCharArray(lpName)));
-            }
-        }
-
-        return keys;
-    }
-
-    Path getRegValue(const HKEY handle, const QString &name = {})
-    {
-        const std::wstring nameWStr = name.toStdWString();
-        DWORD type = 0;
-        DWORD cbData = 0;
-        // Discover the size of the value
-        ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, NULL, &cbData);
-
-        const DWORD cBuffer = (cbData / sizeof(WCHAR)) + 1;
-        LPWSTR lpData = new WCHAR[cBuffer] {0};
-        [[maybe_unused]] const auto lpDataGuard = qScopeGuard([&lpData] { delete[] lpData; });
-
-        const LSTATUS res = ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, reinterpret_cast<LPBYTE>(lpData), &cbData);
-        if (res == ERROR_SUCCESS)
-            return Path(QString::fromWCharArray(lpData));
-
-        return {};
-    }
-
     PathList pythonSearchReg(const REG_SEARCH_TYPE type)
     {
         const HKEY hkRoot = (type == USER) ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
@@ -164,26 +119,26 @@ namespace
             [[maybe_unused]] const auto hkPythonCoreGuard = qScopeGuard([&hkPythonCore] { ::RegCloseKey(hkPythonCore); });
 
             // start with the largest version
-            PathList versions = getRegSubkeys(hkPythonCore);
+            QStringList versions = Utils::Reg::getSubkeys(hkPythonCore);
             // ordinary sort won't suffice, it needs to sort ["3.9", "3.10"] correctly
             const Utils::Compare::NaturalCompare<Qt::CaseInsensitive> comparator;
-            std::ranges::sort(versions, [&comparator](const Path &left, const Path &right)
+            std::ranges::sort(versions, [&comparator](const QString &left, const QString &right)
             {
-                return comparator(left.data(), right.data());
+                return comparator(left, right);
             });
 
             ret.reserve(versions.size() * 2);
 
             while (!versions.empty())
             {
-                const std::wstring version = (versions.takeLast() / Path(u"InstallPath"_s)).toString().toStdWString();
+                const std::wstring version = (Path(versions.takeLast()) / Path(u"InstallPath"_s)).toString().toStdWString();
 
                 HKEY hkInstallPath {0};
                 if (::RegOpenKeyExW(hkPythonCore, version.c_str(), 0, samDesired, &hkInstallPath) == ERROR_SUCCESS)
                 {
                     [[maybe_unused]] const auto hkInstallPathGuard = qScopeGuard([&hkInstallPath] { ::RegCloseKey(hkInstallPath); });
 
-                    const Path basePath = getRegValue(hkInstallPath);
+                    const Path basePath {Utils::Reg::getStringValue(hkInstallPath)};
                     if (basePath.isEmpty())
                         continue;
 

--- a/src/base/utils/reg.cpp
+++ b/src/base/utils/reg.cpp
@@ -1,0 +1,103 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018-2025  Mike Tzou (Chocobo1)
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "reg.h"
+
+#include <QScopeGuard>
+#include <QStringList>
+
+QStringList Utils::Reg::getSubkeys(const HKEY handle)
+{
+    QStringList keys;
+
+    DWORD cSubKeys = 0;
+    DWORD cMaxSubKeyLen = 0;
+    const LSTATUS result = ::RegQueryInfoKeyW(handle, NULL, NULL, NULL, &cSubKeys, &cMaxSubKeyLen, NULL, NULL, NULL, NULL, NULL, NULL);
+
+    if (result == ERROR_SUCCESS)
+    {
+        ++cMaxSubKeyLen; // For null character
+        LPWSTR lpName = new WCHAR[cMaxSubKeyLen] {0};
+        [[maybe_unused]] const auto lpNameGuard = qScopeGuard([&lpName] { delete[] lpName; });
+
+        keys.reserve(cSubKeys);
+
+        for (DWORD i = 0; i < cSubKeys; ++i)
+        {
+            DWORD cName = cMaxSubKeyLen;
+            const LSTATUS res = ::RegEnumKeyExW(handle, i, lpName, &cName, NULL, NULL, NULL, NULL);
+            if (res == ERROR_SUCCESS)
+                keys.append(QString::fromWCharArray(lpName));
+        }
+    }
+
+    return keys;
+}
+
+QString Utils::Reg::getStringValue(const HKEY handle, const QString &name)
+{
+    const std::wstring nameWStr = name.toStdWString();
+    DWORD type = 0;
+    DWORD cbData = 0;
+    // Discover the size of the value
+    ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, NULL, &cbData);
+
+    const DWORD cBuffer = (cbData / sizeof(WCHAR)) + 1;
+    LPWSTR lpData = new WCHAR[cBuffer] {};
+    [[maybe_unused]] const auto lpDataGuard = qScopeGuard([&lpData] { delete[] lpData; });
+
+    if (!((type == REG_SZ) || (type == REG_EXPAND_SZ)))
+        return {};
+
+    const LSTATUS res = ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, reinterpret_cast<LPBYTE>(lpData), &cbData);
+    if (res == ERROR_SUCCESS)
+        return QString::fromWCharArray(lpData);
+
+    return {};
+}
+
+ulong Utils::Reg::getULongValue(const HKEY handle, const QString &name)
+{
+    const std::wstring nameWStr = name.toStdWString();
+    DWORD type = 0;
+    DWORD cbData = 0;
+    // Discover the size of the value
+    ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, NULL, &cbData);
+
+    if (type != REG_DWORD)
+        return 0;
+
+    DWORD lpData = 0;
+    const LSTATUS res = ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, reinterpret_cast<LPBYTE>(&lpData), &cbData);
+    if (res == ERROR_SUCCESS)
+        return lpData;
+
+    return {};
+}

--- a/src/base/utils/reg.h
+++ b/src/base/utils/reg.h
@@ -1,0 +1,43 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018-2025  Mike Tzou (Chocobo1)
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <windows.h>
+
+#include <QtContainerFwd>
+#include <QString>
+
+namespace Utils::Reg
+{
+    QStringList getSubkeys(const HKEY handle);
+    QString getStringValue(const HKEY handle, const QString &name = {});
+    ulong getULongValue(const HKEY handle, const QString &name = {});
+}

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -37,11 +37,16 @@
 #include <QStyle>
 #include <QStyleHints>
 
-#include "base/global.h"
 #include "base/logger.h"
 #include "base/path.h"
 #include "base/preferences.h"
 #include "uithemecommon.h"
+
+#ifdef Q_OS_WIN
+#include "base/utils/reg.h"
+#endif
+
+using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
@@ -77,6 +82,10 @@ UIThemeManager::UIThemeManager()
     , m_useSystemIcons {Preferences::instance()->useSystemIcons()}
 #endif
 {
+#ifdef Q_OS_WIN
+    updateSystemColorMode();
+#endif
+
     if (const QString styleName = Preferences::instance()->getStyle(); styleName.compare(u"system", Qt::CaseInsensitive) != 0)
     {
         if (!QApplication::setStyle(styleName))
@@ -211,8 +220,12 @@ QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) co
 
 QIcon UIThemeManager::getSystrayIcon() const
 {
+#ifdef Q_OS_WIN
+    const auto colorMode = m_systemColorMode;
+#else
     const auto colorMode = (qApp->styleHints()->colorScheme() == Qt::ColorScheme::Dark)
             ? ColorMode::Dark : ColorMode::Light;
+#endif
     const QString fallback = (colorMode == ColorMode::Light)
             ? u"qbittorrent-tray-light"_s : u"qbittorrent-tray-dark"_s;
 
@@ -267,6 +280,30 @@ QColor UIThemeManager::getColor(const QString &id) const
     const QColor color = m_themeSource->getColor(id, (isDarkTheme() ? ColorMode::Dark : ColorMode::Light));
     return color;
 }
+
+#ifdef Q_OS_WIN
+void UIThemeManager::updateSystemColorMode()
+{
+    const HKEY hkRoot = HKEY_CURRENT_USER;
+    const REGSAM samDesired = KEY_READ;
+
+    HKEY hkPersonalize = nullptr;
+    const LSTATUS status = ::RegOpenKeyExW(hkRoot, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", 0, samDesired, &hkPersonalize);
+    if (status != ERROR_SUCCESS)
+        return;
+
+    [[maybe_unused]] const auto hkPersonalizeGuard = qScopeGuard([&hkPersonalize] { ::RegCloseKey(hkPersonalize); });
+
+    const ulong val = Utils::Reg::getULongValue(hkPersonalize, u"SystemUsesLightTheme"_s);
+    const auto systemUsesLightTheme = static_cast<bool>(val);
+    const auto systemColorMode = systemUsesLightTheme ? ColorMode::Light : ColorMode::Dark;
+    if (systemColorMode != m_systemColorMode)
+    {
+        m_systemColorMode = systemColorMode;
+        onColorSchemeChanged();
+    }
+}
+#endif
 
 void UIThemeManager::applyPalette() const
 {

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -75,6 +75,10 @@ public:
 
     QColor getColor(const QString &id) const;
 
+#ifdef Q_OS_WIN
+    void updateSystemColorMode();
+#endif
+
 signals:
     void themeChanged();
 
@@ -104,4 +108,8 @@ private:
     mutable QHash<QString, QIcon> m_icons;
     mutable QHash<QString, QIcon> m_darkModeIcons;
     mutable QHash<QString, QIcon> m_flags;
+
+#ifdef Q_OS_WIN
+    ColorMode m_systemColorMode = ColorMode::Light;
+#endif
 };


### PR DESCRIPTION
Windows has separate color theme settings for applications and for Windows itself. But Qt only provides access to the color theme for applications.
Solved this using WinAPI to get Windows color scheme and decide system tray icon color based on it.