### PR TITLE
Fix building with latest zlib

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -231,7 +231,6 @@ target_link_libraries(qbt_base
     PRIVATE
         OpenSSL::Crypto
         OpenSSL::SSL
-        ZLIB::ZLIB
     PUBLIC
         LibtorrentRasterbar::torrent-rasterbar
         Qt::Core
@@ -241,6 +240,12 @@ target_link_libraries(qbt_base
         Qt::Xml
         qbt_common_cfg
 )
+
+if (TARGET ZLIB::ZLIB)
+    target_link_libraries(qbt_base PRIVATE ZLIB::ZLIB)
+else()
+    target_link_libraries(qbt_base PRIVATE ZLIB::ZLIBSTATIC)
+endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     find_library(AppKit_LIBRARY AppKit)


### PR DESCRIPTION
Latest zlib versions import different targets for static and shared build types.
So we'll now import `ZLIB::ZLIBSTATIC` if `ZLIB::ZLIB` is not available.