### PR TITLE
Handle IPv6 range with prefix length 128 as single IP

### DIFF
--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -153,9 +153,7 @@ namespace Utils
             {
                 // Special case: /128 is a single IP
                 if (prefixLength == 128)
-                {
                     return std::make_pair(address, address);
-                }
 
                 Q_IPV6ADDR addressBytes = address.toIPv6Address();
 

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -151,6 +151,12 @@ namespace Utils
             }
             if (addressFamily == QAbstractSocket::IPv6Protocol)
             {
+                // Special case: /128 is a single IP
+                if (prefixLength == 128)
+                {
+                    return std::make_pair(address, address);
+                }
+
                 Q_IPV6ADDR addressBytes = address.toIPv6Address();
 
                 const int headBytes = prefixLength / 8;


### PR DESCRIPTION
This fix add handling of prefix length of 128, which is special case for IPv6, when range consists only of one IP address.
Without this, headBytes is calculated, equal to 16 and then used as index to access array indexed from 0 to 15.

Closes #24179.