### PR TITLE
Avoid SOCKS proxying multiprocessing IPC

### DIFF
--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -52,9 +52,6 @@ if current_path not in sys.path:
 
 import helpers
 
-# enable SOCKS proxy for all plugins by default
-helpers.enable_socks_proxy(True)
-
 THREADED: bool = True
 try:
     MAX_THREADS: int = cpu_count()
@@ -194,6 +191,9 @@ def run_search(search_params: tuple[type[Engine], str, Category]) -> bool:
 
     engine_class, what, cat = search_params
     try:
+        # Enable SOCKS proxying only while the plugin runs. Keeping the socket
+        # module monkeypatched in the parent process breaks multiprocessing IPC.
+        helpers.enable_socks_proxy(True)
         engine = engine_class()
         # avoid exceptions due to invalid category
         if hasattr(engine, 'supported_categories'):
@@ -205,6 +205,8 @@ def run_search(search_params: tuple[type[Engine], str, Category]) -> bool:
     except Exception:
         traceback.print_exc()
         return False
+    finally:
+        helpers.enable_socks_proxy(False)
 
 
 if __name__ == "__main__":

--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -1,4 +1,4 @@
-# VERSION: 1.52
+# VERSION: 1.53
 
 # Author:
 #  Fabien Devaux <fab AT gnux DOT info>


### PR DESCRIPTION
## Summary

- Avoid enabling the SOCKS proxy socket monkeypatch before the search process creates its multiprocessing pool
- Enable SOCKS proxying only while each search plugin runs, then restore the original socket implementation

Fixes #24208.

## Testing

- `env qbt_socks_proxy=socks5://127.0.0.1:1080 python3 src/searchengine/nova3/nova2.py all all test`
- `python3 -m py_compile src/searchengine/nova3/nova2.py`
- `git diff --check`
