### PR TITLE
Add option to display speeds in bits per second

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -2119,6 +2119,45 @@ void Preferences::setSpeedWidgetGraphEnable(const int id, const bool enable)
     setValue(u"SpeedWidget/graph_enable_%1"_s.arg(id), enable);
 }
 
+Utils::Misc::UnitType Preferences::speedUnitType() const
+{
+    return static_cast<Utils::Misc::UnitType>(value<int>(u"Preferences/Units/SpeedUnitType"_s, static_cast<int>(Utils::Misc::UnitType::Byte)));
+}
+
+void Preferences::setSpeedUnitType(const Utils::Misc::UnitType type)
+{
+    if (type == speedUnitType())
+        return;
+
+    setValue(u"Preferences/Units/SpeedUnitType"_s, static_cast<int>(type));
+}
+
+bool Preferences::speedUseDecimalPrefixes() const
+{
+    return value(u"Preferences/Units/SpeedDecimalPrefixes"_s, false);
+}
+
+void Preferences::setSpeedUseDecimalPrefixes(const bool useDecimal)
+{
+    if (useDecimal == speedUseDecimalPrefixes())
+        return;
+
+    setValue(u"Preferences/Units/SpeedDecimalPrefixes"_s, useDecimal);
+}
+
+bool Preferences::sizeUseDecimalPrefixes() const
+{
+    return value(u"Preferences/Units/SizeDecimalPrefixes"_s, false);
+}
+
+void Preferences::setSizeUseDecimalPrefixes(const bool useDecimal)
+{
+    if (useDecimal == sizeUseDecimalPrefixes())
+        return;
+
+    setValue(u"Preferences/Units/SizeDecimalPrefixes"_s, useDecimal);
+}
+
 bool Preferences::isAddNewTorrentDialogEnabled() const
 {
     return value(u"AddNewTorrentDialog/Enabled"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -35,6 +35,7 @@
 
 #include "base/net/smtpencryptiontype.h"
 #include "base/pathfwd.h"
+#include "base/utils/misc.h"
 #include "base/utils/net.h"
 
 class QDateTime;
@@ -430,6 +431,14 @@ public:
     void setSpeedWidgetPeriod(int period);
     bool getSpeedWidgetGraphEnable(int id) const;
     void setSpeedWidgetGraphEnable(int id, bool enable);
+
+    // Unit display
+    Utils::Misc::UnitType speedUnitType() const;
+    void setSpeedUnitType(Utils::Misc::UnitType type);
+    bool speedUseDecimalPrefixes() const;
+    void setSpeedUseDecimalPrefixes(bool useDecimal);
+    bool sizeUseDecimalPrefixes() const;
+    void setSizeUseDecimalPrefixes(bool useDecimal);
 
     // AddNewTorrentDialog
     bool isAddNewTorrentDialogEnabled() const;

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -54,7 +54,13 @@
 
 namespace
 {
-    const struct { const char *source; const char *comment; } units[] =
+    struct UnitEntry
+    {
+        const char *source;
+        const char *comment;
+    };
+
+    const UnitEntry iecByteUnits[] =
     {
         QT_TRANSLATE_NOOP3("misc", "B", "bytes"),
         QT_TRANSLATE_NOOP3("misc", "KiB", "kibibytes (1024 bytes)"),
@@ -63,6 +69,39 @@ namespace
         QT_TRANSLATE_NOOP3("misc", "TiB", "tebibytes (1024 gibibytes)"),
         QT_TRANSLATE_NOOP3("misc", "PiB", "pebibytes (1024 tebibytes)"),
         QT_TRANSLATE_NOOP3("misc", "EiB", "exbibytes (1024 pebibytes)")
+    };
+
+    const UnitEntry siByteUnits[] =
+    {
+        QT_TRANSLATE_NOOP3("misc", "B", "bytes"),
+        QT_TRANSLATE_NOOP3("misc", "KB", "kilobytes (1000 bytes)"),
+        QT_TRANSLATE_NOOP3("misc", "MB", "megabytes (1000 kilobytes)"),
+        QT_TRANSLATE_NOOP3("misc", "GB", "gigabytes (1000 megabytes)"),
+        QT_TRANSLATE_NOOP3("misc", "TB", "terabytes (1000 gigabytes)"),
+        QT_TRANSLATE_NOOP3("misc", "PB", "petabytes (1000 terabytes)"),
+        QT_TRANSLATE_NOOP3("misc", "EB", "exabytes (1000 petabytes)")
+    };
+
+    const UnitEntry iecBitUnits[] =
+    {
+        QT_TRANSLATE_NOOP3("misc", "bit", "bits"),
+        QT_TRANSLATE_NOOP3("misc", "Kibit", "kibibits (1024 bits)"),
+        QT_TRANSLATE_NOOP3("misc", "Mibit", "mebibits (1024 kibibits)"),
+        QT_TRANSLATE_NOOP3("misc", "Gibit", "gibibits (1024 mebibits)"),
+        QT_TRANSLATE_NOOP3("misc", "Tibit", "tebibits (1024 gibibits)"),
+        QT_TRANSLATE_NOOP3("misc", "Pibit", "pebibits (1024 tebibits)"),
+        QT_TRANSLATE_NOOP3("misc", "Eibit", "exbibits (1024 pebibits)")
+    };
+
+    const UnitEntry siBitUnits[] =
+    {
+        QT_TRANSLATE_NOOP3("misc", "bit", "bits"),
+        QT_TRANSLATE_NOOP3("misc", "Kbit", "kilobits (1000 bits)"),
+        QT_TRANSLATE_NOOP3("misc", "Mbit", "megabits (1000 kilobits)"),
+        QT_TRANSLATE_NOOP3("misc", "Gbit", "gigabits (1000 megabits)"),
+        QT_TRANSLATE_NOOP3("misc", "Tbit", "terabits (1000 gigabits)"),
+        QT_TRANSLATE_NOOP3("misc", "Pbit", "petabits (1000 terabits)"),
+        QT_TRANSLATE_NOOP3("misc", "Ebit", "exabits (1000 petabits)")
     };
 
     // return best userfriendly storage unit (B, KiB, MiB, GiB, TiB, ...)
@@ -76,7 +115,7 @@ namespace
         Utils::Misc::SizeUnit unit;
     };
 
-    std::optional<SplitToFriendlyUnitResult> splitToFriendlyUnit(const qint64 bytes, const int unitThreshold = 1024)
+    std::optional<SplitToFriendlyUnitResult> splitToFriendlyUnit(const qint64 bytes, const int divisor = 1024)
     {
         if (bytes < 0)
             return std::nullopt;
@@ -84,33 +123,45 @@ namespace
         int i = 0;
         auto value = static_cast<qreal>(bytes);
 
-        while ((value >= unitThreshold) && (i < static_cast<int>(Utils::Misc::SizeUnit::ExbiByte)))
+        while ((value >= divisor) && (i < static_cast<int>(Utils::Misc::SizeUnit::ExbiByte)))
         {
-            value /= 1024;
+            value /= divisor;
             ++i;
         }
         return {{value, static_cast<Utils::Misc::SizeUnit>(i)}};
     }
+
+    const auto &selectUnitTable(const Utils::Misc::UnitType type, const bool useDecimalPrefix)
+    {
+        if (type == Utils::Misc::UnitType::Bit)
+            return useDecimalPrefix ? siBitUnits : iecBitUnits;
+        return useDecimalPrefix ? siByteUnits : iecByteUnits;
+    }
 }
 
-QString Utils::Misc::unitString(const SizeUnit unit, const bool isSpeed)
+QString Utils::Misc::unitString(const SizeUnit unit, const bool isSpeed, const UnitType type, const bool useDecimalPrefix)
 {
-    const auto &unitString = units[static_cast<int>(unit)];
-    QString ret = QCoreApplication::translate("misc", unitString.source, unitString.comment);
+    const auto &table = selectUnitTable(type, useDecimalPrefix);
+    const auto &entry = table[static_cast<int>(unit)];
+    QString ret = QCoreApplication::translate("misc", entry.source, entry.comment);
     if (isSpeed)
         ret += QCoreApplication::translate("misc", "/s", "per second");
     return ret;
 }
 
-QString Utils::Misc::friendlyUnit(const qint64 bytes, const bool isSpeed, const int precision)
+QString Utils::Misc::friendlyUnit(const qint64 bytes, const bool isSpeed, const UnitType type, const bool useDecimalPrefix, const int precision)
 {
-    const std::optional<SplitToFriendlyUnitResult> result = splitToFriendlyUnit(bytes);
+    const int divisor = useDecimalPrefix ? 1000 : 1024;
+    // For bit mode, multiply by 8. Overflow is not a concern for practical speed values.
+    const qint64 val = (type == UnitType::Bit) ? (bytes * 8) : bytes;
+
+    const std::optional<SplitToFriendlyUnitResult> result = splitToFriendlyUnit(val, divisor);
     if (!result)
         return QCoreApplication::translate("misc", "Unknown", "Unknown (size)");
 
     const int digitPrecision = (precision >= 0) ? precision : friendlyUnitPrecision(result->unit);
     return Utils::String::fromDouble(result->value, digitPrecision)
-           + QChar::Nbsp + unitString(result->unit, isSpeed);
+           + QChar::Nbsp + unitString(result->unit, isSpeed, type, useDecimalPrefix);
 }
 
 QString Utils::Misc::friendlyUnitCompact(const qint64 bytes)
@@ -148,11 +199,17 @@ int Utils::Misc::friendlyUnitPrecision(const SizeUnit unit)
     }
 }
 
