### PR TITLE
GHA CI: Sync `NSIS` third party action with upstream

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -219,9 +219,9 @@ jobs:
           path: upload
 
       - name: Install NSIS
-        uses: repolevedavaj/install-nsis@a55ed92772254d1e51d880f85ce9b5719f907801 # v1.1.0
+        uses: repolevedavaj/install-nsis@c14d0ea1b829818b4e9313d8e009b43f0a65fddd # v1.2.0
         with:
-          nsis-version: '3.11'
+          nsis-version: '3.12'
 
       - name: Create installer
         run: |


### PR DESCRIPTION
Partial backport of PR #24178 to address failure as seen in https://github.com/qbittorrent/qBittorrent/pull/24178#issuecomment-4406111189 on CI - Windows

* Bump NSIS: `3.11` -> `3.12` (Windows)
https://nsis.sourceforge.io/Main_Page
* Bump `repolevedavaj/install-nsis` action `1.1.0` -> `1.2.0`
https://github.com/repolevedavaj/install-nsis/releases/tag/v1.2.0