### PR TITLE
WebUI: Respect excluded file names in Add torrent dialog

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,6 +1,8 @@
 # WebAPI Changelog
 
 ## 2.16.0
+* [#24246](https://github.com/qbittorrent/qBittorrent/pull/24246)
+  * `torrents/fetchMetadata` and `torrents/parseMetadata` endpoints include file `priority` when excluded file names apply
 * [#24158](https://github.com/qbittorrent/qBittorrent/pull/24158)
   * `app/preferences` endpoint includes `seeding_outgoing_connections` option
   * `app/setPreferences` endpoint allows to set `seeding_outgoing_connections` option

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -408,16 +408,25 @@ namespace
     {
         qlonglong torrentSize = 0;
         QJsonArray files;
+
+        QList<BitTorrent::DownloadPriority> filePriorities;
+        BitTorrent::Session::instance()->applyFilenameFilter(info.filePaths(), filePriorities);
+
         for (int fileIndex = 0; fileIndex < info.filesCount(); ++fileIndex)
         {
             const qlonglong fileSize = info.fileSize(fileIndex);
             torrentSize += fileSize;
-            files << QJsonObject
+            QJsonObject file
             {
                 // use platform-independent separators
                 {KEY_TORRENTINFO_FILE_PATH, info.filePath(fileIndex).data()},
                 {KEY_TORRENTINFO_FILE_LENGTH, fileSize}
             };
+
+            if (!filePriorities.isEmpty())
+                file.insert(KEY_FILE_PRIORITY, static_cast<int>(filePriorities.at(fileIndex)));
+
+            files << file;
         }
 
         const BitTorrent::InfoHash infoHash = info.infoHash();

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -298,12 +298,44 @@ window.qBittorrent.AddTorrent ??= (() => {
     };
 
     const wildcardToRegExp = (pattern) => {
-        const escapedPattern = pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
-        return new RegExp(`^${escapedPattern.replaceAll("*", ".*").replaceAll("?", ".")}$`, "i");
+        let expression = "^";
+        for (let i = 0; i < pattern.length; ++i) {
+            const char = pattern[i];
+            if (char === "*") {
+                expression += ".*";
+                continue;
+            }
+            if (char === "?") {
+                expression += ".";
+                continue;
+            }
+            if (char === "[") {
+                let end = i + 1;
+                if ((pattern[end] === "!") || (pattern[end] === "^"))
+                    ++end;
+                if (pattern[end] === "]")
+                    ++end;
+                while ((end < pattern.length) && (pattern[end] !== "]"))
+                    ++end;
+
+                if (end < pattern.length) {
+                    let charClass = pattern.slice(i + 1, end).replace(/\\/g, "\\\\");
+                    if (charClass.startsWith("!"))
+                        charClass = `^${charClass.slice(1)}`;
+                    else if (charClass.startsWith("^"))
+                        charClass = `\\${charClass}`;
+                    expression += `[${charClass}]`;
+                    i = end;
+                    continue;
+                }
+            }
+            expression += char.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+        }
+        return new RegExp(`${expression}$`, "i");
     };
 
-    const isExcludedFileName = (path, patterns) => {
-        const pathParts = path.split(/[\\/]+/);
+    const isExcludedFileName = (path, rootName, patterns) => {
+        const pathParts = [rootName, ...path.split(/[\\/]+/)].filter((part) => part.length > 0);
         return pathParts.some((part) => patterns.some((pattern) => pattern.test(part)));
     };
 
@@ -318,8 +350,8 @@ window.qBittorrent.AddTorrent ??= (() => {
             .map(wildcardToRegExp);
     };
 
-    const getFilePriority = (path, excludedFileNamePatterns) => {
-        return isExcludedFileName(path, excludedFileNamePatterns)
+    const getFilePriority = (path, rootName, excludedFileNamePatterns) => {
+        return isExcludedFileName(path, rootName, excludedFileNamePatterns)
             ? window.qBittorrent.FileTree.FilePriority.Ignored
             : window.qBittorrent.FileTree.FilePriority.Normal;
     };
@@ -349,7 +381,8 @@ window.qBittorrent.AddTorrent ??= (() => {
                 index: index,
                 name: file.path,
                 size: file.length,
-                priority: getFilePriority(file.path, excludedFileNamePatterns),
+                priority: getFilePriority(file.path, metadata.info.name ?? "",
+                    excludedFileNamePatterns),
             }));
             window.qBittorrent.TorrentContent.updateData(files);
         }

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -297,6 +297,33 @@ window.qBittorrent.AddTorrent ??= (() => {
         document.getElementById("errorIcon").classList.remove("invisible");
     };
 
+    const wildcardToRegExp = (pattern) => {
+        const escapedPattern = pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+        return new RegExp(`^${escapedPattern.replaceAll("*", ".*").replaceAll("?", ".")}$`, "i");
+    };
+
+    const isExcludedFileName = (path, patterns) => {
+        const pathParts = path.split(/[\\/]+/);
+        return pathParts.some((part) => patterns.some((pattern) => pattern.test(part)));
+    };
+
+    const getExcludedFileNamePatterns = () => {
+        const pref = window.parent.qBittorrent.Cache.preferences.get();
+        if (!pref.excluded_file_names_enabled)
+            return [];
+
+        return pref.excluded_file_names
+            .split("\n")
+            .filter((pattern) => pattern.length > 0)
+            .map(wildcardToRegExp);
+    };
+
+    const getFilePriority = (path, excludedFileNamePatterns) => {
+        return isExcludedFileName(path, excludedFileNamePatterns)
+            ? window.qBittorrent.FileTree.FilePriority.Ignored
+            : window.qBittorrent.FileTree.FilePriority.Normal;
+    };
+
     const populateMetadata = (metadata) => {
         // update window title
         if (metadata.info?.name !== undefined)
@@ -317,11 +344,12 @@ window.qBittorrent.AddTorrent ??= (() => {
             document.getElementById("comment").textContent = metadata.comment;
 
         if (metadata.info?.files !== undefined) {
+            const excludedFileNamePatterns = getExcludedFileNamePatterns();
             const files = metadata.info.files.map((file, index) => ({
                 index: index,
                 name: file.path,
                 size: file.length,
-                priority: window.qBittorrent.FileTree.FilePriority.Normal,
+                priority: getFilePriority(file.path, excludedFileNamePatterns),
             }));
             window.qBittorrent.TorrentContent.updateData(files);
         }

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -297,65 +297,6 @@ window.qBittorrent.AddTorrent ??= (() => {
         document.getElementById("errorIcon").classList.remove("invisible");
     };
 
-    const wildcardToRegExp = (pattern) => {
-        let expression = "^";
-        for (let i = 0; i < pattern.length; ++i) {
-            const char = pattern[i];
-            if (char === "*") {
-                expression += ".*";
-                continue;
-            }
-            if (char === "?") {
-                expression += ".";
-                continue;
-            }
-            if (char === "[") {
-                let end = i + 1;
-                if ((pattern[end] === "!") || (pattern[end] === "^"))
-                    ++end;
-                if (pattern[end] === "]")
-                    ++end;
-                while ((end < pattern.length) && (pattern[end] !== "]"))
-                    ++end;
-
-                if (end < pattern.length) {
-                    let charClass = pattern.slice(i + 1, end).replace(/\\/g, "\\\\");
-                    if (charClass.startsWith("!"))
-                        charClass = `^${charClass.slice(1)}`;
-                    else if (charClass.startsWith("^"))
-                        charClass = `\\${charClass}`;
-                    expression += `[${charClass}]`;
-                    i = end;
-                    continue;
-                }
-            }
-            expression += char.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
-        }
-        return new RegExp(`${expression}$`, "i");
-    };
-
-    const isExcludedFileName = (path, rootName, patterns) => {
-        const pathParts = [rootName, ...path.split(/[\\/]+/)].filter((part) => part.length > 0);
-        return pathParts.some((part) => patterns.some((pattern) => pattern.test(part)));
-    };
-
-    const getExcludedFileNamePatterns = () => {
-        const pref = window.parent.qBittorrent.Cache.preferences.get();
-        if (!pref.excluded_file_names_enabled)
-            return [];
-
-        return pref.excluded_file_names
-            .split("\n")
-            .filter((pattern) => pattern.length > 0)
-            .map(wildcardToRegExp);
-    };
-
-    const getFilePriority = (path, rootName, excludedFileNamePatterns) => {
-        return isExcludedFileName(path, rootName, excludedFileNamePatterns)
-            ? window.qBittorrent.FileTree.FilePriority.Ignored
-            : window.qBittorrent.FileTree.FilePriority.Normal;
-    };
-
     const populateMetadata = (metadata) => {
         // update window title
         if (metadata.info?.name !== undefined)
@@ -376,13 +317,11 @@ window.qBittorrent.AddTorrent ??= (() => {
             document.getElementById("comment").textContent = metadata.comment;
 
         if (metadata.info?.files !== undefined) {
-            const excludedFileNamePatterns = getExcludedFileNamePatterns();
             const files = metadata.info.files.map((file, index) => ({
                 index: index,
                 name: file.path,
                 size: file.length,
-                priority: getFilePriority(file.path, metadata.info.name ?? "",
-                    excludedFileNamePatterns),
+                priority: file.priority ?? window.qBittorrent.FileTree.FilePriority.Normal,
             }));
             window.qBittorrent.TorrentContent.updateData(files);
         }


### PR DESCRIPTION
Closes #24235.

The WebUI add torrent dialog initialized every fetched metadata file with normal priority and then submitted the explicit priority list. That bypassed the backend filename filter, which only applies when priorities are not explicitly set.

This mirrors the native add dialog behavior by applying the configured excluded file name wildcard patterns while metadata is populated, marking matching files as ignored before the priorities are submitted.

Validation:
- npm test
- npm run lint
- node --check src/webui/www/private/scripts/addtorrent.js
- git diff --check origin/master..HEAD

Maintainer edits are welcome.

If this PR is squashed or reworked, please preserve author attribution or include: Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>