-qlonglong Utils::Misc::sizeInBytes(qreal size, const Utils::Misc::SizeUnit unit)
+qlonglong Utils::Misc::sizeInBytes(qreal size, const Utils::Misc::SizeUnit unit, const bool useDecimalPrefix)
 {
+    const int multiplier = useDecimalPrefix ? 1000 : 1024;
     for (int i = 0; i < static_cast<int>(unit); ++i)
-        size *= 1024;
+        size *= multiplier;
     return size;
+}
+
+qlonglong Utils::Misc::sizeInBytes(qreal size, const Utils::Misc::UnitPrefix prefix)
+{
+    return static_cast<qlonglong>(size * static_cast<qint64>(prefix));
 }
 
 bool Utils::Misc::isPreviewable(const Path &filePath)

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -54,6 +54,32 @@ namespace Utils::Misc
         // YobiByte,   // 1024^8
     };
 
+    // Base unit type: bit or byte
+    enum class UnitType
+    {
+        Bit,
+        Byte
+    };
+
+    // Unit prefix/multiplier with values encoding the actual multiplier
+    // to simplify conversion logic (e.g. sizeInBytes)
+    enum class UnitPrefix : qint64
+    {
+        None = 1,
+        Kilo = 1000LL,
+        Kibi = 1024LL,
+        Mega = 1000LL * 1000,
+        Mebi = 1024LL * 1024,
+        Giga = 1000LL * 1000 * 1000,
+        Gibi = 1024LL * 1024 * 1024,
+        Tera = 1000LL * 1000 * 1000 * 1000,
+        Tebi = 1024LL * 1024 * 1024 * 1024,
+        Peta = 1000LL * 1000 * 1000 * 1000 * 1000,
+        Pebi = 1024LL * 1024 * 1024 * 1024 * 1024,
+        Exa  = 1000LL * 1000 * 1000 * 1000 * 1000 * 1000,
+        Exbi = 1024LL * 1024 * 1024 * 1024 * 1024 * 1024
+    };
+
     enum class TimeResolution
     {
         Seconds,
@@ -68,14 +94,15 @@ namespace Utils::Misc
     QString opensslVersionString();
     QString zlibVersionString();
 
-    QString unitString(SizeUnit unit, bool isSpeed = false);
+    QString unitString(SizeUnit unit, bool isSpeed = false, UnitType type = UnitType::Byte, bool useDecimalPrefix = false);
 
     // return the best user friendly storage unit (B, KiB, MiB, GiB, TiB)
     // value must be given in bytes
-    QString friendlyUnit(qint64 bytes, bool isSpeed = false, int precision = -1);
+    QString friendlyUnit(qint64 bytes, bool isSpeed = false, UnitType type = UnitType::Byte, bool useDecimalPrefix = false, int precision = -1);
     QString friendlyUnitCompact(qint64 bytes);
     int friendlyUnitPrecision(SizeUnit unit);
-    qint64 sizeInBytes(qreal size, SizeUnit unit);
+    qint64 sizeInBytes(qreal size, SizeUnit unit, bool useDecimalPrefix = false);
+    qint64 sizeInBytes(qreal size, UnitPrefix prefix);
 
     bool isPreviewable(const Path &filePath);
     bool isTorrentLink(const QString &str);

--- a/src/gui/macosstatusitem/itemview.mm
+++ b/src/gui/macosstatusitem/itemview.mm
@@ -29,6 +29,7 @@
 #import "itemview.h"
 
 #include <QString>
+#include "base/preferences.h"
 #include "base/utils/misc.h"
 
 namespace
@@ -68,8 +69,11 @@ namespace
 
         self.statusMenu = [[NSMenu alloc] init];
 
-        const QString uploadString = Utils::Misc::friendlyUnit(self.fUploadRate, true);
-        const QString downloadString = Utils::Misc::friendlyUnit(self.fDownloadRate, true);
+        const auto *pref = Preferences::instance();
+        const auto speedType = pref->speedUnitType();
+        const bool speedDecimal = pref->speedUseDecimalPrefixes();
+        const QString uploadString = Utils::Misc::friendlyUnit(self.fUploadRate, speedType, speedDecimal, true);
+        const QString downloadString = Utils::Misc::friendlyUnit(self.fDownloadRate, speedType, speedDecimal, true);
 
         NSString *uploadNSString = uploadString.toNSString();
         NSString *downloadNSString = downloadString.toNSString();
@@ -95,8 +99,11 @@ namespace
     self.fDownloadRate = downloadRate;
     self.fUploadRate = uploadRate;
 
-    const QString uploadString = Utils::Misc::friendlyUnit(self.fUploadRate, true);
-    const QString downloadString = Utils::Misc::friendlyUnit(self.fDownloadRate, true);
+    const auto *pref = Preferences::instance();
+    const auto speedType = pref->speedUnitType();
+    const bool speedDecimal = pref->speedUseDecimalPrefixes();
+    const QString uploadString = Utils::Misc::friendlyUnit(self.fUploadRate, speedType, speedDecimal, true);
+    const QString downloadString = Utils::Misc::friendlyUnit(self.fDownloadRate, speedType, speedDecimal, true);
 
     NSString *uploadNSString = uploadString.toNSString();
     NSString *downloadNSString = downloadString.toNSString();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1474,8 +1474,11 @@ void MainWindow::loadSessionStats()
 {
     const auto *btSession = BitTorrent::Session::instance();
     const BitTorrent::SessionStatus &status = btSession->status();
-    m_downloadRate = Utils::Misc::friendlyUnit(status.payloadDownloadRate, true);
-    m_uploadRate = Utils::Misc::friendlyUnit(status.payloadUploadRate, true);
+    const auto *pref = Preferences::instance();
+    const auto speedType = pref->speedUnitType();
+    const bool speedDecimal = pref->speedUseDecimalPrefixes();
+    m_downloadRate = Utils::Misc::friendlyUnit(status.payloadDownloadRate, true, speedType, speedDecimal);
+    m_uploadRate = Utils::Misc::friendlyUnit(status.payloadUploadRate, true, speedType, speedDecimal);
 
     // update global information
 #ifdef Q_OS_MACOS

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1101,6 +1101,12 @@ void OptionsDialog::loadSpeedTabOptions()
     connect(m_ui->checkShowSpeedInDock, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkShowMenuBarIcon, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 #endif
+
+    m_ui->checkSpeedInBits->setChecked(pref->speedUnitType() == Utils::Misc::UnitType::Bit);
+    m_ui->checkSpeedDecimalPrefixes->setChecked(pref->speedUseDecimalPrefixes());
+
+    connect(m_ui->checkSpeedInBits, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkSpeedDecimalPrefixes, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 }
 
 void OptionsDialog::saveSpeedTabOptions() const
@@ -1127,6 +1133,9 @@ void OptionsDialog::saveSpeedTabOptions() const
     pref->setSpeedInDockEnabled(m_ui->checkShowSpeedInDock->isChecked());
     pref->setMacOSMenuBarIconEnabled(m_ui->checkShowMenuBarIcon->isChecked());
 #endif
+
+    pref->setSpeedUnitType(m_ui->checkSpeedInBits->isChecked() ? Utils::Misc::UnitType::Bit : Utils::Misc::UnitType::Byte);
+    pref->setSpeedUseDecimalPrefixes(m_ui->checkSpeedDecimalPrefixes->isChecked());
 }
 
 void OptionsDialog::loadBittorrentTabOptions()

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2702,6 +2702,29 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="groupBoxSpeedDisplay">
+              <property name="title">
+               <string>Speed Display</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayoutSpeedDisplay">
+               <item>
+                <widget class="QCheckBox" name="checkSpeedInBits">
+                 <property name="text">
+                  <string>Display speeds in bits per second (e.g. Mbit/s)</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkSpeedDecimalPrefixes">
+                 <property name="text">
+                  <string>Use decimal prefixes for speed (KB, MB instead of KiB, MiB)</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -497,12 +497,16 @@ void PeerListWidget::updatePeer(const int row, const BitTorrent::Torrent *torren
     const QString peerIdClient = peer.peerIdClient().toHtmlEscaped();
     setModelData(m_listModel, row, PeerListColumns::PEERID_CLIENT, peerIdClient, peerIdClient);
 
+    const auto *pref = Preferences::instance();
+    const auto speedType = pref->speedUnitType();
+    const bool speedDecimal = pref->speedUseDecimalPrefixes();
+
     const QString downSpeed = (hideZeroValues && (peer.payloadDownSpeed() <= 0))
-            ? QString() : Utils::Misc::friendlyUnit(peer.payloadDownSpeed(), true);
+            ? QString() : Utils::Misc::friendlyUnit(peer.payloadDownSpeed(), true, speedType, speedDecimal);
     setModelData(m_listModel, row, PeerListColumns::DOWN_SPEED, downSpeed, peer.payloadDownSpeed(), intDataTextAlignment);
 
     const QString upSpeed = (hideZeroValues && (peer.payloadUpSpeed() <= 0))
-            ? QString() : Utils::Misc::friendlyUnit(peer.payloadUpSpeed(), true);
+            ? QString() : Utils::Misc::friendlyUnit(peer.payloadUpSpeed(), true, speedType, speedDecimal);
     setModelData(m_listModel, row, PeerListColumns::UP_SPEED, upSpeed, peer.payloadUpSpeed(), intDataTextAlignment);
 
     const QString totalDown = (hideZeroValues && (peer.totalDownload() <= 0))

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -406,6 +406,10 @@ void PropertiesWidget::loadDynamicData()
     {
     case PropTabBar::MainTab:
         {
+            const auto *pref = Preferences::instance();
+            const auto speedType = pref->speedUnitType();
+            const bool speedDecimal = pref->speedUseDecimalPrefixes();
+
             m_ui->labelWastedVal->setText(Utils::Misc::friendlyUnit(m_torrent->wastedSize()));
 
             m_ui->labelUpTotalVal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload())
@@ -414,9 +418,9 @@ void PropertiesWidget::loadDynamicData()
             m_ui->labelDlTotalVal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload())
                 , Utils::Misc::friendlyUnit(m_torrent->totalPayloadDownload())));
 
-            m_ui->labelUpLimitVal->setText(m_torrent->uploadLimit() <= 0 ? C_INFINITY : Utils::Misc::friendlyUnit(m_torrent->uploadLimit(), true));
+            m_ui->labelUpLimitVal->setText(m_torrent->uploadLimit() <= 0 ? C_INFINITY : Utils::Misc::friendlyUnit(m_torrent->uploadLimit(), true, speedType, speedDecimal));
 
-            m_ui->labelDlLimitVal->setText(m_torrent->downloadLimit() <= 0 ? C_INFINITY : Utils::Misc::friendlyUnit(m_torrent->downloadLimit(), true));
+            m_ui->labelDlLimitVal->setText(m_torrent->downloadLimit() <= 0 ? C_INFINITY : Utils::Misc::friendlyUnit(m_torrent->downloadLimit(), true, speedType, speedDecimal));
 
             QString elapsedString;
             if (m_torrent->isFinished())
@@ -456,14 +460,14 @@ void PropertiesWidget::loadDynamicData()
                     , QString::number(m_torrent->totalLeechersCount())));
 
             const qlonglong dlDuration = m_torrent->activeTime() - m_torrent->finishedTime();
