### PR TITLE
WebUI: Avoid search downloader for magnet links

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1202,7 +1202,7 @@ void TorrentsController::addAction()
                 ++failure;
             }
         }
-        else if (!downloaderParam.isEmpty())
+        else if (!downloaderParam.isEmpty() && !infoHash.isValid())
         {
             if (!filePriorities.isEmpty())
                 throw APIError(APIErrorType::BadParams, tr("`filePriorities` may only be specified when metadata has already been fetched"));


### PR DESCRIPTION
## Summary

- Avoid routing magnet links through the search plugin downloader when adding from the WebUI add-torrent dialog
- Let parseable sources with an info hash use the normal add-torrent path even when a `downloader` parameter is present

Fixes #24161.

## Testing

- `git diff --check`

Full C++ build not run locally: Qt6Core and libtorrent-rasterbar are not installed in this environment.
