### PR TITLE
Add 'request latency' metric to Statistics dialog

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,6 +1,10 @@
 # WebAPI Changelog
 
 ## 2.16.0
+* [#24152](https://github.com/qbittorrent/qBittorrent/pull/24152)
+  * `sync/maindata` endpoint now includes `request_latency` metric
+* [#24084](https://github.com/qbittorrent/qBittorrent/pull/24084)
+  * `sync/maindata` endpoint now includes `queued_tracker_announces` metric
 * [#23838](https://github.com/qbittorrent/qBittorrent/pull/23838)
   * `app/preferences` endpoint no longer includes `mail_notification_ssl_enabled` option as it no longer exists
   * `app/preferences` endpoint includes `mail_notification_encryption_type` option, replacing the removed `mail_notification_ssl_enabled` option

--- a/src/base/bittorrent/cachestatus.h
+++ b/src/base/bittorrent/cachestatus.h
@@ -39,5 +39,6 @@ namespace BitTorrent
         qint64 averageJobTime = 0;
         qint64 queuedBytes = 0;
         qreal readRatio = 0;  // TODO: remove when LIBTORRENT_VERSION_NUM >= 20000
+        qint64 requestLatency = 0;
     };
 }

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1841,7 +1841,8 @@ void SessionImpl::initMetrics()
             .readJobs = findMetricIndex("disk.num_read_ops"),
             .hashJobs = findMetricIndex("disk.num_blocks_hashed"),
             .queuedDiskJobs = findMetricIndex("disk.queued_disk_jobs"),
-            .diskJobTime = findMetricIndex("disk.disk_job_time")
+            .diskJobTime = findMetricIndex("disk.disk_job_time"),
+            .requestLatency = findMetricIndex("disk.request_latency")
         },
         .tracker =
         {
@@ -6288,6 +6289,8 @@ void SessionImpl::handleSessionStatsAlert(const lt::session_stats_alert *alert)
                   + stats[m_metricIndices.disk.hashJobs];
     m_cacheStatus.averageJobTime = (totalJobs > 0)
                                    ? (stats[m_metricIndices.disk.diskJobTime] / totalJobs) : 0;
+
+    m_cacheStatus.requestLatency = stats[m_metricIndices.disk.requestLatency];
 
     emit statsUpdated();
 }

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -131,6 +131,7 @@ namespace BitTorrent
             int hashJobs = -1;
             int queuedDiskJobs = -1;
             int diskJobTime = -1;
+            int requestLatency = -1;
         } disk;
 
         struct

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -96,10 +96,10 @@ void StatsDialog::update()
 #endif
     // Buffers size
     m_ui->labelTotalBuf->setText(Utils::Misc::friendlyUnit(cs.totalUsedBuffers * 16 * 1024));
+
     // Disk overload (100%) equivalent
     // From lt manual: disk_write_queue and disk_read_queue are the number of peers currently waiting on a disk write or disk read
     // to complete before it receives or sends any more data on the socket. It's a metric of how disk bound you are.
-
     m_ui->labelWriteStarve->setText(u"%1%"_s.arg(((ss.diskWriteQueue > 0) && (ss.peersCount > 0))
         ? Utils::String::fromDouble((100. * ss.diskWriteQueue / ss.peersCount), 2)
         : u"0"_s));
@@ -108,9 +108,11 @@ void StatsDialog::update()
         : u"0"_s));
 
     // Disk queues
+    const QString msSuffix = tr("%1 ms");
     m_ui->labelQueuedJobs->setText(QString::number(cs.jobQueueLength));
-    m_ui->labelJobsTime->setText(tr("%1 ms", "18 milliseconds").arg(cs.averageJobTime));
+    m_ui->labelJobsTime->setText(msSuffix.arg(cs.averageJobTime));
     m_ui->labelQueuedBytes->setText(Utils::Misc::friendlyUnit(cs.queuedBytes));
+    m_ui->labelRequestLatency->setText(msSuffix.arg(cs.requestLatency));
 
     // Total connected peers
     m_ui->labelPeers->setText(QString::number(ss.peersCount));

--- a/src/gui/statsdialog.ui
+++ b/src/gui/statsdialog.ui
@@ -224,6 +224,23 @@
             </property>
            </widget>
           </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelRequestLatencyText">
+            <property name="toolTip">
+             <string>The time it takes from receiving a request from a peer until we're sending the response back on the socket</string>
+            </property>
+            <property name="text">
+             <string>Request latency:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+           <widget class="QLabel" name="labelRequestLatency">
+            <property name="text">
+             <string notr="true">TextLabel</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -243,7 +260,7 @@
           <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
            <widget class="QLabel" name="labelQueuedTrackerAnnounces">
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">TextLabel</string>
             </property>
            </widget>
           </item>

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -100,14 +100,15 @@ namespace
     const QString KEY_TRANSFER_AVERAGE_TIME_QUEUE = u"average_time_queue"_s;
     const QString KEY_TRANSFER_GLOBAL_RATIO = u"global_ratio"_s;
     const QString KEY_TRANSFER_QUEUED_IO_JOBS = u"queued_io_jobs"_s;
