### PR TITLE
GHA CI: fix .editorconfig format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,12 +29,7 @@ end_of_line = crlf
 end_of_line = crlf
 
 # ignore paths
-[dist/windows/3rdparty/*,
-  src/base/3rdparty/*,
-  src/lang/*.ts,
-  src/webui/www/private/css/lib/*,
-  src/webui/www/private/scripts/lib/*,
-  src/webui/www/translations/*.ts]
+[{dist/windows/3rdparty/*,src/base/3rdparty/*,src/lang/*.ts,src/webui/www/private/css/lib/*,src/webui/www/private/scripts/lib/*,src/webui/www/translations/*.ts}]
 charset = unset
 end_of_line = unset
 indent_style = unset

--- a/Changelog
+++ b/Changelog
@@ -1,25 +1,25 @@
 Unreleased - sledgehammer999 <sledgehammer999@qbittorrent.org> - v5.3.0alpha1
     - FEATURE: Add an option to match all share limits (glassez) #24043
-	- FEATURE: Put Email examples in placeholder text (Chocobo1) #23949
-	- FEATURE: Add support for widely used image types in HTTP server (Chocobo1) #23886
-	- FEATURE: Allow to filter torrent list by infohash (stalkerok) #23829
-	- FEATURE: Add "Copy path" in Content tab (vafada) #23973
-	- FEATURE: Don't overwrite config file when it has no write permission (Chocobo1) #23817
+    - FEATURE: Put Email examples in placeholder text (Chocobo1) #23949
+    - FEATURE: Add support for widely used image types in HTTP server (Chocobo1) #23886
+    - FEATURE: Allow to filter torrent list by infohash (stalkerok) #23829
+    - FEATURE: Add "Copy path" in Content tab (vafada) #23973
+    - FEATURE: Don't overwrite config file when it has no write permission (Chocobo1) #23817
     - FEATURE: Allow banning IP range (KagurazakaNyaa) #23157
-	- BUGFIX: Fix Comment area background mismatch in Add New Torrent dialog (M-Hassan-Raza) #23916
-	- BUGFIX: Rename FYR Macedonia to North Macedonia (alphanumericcharter) #23825
+    - BUGFIX: Fix Comment area background mismatch in Add New Torrent dialog (M-Hassan-Raza) #23916
+    - BUGFIX: Rename FYR Macedonia to North Macedonia (alphanumericcharter) #23825
     - BUGFIX: Fix LineEdit dark corner artifacts on macOS (M-Hassan-Raza) #23909
     - BUGFIX: Fix macOS delete shortcuts to match platform conventions (M-Hassan-Raza) #23908
     - BUGFIX: Replace invisible toolbar spacers with visible separators on macOS (M-Hassan-Raza) #23905
     - WEBUI: Add "Select All" and "Invert Selection" (aaron-kruse) #23975
-	- WEBUI: Enable virtual list by default (tehcneko) #23887
+    - WEBUI: Enable virtual list by default (tehcneko) #23887
     - WEBUI: Improve folder collapse behavior (Piccirello) #23878
     - WEBUI: Show free disk space in add torrent window (Ryu481) #23856
     - WEBUI: filter array elements in-place (Chocobo1) #23837
     - WEBUI: improve 'set rows' operation performance (Chocobo1) #23818
     - RSS: Fix the added RSS rule item doesn't follow "enabled" state (glassez) #24082
     - RSS: Add "All" sticky RSS item (glassez) #23963
-	- SEARCH: Clean up documentation format (Chocobo1) #23911
+    - SEARCH: Clean up documentation format (Chocobo1) #23911
     - OTHER: Support build against latest version of libtorrent (arvidn) #23953
     - OTHER: Don't use deprecated libtorrent features (glassez) #24007
     - OTHER: Remove outdated setting keys (Chocobo1) #23952

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -87,7 +87,7 @@ GUIAddTorrentManager::~GUIAddTorrentManager()
     {
         dialog->disconnect(this);
         dialog->reject();
-        // `dialog` should be deleted here in order to avoid accessing 
+        // `dialog` should be deleted here in order to avoid accessing
         // already deleted core components when deleting later
         delete dialog;
     }

--- a/src/icons/icons.qrc
+++ b/src/icons/icons.qrc
@@ -364,7 +364,7 @@
         <file>view-statistics.svg</file>
         <file>wallet-open.svg</file>
         <file alias="qbittorrent.svg">qbittorrent-tray.svg</file>
-		<file alias="qbittorrent-tray-mono.svg">qbittorrent-tray-light.svg</file>
-		<file alias="dark/qbittorrent-tray-mono.svg">qbittorrent-tray-dark.svg</file>
+        <file alias="qbittorrent-tray-mono.svg">qbittorrent-tray-light.svg</file>
+        <file alias="dark/qbittorrent-tray-mono.svg">qbittorrent-tray-dark.svg</file>
     </qresource>
 </RCC>

--- a/src/webui/www/private/css/Window.css
+++ b/src/webui/www/private/css/Window.css
@@ -138,9 +138,8 @@ div.mochaToolbarWrapper.bottom {
     To use images for these buttons:
     1. Set the useCanvasControls window option to false.
     2. If you use a different button size you may need to reposition the controls.
-       Modify the controlsOffset window option.
-    2. Replcac the background-color with a background-image for each button.
-
+    3. Modify the controlsOffset window option.
+    4. Replace the background-color with a background-image for each button.
 */
 .mochaMinimizeButton,
 .mochaMaximizeButton,


### PR DESCRIPTION
The wrong format for 'ignore paths' was used and is now fixed.

Also address formatting issues on affected files.
