### PR TITLE
Prefer closing search tabs with Cmd+W on macOS

### DIFF
--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -42,6 +42,7 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QJsonValue>
+#include <QKeyEvent>
 #include <QList>
 #include <QMenu>
 #include <QMessageBox>
@@ -451,6 +452,27 @@ SearchWidget::SearchWidget(IGUIApplication *app, QWidget *parent)
 
     loadHistory();
     restoreSession();
+}
+
+bool SearchWidget::event(QEvent *event)
+{
+#ifdef Q_OS_MACOS
+    if (((event->type() == QEvent::ShortcutOverride) || (event->type() == QEvent::KeyPress))
+            && (m_ui->tabWidget->currentIndex() >= 0))
+    {
+        const auto *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->matches(QKeySequence::Close))
+        {
+            event->accept();
+            if (event->type() == QEvent::KeyPress)
+                closeTab(m_ui->tabWidget->currentIndex());
+
+            return true;
+        }
+    }
+#endif
+
+    return GUIApplicationComponent<QWidget>::event(event);
 }
 
 bool SearchWidget::eventFilter(QObject *object, QEvent *event)

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -63,6 +63,7 @@ signals:
     void searchFinished(bool failed);
 
 private:
+    bool event(QEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event) override;
 
     void onPreferencesChanged();


### PR DESCRIPTION
Closes #24214.

On macOS, Cmd+W is assigned to the main window Close Window action. When the Search tab is active, that action can close/hide the qBittorrent window before the search widget's close-tab shortcut handles the same standard key sequence.

This keeps the close-tab handling inside `SearchWidget`: on macOS the search widget accepts the Close shortcut override while it has a current search tab, then closes that tab on the key press before the shortcut reaches the main window close action.

## Validation
- Built the local macOS app with `cmake --build /private/tmp/qbt-24362-build --target qbittorrent -j4`.
- Ran `git diff --check`.
- Manually verified on macOS with an isolated profile: enabled the Search tab with a saved SearchUI session containing one current search tab (`Codex Cmd W Review`), selected the Search tab, then pressed Cmd+W. The SearchUI session changed from one current tab to `{"CurrentTab":"","Tabs":[]}`, while the qBittorrent process and main window stayed open.

If this PR is squashed or reworked, please preserve author attribution or include: Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