+    const QString KEY_TRANSFER_QUEUED_TRACKER_ANNOUNCES = u"queued_tracker_announces"_s;
     const QString KEY_TRANSFER_READ_CACHE_HITS = u"read_cache_hits"_s;
     const QString KEY_TRANSFER_READ_CACHE_OVERLOAD = u"read_cache_overload"_s;
+    const QString KEY_TRANSFER_REQUEST_LATENCY = u"request_latency"_s;
     const QString KEY_TRANSFER_TOTAL_BUFFERS_SIZE = u"total_buffers_size"_s;
     const QString KEY_TRANSFER_TOTAL_PEER_CONNECTIONS = u"total_peer_connections"_s;
     const QString KEY_TRANSFER_TOTAL_QUEUED_SIZE = u"total_queued_size"_s;
     const QString KEY_TRANSFER_TOTAL_WASTE_SESSION = u"total_wasted_session"_s;
     const QString KEY_TRANSFER_WRITE_CACHE_OVERLOAD = u"write_cache_overload"_s;
-    const QString KEY_TRANSFER_QUEUED_TRACKER_ANNOUNCES = u"queued_tracker_announces"_s;
 
     const QString KEY_SUFFIX_REMOVED = u"_removed"_s;
 
@@ -186,6 +187,7 @@ namespace
         map[KEY_TRANSFER_QUEUED_IO_JOBS] = cacheStatus.jobQueueLength;
         map[KEY_TRANSFER_AVERAGE_TIME_QUEUE] = cacheStatus.averageJobTime;
         map[KEY_TRANSFER_TOTAL_QUEUED_SIZE] = cacheStatus.queuedBytes;
+        map[KEY_TRANSFER_REQUEST_LATENCY] = cacheStatus.requestLatency;
 
         map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4] = session->lastExternalIPv4Address();
         map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6] = session->lastExternalIPv6Address();

--- a/src/webui/www/private/scripts/statistics.js
+++ b/src/webui/www/private/scripts/statistics.js
@@ -45,6 +45,7 @@ window.qBittorrent.Statistics ??= (() => {
         queuedIOJobs: 0,
         averageTimeInQueue: 0,
         totalQueuedSize: 0,
+        requestLatency: 0,
         // Tracker statistics
         queuedTrackerAnnounces: 0
     };
@@ -62,6 +63,7 @@ window.qBittorrent.Statistics ??= (() => {
         statistics.queuedIOJobs = serverState.queued_io_jobs;
         statistics.averageTimeInQueue = serverState.average_time_queue;
         statistics.totalQueuedSize = serverState.total_queued_size;
+        statistics.requestLatency = serverState.request_latency;
         // Tracker statistics
         statistics.queuedTrackerAnnounces = serverState.queued_tracker_announces;
     };
@@ -82,6 +84,7 @@ window.qBittorrent.Statistics ??= (() => {
         document.getElementById("QueuedIOJobs").textContent = statistics.queuedIOJobs;
         document.getElementById("AverageTimeInQueue").textContent = `${statistics.averageTimeInQueue} ms`;
         document.getElementById("TotalQueuedSize").textContent = window.qBittorrent.Misc.friendlyUnit(statistics.totalQueuedSize, false);
+        document.getElementById("RequestLatency").textContent = `${statistics.requestLatency} ms`;
         // Tracker statistics
         document.getElementById("queuedTrackerAnnounces").textContent = statistics.queuedTrackerAnnounces;
     };

--- a/src/webui/www/private/views/statistics.html
+++ b/src/webui/www/private/views/statistics.html
@@ -60,6 +60,10 @@
                 <td>QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]</td>
                 <td id="TotalQueuedSize" class="statisticsValue"></td>
             </tr>
+            <tr>
+                <td title="QBT_TR(The time it takes from receiving a request from a peer until we're sending the response back on the socket)QBT_TR[CONTEXT=StatsDialog]">QBT_TR(Request latency:)QBT_TR[CONTEXT=StatsDialog]</td>
+                <td id="RequestLatency" class="statisticsValue"></td>
+            </tr>
         </tbody>
     </table>
     <h3>QBT_TR(Tracker statistics)QBT_TR[CONTEXT=StatsDialog]</h3>


### PR DESCRIPTION
It is defined as:
> The time it takes from receiving a request from a peer until we're sending the response back on the socket.

http://libtorrent.org/manual-ref.html#session-statistics

Screenshot:
<img width="304" height="169" alt="screenshot" src="https://github.com/user-attachments/assets/1ea5dd1a-221a-4d44-b2b4-257d76832af2" />

