### PR TITLE
WebAPI: Restrict RSS cloneRule action allowed methods

### DIFF
--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -155,6 +155,7 @@ private:
         {{u"clientdata"_s, u"store"_s}, Http::METHOD_POST},
         {{u"rss"_s, u"addFeed"_s}, Http::METHOD_POST},
         {{u"rss"_s, u"addFolder"_s}, Http::METHOD_POST},
+        {{u"rss"_s, u"cloneRule"_s}, Http::METHOD_POST},
         {{u"rss"_s, u"markAsRead"_s}, Http::METHOD_POST},
         {{u"rss"_s, u"moveItem"_s}, Http::METHOD_POST},
         {{u"rss"_s, u"refreshItem"_s}, Http::METHOD_POST},


### PR DESCRIPTION
Add RSS `cloneRule` to `m_allowedMethod` in `webapplication.h` to limit HTTP methods of RSS rule cloning to `HTTP POST` requests only.

This is an addition to PR #24056 