### PR TITLE
GHA CI: Bump numerous dependency revs

### DIFF
--- a/.github/workflows/ci_file_health.yaml
+++ b/.github/workflows/ci_file_health.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Check doc
         env:
           pandoc_path: "${{ github.workspace }}/../pandoc"
-          pandoc_version: "3.8.3"
+          pandoc_version: "3.9.0.2"
         run: |
           # install pandoc
           curl \

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -21,18 +21,18 @@ jobs:
         libtorrent:
           - version: "2.1.0-rc1"
             boost_major_version: "1"
-            boost_minor_version: "90"
+            boost_minor_version: "91"
             boost_patch_version: "0"
-          - version: "2.0.11"
+          - version: "2.0.12"
             boost_major_version: "1"
-            boost_minor_version: "90"
+            boost_minor_version: "91"
             boost_patch_version: "0"
           - version: "1.2.20"
             boost_major_version: "1"
             boost_minor_version: "86"
             boost_patch_version: "0"
         qbt_gui: ["GUI=ON", "GUI=OFF"]
-        qt_version: ["6.10.1"]
+        qt_version: ["6.10.3"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -24,7 +24,7 @@ jobs:
             boost_major_version: "1"
             boost_minor_version: "77"
             boost_patch_version: "0"
-          - version: "2.0.11"
+          - version: "2.0.12"
             boost_major_version: "1"
             boost_minor_version: "77"
             boost_patch_version: "0"

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -21,11 +21,11 @@ jobs:
         libtorrent:
           - version: "2.1.0-rc1"
             boost_major_version: "1"
-            boost_minor_version: "90"
+            boost_minor_version: "91"
             boost_patch_version: "0"
-          - version: "2.0.11"
+          - version: "2.0.12"
             boost_major_version: "1"
-            boost_minor_version: "90"
+            boost_minor_version: "91"
             boost_patch_version: "0"
           - version: "1.2.20"
             boost_major_version: "1"
@@ -120,7 +120,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: "6.10.1"
+          version: "6.10.3"
           arch: ${{ matrix.config.qt_arch }}
           archives: qtbase qtsvg qttools
           modules: qtimageformats
@@ -224,9 +224,9 @@ jobs:
           path: upload
 
       - name: Install NSIS
-        uses: repolevedavaj/install-nsis@a55ed92772254d1e51d880f85ce9b5719f907801 # v1.1.0
+        uses: repolevedavaj/install-nsis@c14d0ea1b829818b4e9313d8e009b43f0a65fddd # v1.2.0
         with:
-          nsis-version: '3.11'
+          nsis-version: '3.12'
 
       - name: Create installer
         run: |

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         libtorrent:
-          - version: "2.0.11"
+          - version: "2.0.12"
             boost_major_version: "1"
-            boost_minor_version: "90"
+            boost_minor_version: "91"
             boost_patch_version: "0"
         qbt_gui: ["GUI=ON"]
-        qt_version: ["6.10.1"]
+        qt_version: ["6.10.3"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"


### PR DESCRIPTION
Bumped dependencies:

* Pandoc: `3.8.3` -> `3.9.0.2` (file health)
* Libtorrent: `2.0.11` -> `2.0.12`
* Boost: `1.90.0` -> `1.91.0`
* Qt: `6.10.1` -> `6.10.3`
* NSIS: `3.11` -> `3.12` (Windows)
* `repolevedavaj/install-nsis` action `1.1.0` -> `1.2.0`

Note:
Linux - (Boost/Qt) were left untouched.