### PR TITLE
Make "Force reannounce" actually do it

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1670,7 +1670,7 @@ bool TorrentImpl::setCategory(const QString &category)
 
 void TorrentImpl::forceReannounce(const int index)
 {
-    m_nativeHandle.force_reannounce(0, index);
+    m_nativeHandle.force_reannounce(0, index, lt::torrent_handle::ignore_min_interval);
 }
 
 void TorrentImpl::forceDHTAnnounce()


### PR DESCRIPTION
Currently, the "Force reannounce" function doesn't actually force reannounce for working trackers and obeys their timers.

This change makes the function actually do what it says.
