### PR TITLE
GHA CI: Replace some `third party` actions

### DIFF
--- a/.github/workflows/ci_file_health.yaml
+++ b/.github/workflows/ci_file_health.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: "*"
 
       - name: Check files
-        uses: pre-commit/action@v3.0.1
+        uses: j178/prek-action@v2
 
       - name: Check doc
         env:

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -45,13 +45,14 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
-        uses: Wandalen/wretry.action@v3
+        uses: nick-fields/retry@v4
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         with:
-          attempt_delay: 20000
-          attempt_limit: 6
+          timeout_seconds: 90
+          retry_wait_seconds: 20
+          max_attempts: 6
           command: |
             brew update > /dev/null
             brew install \

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup devcmd
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: ${{ matrix.config.arch }}
 


### PR DESCRIPTION
Replaced 3x `third party` actions with `node24 compatible` variants, addresses "Node.js 20 actions are deprecated." warnings/annotations.

* [pre-commit/action](https://github.com/pre-commit/action) -> [j178/prek-action](https://github.com/j178/prek-action)

* [ilammy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd) -> [TheMrMilchmann/setup-msvc-dev](https://github.com/TheMrMilchmann/setup-msvc-dev)

* [Wandalen/wretry.action](https://github.com/Wandalen/wretry.action) -> [nick-fields/retry](https://github.com/nick-fields/retry)