-            const QString dlAvg = Utils::Misc::friendlyUnit((m_torrent->totalDownload() / ((dlDuration == 0) ? -1 : dlDuration)), true);
+            const QString dlAvg = Utils::Misc::friendlyUnit((m_torrent->totalDownload() / ((dlDuration == 0) ? -1 : dlDuration)), true, speedType, speedDecimal);
             m_ui->labelDlSpeedVal->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
-                .arg(Utils::Misc::friendlyUnit(m_torrent->downloadPayloadRate(), true), dlAvg));
+                .arg(Utils::Misc::friendlyUnit(m_torrent->downloadPayloadRate(), true, speedType, speedDecimal), dlAvg));
 
             const qlonglong ulDuration = m_torrent->activeTime();
-            const QString ulAvg = Utils::Misc::friendlyUnit((m_torrent->totalUpload() / ((ulDuration == 0) ? -1 : ulDuration)), true);
+            const QString ulAvg = Utils::Misc::friendlyUnit((m_torrent->totalUpload() / ((ulDuration == 0) ? -1 : ulDuration)), true, speedType, speedDecimal);
             m_ui->labelUpSpeedVal->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
-                .arg(Utils::Misc::friendlyUnit(m_torrent->uploadPayloadRate(), true), ulAvg));
+                .arg(Utils::Misc::friendlyUnit(m_torrent->uploadPayloadRate(), true, speedType, speedDecimal), ulAvg));
 
             m_ui->labelLastSeenCompleteVal->setText(m_torrent->lastSeenComplete().isValid() ? QLocale().toString(m_torrent->lastSeenComplete(), QLocale::ShortFormat) : tr("Never"));
 

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -37,6 +37,7 @@
 
 #include "base/bittorrent/session.h"
 #include "base/global.h"
