### PR TITLE
WebUI: Work around browser extension interfering with Add Torrent Dialog

### DIFF
--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -82,7 +82,7 @@
 
                 // ensure event is from qBittorrent and not from a browser extension
                 // also make sure the event is a message from the AddTorrent dialog
-                if (event?.data?.type !== 'addtorrent_metadata')
+                if (event?.data?.type !== "addtorrent_metadata")
                     return;
 
                 window.qBittorrent.AddTorrent.populateMetadata(event.data.metadata);

--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -80,6 +80,10 @@
                 if (event.origin !== window.origin)
                     return;
 
+                // ensure event is from qBittorrent and not from a browser extension
+                if (event?.data?.isQBittorrent !== true)
+                    return;
+
                 window.qBittorrent.AddTorrent.populateMetadata(event.data);
                 window.qBittorrent.AddTorrent.metadataCompleted(false);
             });

--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -81,10 +81,11 @@
                     return;
 
                 // ensure event is from qBittorrent and not from a browser extension
-                if (event?.data?.isQBittorrent !== true)
+                // also make sure the event is a message from the AddTorrent dialog
+                if (event?.data?.type !== 'addtorrent_metadata')
                     return;
 
-                window.qBittorrent.AddTorrent.populateMetadata(event.data);
+                window.qBittorrent.AddTorrent.populateMetadata(event.data.metadata);
                 window.qBittorrent.AddTorrent.metadataCompleted(false);
             });
 

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -204,8 +204,9 @@ window.qBittorrent.Client ??= (() => {
             }),
             onContentLoaded: () => {
                 if (metadata !== undefined) {
+                    const type = "addtorrent_metadata";
                     document.getElementById(`${id}_iframe`).contentWindow.postMessage({
-                        type: 'addtorrent_metadata',
+                        type,
                         metadata,
                     }, window.origin);
                 }

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -203,11 +203,12 @@ window.qBittorrent.Client ??= (() => {
                 saveWindowSize(staticId, id);
             }),
             onContentLoaded: () => {
-                if (metadata !== undefined)
+                if (metadata !== undefined) {
                     document.getElementById(`${id}_iframe`).contentWindow.postMessage({
                         ...metadata,
                         isQBittorrent: true,
                     }, window.origin);
+                }
             }
         });
     };

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -204,7 +204,10 @@ window.qBittorrent.Client ??= (() => {
             }),
             onContentLoaded: () => {
                 if (metadata !== undefined)
-                    document.getElementById(`${id}_iframe`).contentWindow.postMessage(metadata, window.origin);
+                    document.getElementById(`${id}_iframe`).contentWindow.postMessage({
+                        ...metadata,
+                        isQBittorrent: true,
+                    }, window.origin);
             }
         });
     };

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -205,8 +205,8 @@ window.qBittorrent.Client ??= (() => {
             onContentLoaded: () => {
                 if (metadata !== undefined) {
                     document.getElementById(`${id}_iframe`).contentWindow.postMessage({
-                        ...metadata,
-                        isQBittorrent: true,
+                        type: 'addtorrent_metadata',
+                        metadata,
                     }, window.origin);
                 }
             }


### PR DESCRIPTION
<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->

Closes #24216

Add a new property `type` when calling `postMessage` so we can filter out messages that aren't triggered by our WebUI. Browser extension can trigger `message` event and our listener is getting triggered causing undesired behavior.

Verified WebUI upload torrent flow still works which is the only place we are  calling `postMessage`