### PR TITLE
WebUI: Serialize torrent creator dates as epoch seconds

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,6 +1,8 @@
 # WebAPI Changelog
 
 ## 2.16.0
+* [#24210](https://github.com/qbittorrent/qBittorrent/pull/24210)
+  * `torrentcreator/status` endpoint now returns `timeAdded`, `timeStarted`, and `timeFinished` as Unix timestamps
 * [#24158](https://github.com/qbittorrent/qBittorrent/pull/24158)
   * `app/preferences` endpoint includes `seeding_outgoing_connections` option
   * `app/setPreferences` endpoint allows to set `seeding_outgoing_connections` option

--- a/src/webui/api/torrentcreatorcontroller.cpp
+++ b/src/webui/api/torrentcreatorcontroller.cpp
@@ -37,6 +37,7 @@
 #include "base/global.h"
 #include "base/bittorrent/torrentcreationmanager.h"
 #include "base/preferences.h"
+#include "base/utils/datetime.h"
 #include "base/utils/io.h"
 #include "base/utils/string.h"
 #include "apierror.h"
@@ -174,7 +175,7 @@ void TorrentCreatorController::statusAction()
             {KEY_SOURCE_PATH, task->params().sourcePath.toString()},
             {KEY_PIECE_SIZE, task->params().pieceSize},
             {KEY_PRIVATE, task->params().isPrivate},
-            {KEY_TIME_ADDED, task->timeAdded().toString()},
+            {KEY_TIME_ADDED, Utils::DateTime::toSecsSinceEpoch(task->timeAdded())},
 #ifdef QBT_USES_LIBTORRENT2
             {KEY_FORMAT, torrentFormatToString(task->params().torrentFormat)},
 #else
@@ -200,10 +201,10 @@ void TorrentCreatorController::statusAction()
             taskJson[KEY_URL_SEEDS] = QJsonArray::fromStringList(task->params().urlSeeds);
 
         if (const QDateTime timeStarted = task->timeStarted(); !timeStarted.isNull())
-            taskJson[KEY_TIME_STARTED] = timeStarted.toString();
+            taskJson[KEY_TIME_STARTED] = Utils::DateTime::toSecsSinceEpoch(timeStarted);
 
-        if (const QDateTime timeFinished = task->timeFinished(); !task->timeFinished().isNull())
-            taskJson[KEY_TIME_FINISHED] = timeFinished.toString();
+        if (const QDateTime timeFinished = task->timeFinished(); !timeFinished.isNull())
+            taskJson[KEY_TIME_FINISHED] = Utils::DateTime::toSecsSinceEpoch(timeFinished);
 
         if (task->isFinished())
         {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -3742,7 +3742,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = "";
                 }
                 else {
-                    const date = window.qBittorrent.Misc.formatDate(new Date(val));
+                    const date = window.qBittorrent.Misc.formatDate(new Date(val * 1000));
                     td.textContent = date;
                     td.title = date;
                 }


### PR DESCRIPTION
## Summary

- Serialize torrent creator task timestamps as epoch seconds in the WebUI status API
- Update the torrent creator table to render those epoch-second values correctly

Fixes #24154.

## Testing

- `node --check src/webui/www/private/scripts/dynamicTable.js`
- `git diff --check`

Full C++ build not run locally: Qt6Core and libtorrent-rasterbar are not installed in this environment.