+#include "base/preferences.h"
 #include "base/unicodestrings.h"
 #include "base/utils/misc.h"
 
@@ -49,52 +50,56 @@ namespace
     {
         qreal arg = 0;
         Utils::Misc::SizeUnit unit {};
+        int divisor = 1024;
         qlonglong sizeInBytes() const
         {
-            return Utils::Misc::sizeInBytes(arg, unit);
+            return Utils::Misc::sizeInBytes(arg, unit, (divisor == 1000));
         }
     };
 
-    SplitValue getRoundedYScale(qreal value)
+    SplitValue getRoundedYScale(qreal value, const int divisor = 1024)
     {
         using Utils::Misc::SizeUnit;
 
-        if (value == 0.0) return {0, SizeUnit::Byte};
-        if (value <= 12.0) return {12, SizeUnit::Byte};
+        if (value == 0.0) return {0, SizeUnit::Byte, divisor};
+        if (value <= 12.0) return {12, SizeUnit::Byte, divisor};
 
         SizeUnit calculatedUnit = SizeUnit::Byte;
-        while (value > 1024)
+        while (value > divisor)
         {
-            value /= 1024;
+            value /= divisor;
             calculatedUnit = static_cast<SizeUnit>(static_cast<int>(calculatedUnit) + 1);
         }
 
         if (value > 100)
         {
             const qreal roundedValue {std::ceil(value / 40) * 40};
-            return {roundedValue, calculatedUnit};
+            return {roundedValue, calculatedUnit, divisor};
         }
 
         if (value > 10)
         {
             const qreal roundedValue {std::ceil(value / 4) * 4};
-            return {roundedValue, calculatedUnit};
+            return {roundedValue, calculatedUnit, divisor};
         }
 
         for (const auto &roundedValue : roundingTable)
         {
             if (value <= roundedValue)
-                return {roundedValue, calculatedUnit};
+                return {roundedValue, calculatedUnit, divisor};
         }
-        return {10.0, calculatedUnit};
+        return {10.0, calculatedUnit, divisor};
     }
 
