### PR TITLE
GHA CI: Add `commit-message` to `dependabot` workflow config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,13 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    commit-message:
-      prefix: "GHA CI"
     groups:
       GHA_CI-dependency-update:
         patterns:
           - "*"
+    commit-message:
+      prefix: "GHA CI"
+      include: "Bump action versions"
     labels:
       - "CI"
     schedule:
@@ -16,12 +17,13 @@ updates:
 
   - package-ecosystem: "pre-commit"
     directory: "/"
-    commit-message:
-      prefix: "GHA CI"
     groups:
       GHA_CI-dependency-update:
         patterns:
           - "*"
+    commit-message:
+      prefix: "GHA CI"
+      include:  "Bump pre-commit hook versions"
     labels:
       - "CI"
     schedule:


### PR DESCRIPTION
>Since the titles of pull requests are written based on commit messages, this setting also impacts the titles of pull requests.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#commit-message--

Xref.:

* https://github.com/qbittorrent/qBittorrent/pull/24032#issuecomment-4185481173

* https://github.com/qbittorrent/qBittorrent/pull/24032#issuecomment-4185507208