-    QString formatLabel(const qreal argValue, const Utils::Misc::SizeUnit unit)
+    QString formatLabel(const qreal argValue, const Utils::Misc::SizeUnit unit,
+                        const Utils::Misc::UnitType type, const bool useDecimalPrefix)
     {
+        using Utils::Misc::friendlyUnitPrecision;
+        using Utils::Misc::unitString;
         // check is there need for digits after decimal separator
         const int precision = (argValue < 10) ? friendlyUnitPrecision(unit) : 0;
         return QLocale::system().toString(argValue, 'f', precision)
-               + QChar::Nbsp + unitString(unit, true);
+               + QChar::Nbsp + unitString(unit, true, type, useDecimalPrefix);
     }
 }
 
@@ -288,17 +293,24 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     QFontMetrics fontMetrics = painter.fontMetrics();
 
     rect.adjust(4, 4, 0, -4); // Add padding
-    const SplitValue niceScale = getRoundedYScale(maxYValue());
+    const auto *pref = Preferences::instance();
+    const auto speedType = pref->speedUnitType();
+    const bool speedDecimal = pref->speedUseDecimalPrefixes();
+    const int divisor = speedDecimal ? 1000 : 1024;
+    qreal maxY = static_cast<qreal>(maxYValue());
+    if (speedType == Utils::Misc::UnitType::Bit)
+        maxY *= 8;
+    const SplitValue niceScale = getRoundedYScale(maxY, divisor);
     rect.adjust(0, fontMetrics.height(), 0, 0); // Add top padding for top speed text
 
     // draw Y axis speed labels
     const QList<QString> speedLabels =
     {
-        formatLabel(niceScale.arg, niceScale.unit),
-        formatLabel((0.75 * niceScale.arg), niceScale.unit),
-        formatLabel((0.50 * niceScale.arg), niceScale.unit),
-        formatLabel((0.25 * niceScale.arg), niceScale.unit),
-        formatLabel(0.0, niceScale.unit),
+        formatLabel(niceScale.arg, niceScale.unit, speedType, speedDecimal),
+        formatLabel((0.75 * niceScale.arg), niceScale.unit, speedType, speedDecimal),
+        formatLabel((0.50 * niceScale.arg), niceScale.unit, speedType, speedDecimal),
+        formatLabel((0.25 * niceScale.arg), niceScale.unit, speedType, speedDecimal),
+        formatLabel(0.0, niceScale.unit, speedType, speedDecimal),
     };
 
     int yAxisWidth = 0;
@@ -352,6 +364,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     const milliseconds lastDuration {queue.empty() ? 0ms : queue.back().duration};
     const qreal xTickSize = static_cast<qreal>(rect.width()) / (m_currentMaxDuration - lastDuration).count();
     const qreal yMultiplier = (niceScale.arg == 0) ? 0 : (static_cast<qreal>(rect.height()) / niceScale.sizeInBytes());
+    const qreal bitMultiplier = (speedType == Utils::Misc::UnitType::Bit) ? 8.0 : 1.0;
 
     for (int id = UP; id < NB_GRAPHS; ++id)
     {
@@ -364,7 +377,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
         for (int i = static_cast<int>(queue.size()) - 1; i >= 0; --i)
         {
             const int newX = rect.right() - (duration.count() * xTickSize);
-            const int newY = rect.bottom() - (queue[i].data[id] * yMultiplier);
+            const int newY = rect.bottom() - (queue[i].data[id] * bitMultiplier * yMultiplier);
             points.push_back(QPoint(newX, newY));
 
             duration += queue[i].duration;

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -249,18 +249,21 @@ void StatusBar::updateExternalAddressesVisibility()
 void StatusBar::updateSpeedLabels()
 {
     const BitTorrent::SessionStatus &sessionStatus = BitTorrent::Session::instance()->status();
+    const auto *pref = Preferences::instance();
+    const auto speedType = pref->speedUnitType();
+    const bool speedDecimal = pref->speedUseDecimalPrefixes();
 
-    QString dlSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadDownloadRate, true);
+    QString dlSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadDownloadRate, true, speedType, speedDecimal);
     const int dlSpeedLimit = BitTorrent::Session::instance()->downloadSpeedLimit();
     if (dlSpeedLimit > 0)
-        dlSpeedLbl += u" [" + Utils::Misc::friendlyUnit(dlSpeedLimit, true) + u']';
+        dlSpeedLbl += u" [" + Utils::Misc::friendlyUnit(dlSpeedLimit, true, speedType, speedDecimal) + u']';
     dlSpeedLbl += u" (" + Utils::Misc::friendlyUnit(sessionStatus.totalPayloadDownload) + u')';
     m_dlSpeedLbl->setText(dlSpeedLbl);
 
-    QString upSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadUploadRate, true);
+    QString upSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadUploadRate, true, speedType, speedDecimal);
     const int upSpeedLimit = BitTorrent::Session::instance()->uploadSpeedLimit();
     if (upSpeedLimit > 0)
-        upSpeedLbl += u" [" + Utils::Misc::friendlyUnit(upSpeedLimit, true) + u']';
+        upSpeedLbl += u" [" + Utils::Misc::friendlyUnit(upSpeedLimit, true, speedType, speedDecimal) + u']';
     upSpeedLbl += u" (" + Utils::Misc::friendlyUnit(sessionStatus.totalPayloadUpload) + u')';
     m_upSpeedLbl->setText(upSpeedLbl);
 }

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -124,7 +124,7 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
     for (int i = 4; i <= 17; ++i)
     {
         const int size = 1024 << i;
-        const QString displaySize = Utils::Misc::friendlyUnit(size, false, 0);
+        const QString displaySize = Utils::Misc::friendlyUnit(size, false, Utils::Misc::UnitType::Byte, false, 0);
         m_ui->comboPieceSize->addItem(displaySize, size);
     }
 

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -262,8 +262,12 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
 
     const auto unitString = [hideValues](const qint64 value, const bool isSpeedUnit = false) -> QString
     {
-        return (hideValues && (value == 0))
-                ? QString {} : Utils::Misc::friendlyUnit(value, isSpeedUnit);
+        if (hideValues && (value == 0))
+            return {};
+        const auto *pref = Preferences::instance();
+        if (isSpeedUnit)
+            return Utils::Misc::friendlyUnit(value, true, pref->speedUnitType(), pref->speedUseDecimalPrefixes());
+        return Utils::Misc::friendlyUnit(value, false, Utils::Misc::UnitType::Byte, pref->sizeUseDecimalPrefixes());
     };
 
     const auto limitString = [hideValues](const qint64 value) -> QString
@@ -271,9 +275,12 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         if (hideValues && (value <= 0))
             return {};
 
-        return (value > 0)
-                ? Utils::Misc::friendlyUnit(value, true)
-                : C_INFINITY;
+        if (value > 0)
+        {
+            const auto *pref = Preferences::instance();
+            return Utils::Misc::friendlyUnit(value, true, pref->speedUnitType(), pref->speedUseDecimalPrefixes());
+        }
+        return C_INFINITY;
     };
 
     const auto amountString = [hideValues](const qint64 value, const qint64 total) -> QString

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -294,6 +294,10 @@ void AppController::preferencesAction()
     data[u"schedule_to_hour"_s] = end_time.hour();
     data[u"schedule_to_min"_s] = end_time.minute();
     data[u"scheduler_days"_s] = static_cast<int>(pref->getSchedulerDays());
+    // Speed Display
+    data[u"speed_unit_type"_s] = static_cast<int>(pref->speedUnitType());
+    data[u"speed_use_decimal_prefixes"_s] = pref->speedUseDecimalPrefixes();
+    data[u"size_use_decimal_prefixes"_s] = pref->sizeUseDecimalPrefixes();
 
     // Bittorrent
     // Privacy
@@ -815,6 +819,13 @@ void AppController::setPreferencesAction()
         pref->setSchedulerEndTime({hourIter.value().toInt(), minIter.value().toInt()});
     if (hasKey(u"scheduler_days"_s))
         pref->setSchedulerDays(static_cast<Scheduler::Days>(it.value().toInt()));
+    // Speed Display
+    if (hasKey(u"speed_unit_type"_s))
+        pref->setSpeedUnitType(static_cast<Utils::Misc::UnitType>(it.value().toInt()));
+    if (hasKey(u"speed_use_decimal_prefixes"_s))
+        pref->setSpeedUseDecimalPrefixes(it.value().toBool());
+    if (hasKey(u"size_use_decimal_prefixes"_s))
+        pref->setSizeUseDecimalPrefixes(it.value().toBool());
 
     // Bittorrent
     // Privacy

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -110,7 +110,7 @@ window.qBittorrent.Misc ??= (() => {
         if ((value === undefined) || (value === null) || Number.isNaN(value) || (value < 0))
             return "QBT_TR(Unknown)QBT_TR[CONTEXT=misc]";
 
-        const units = [
+        const iecByteUnits = [
             "QBT_TR(B)QBT_TR[CONTEXT=misc]",
             "QBT_TR(KiB)QBT_TR[CONTEXT=misc]",
             "QBT_TR(MiB)QBT_TR[CONTEXT=misc]",
@@ -119,6 +119,59 @@ window.qBittorrent.Misc ??= (() => {
             "QBT_TR(PiB)QBT_TR[CONTEXT=misc]",
             "QBT_TR(EiB)QBT_TR[CONTEXT=misc]"
         ];
+        const siByteUnits = [
+            "QBT_TR(B)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(kB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(MB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(GB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(TB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(PB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(EB)QBT_TR[CONTEXT=misc]"
+        ];
+        const iecBitUnits = [
+            "QBT_TR(bit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Kibit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Mibit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Gibit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Tibit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Pibit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Eibit)QBT_TR[CONTEXT=misc]"
+        ];
+        const siBitUnits = [
+            "QBT_TR(bit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(kbit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Mbit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Gbit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Tbit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Pbit)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(Ebit)QBT_TR[CONTEXT=misc]"
+        ];
+
+        let useDecimal = false;
+        let useBits = false;
+        if (isSpeed && window.qBittorrent && window.qBittorrent.Cache && window.qBittorrent.Cache.preferences) {
+            const prefs = window.qBittorrent.Cache.preferences.get();
+            if (prefs) {
+                useBits = (prefs.speed_unit_type === 0);
+                useDecimal = !!prefs.speed_use_decimal_prefixes;
+            }
+        }
+        else if (!isSpeed && window.qBittorrent && window.qBittorrent.Cache && window.qBittorrent.Cache.preferences) {
+            const prefs = window.qBittorrent.Cache.preferences.get();
+            if (prefs) {
+                useDecimal = !!prefs.size_use_decimal_prefixes;
+            }
+        }
+
+        const divisor = useDecimal ? 1000 : 1024;
+        let units;
+        if (useBits && isSpeed)
+            units = useDecimal ? siBitUnits : iecBitUnits;
+        else
+            units = useDecimal ? siByteUnits : iecByteUnits;
+
+        if (useBits && isSpeed)
+            value *= 8;
 
         const friendlyUnitPrecision = (sizeUnit) => {
             if (sizeUnit <= 2) // KiB, MiB
@@ -130,8 +183,8 @@ window.qBittorrent.Misc ??= (() => {
         };
 
         let i = 0;
-        while ((value >= 1024) && (i < 6)) {
-            value /= 1024;
+        while ((value >= divisor) && (i < 6)) {
+            value /= divisor;
             ++i;
         }
 


### PR DESCRIPTION
Introduce UnitType {Bit, Byte} and UnitPrefix (with numeric multiplier values) enums to cleanly separate the base unit from the magnitude.

New overloads of friendlyUnit(), unitString(), and sizeInBytes() accept UnitType and a decimal-prefix flag, selecting among four unit string tables: iecByteUnits, siByteUnits, iecBitUnits, siBitUnits.

Bit mode only applies to speed displays (not file sizes), defaulting to binary (IEC) prefixes. Two checkboxes are added to the Speed tab in the Options dialog: one to switch speeds to bit/s, one for decimal prefixes.

The same logic is mirrored in the WebUI (misc.js) and exposed through the preferences API (speed_unit_type, speed_use_decimal_prefixes, size_use_decimal_prefixes).

Closes #12971.

<img width="811" height="646" alt="image" src="https://github.com/user-attachments/assets/9c00a2b8-b47b-4203-a985-14b3a91dc7c5" />

<img width="1578" height="354" alt="image" src="https://github.com/user-attachments/assets/0636fc72-2650-4d44-9a5e-0266d4f55cae" />
