### PR TITLE
Fallback to FileManager1 for folder selection

### DIFF
--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -38,6 +38,11 @@
 #endif
 
 #include <QApplication>
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#endif
 #include <QDesktopServices>
 #include <QPixmap>
 #include <QPixmapCache>
@@ -47,6 +52,7 @@
 #include <QScreen>
 #include <QSize>
 #include <QStyle>
+#include <QStringList>
 #include <QThread>
 #include <QUrl>
 #include <QWidget>
@@ -57,6 +63,45 @@
 #include "base/tag.h"
 #include "base/utils/fs.h"
 #include "base/utils/version.h"
+
+namespace
+{
+    QUrl pathToFileUrl(const Path &path)
+    {
+        // Hack to access samba shares with QDesktopServices::openUrl
+        return path.data().startsWith(u"//")
+            ? QUrl(u"file:" + path.data())
+            : QUrl::fromLocalFile(path.data());
+    }
+
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    bool showItemsInFileManager(const Path &path)
+    {
+        QDBusInterface fileManager {u"org.freedesktop.FileManager1"_s
+                , u"/org/freedesktop/FileManager1"_s
+                , u"org.freedesktop.FileManager1"_s
+                , QDBusConnection::sessionBus()};
+        if (!fileManager.isValid())
+            return false;
+
+        const QStringList urls {pathToFileUrl(path).toString()};
+        const QDBusMessage reply = fileManager.call(u"ShowItems"_s, urls, QString {});
+        return (reply.type() == QDBusMessage::ReplyMessage);
+    }
+
+    void openFolderSelectFallback(const Path &path)
+    {
+        if (!showItemsInFileManager(path))
+            Utils::Gui::openPath(path.parentPath());
+    }
+
+    void startDetachedOrFallback(const QString &program, const QStringList &arguments, const Path &path)
+    {
+        if (!QProcess::startDetached(program, arguments))
+            openFolderSelectFallback(path);
+    }
+#endif
+}
 
 QPixmap Utils::Gui::scaledPixmap(const Path &path, const int height)
 {
@@ -117,10 +162,7 @@ QPoint Utils::Gui::screenCenter(const QWidget *w)
 // Open the given path with an appropriate application
 void Utils::Gui::openPath(const Path &path)
 {
-    // Hack to access samba shares with QDesktopServices::openUrl
-    const QUrl url = path.data().startsWith(u"//")
-        ? QUrl(u"file:" + path.data())
-        : QUrl::fromLocalFile(path.data());
+    const QUrl url = pathToFileUrl(path);
 
 #ifdef Q_OS_WIN
     auto *thread = QThread::create([path]()
@@ -186,7 +228,7 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
         const auto output = QString::fromLocal8Bit(lookupProc->readLine(lineMaxLength).simplified());
         if ((output == u"dolphin.desktop") || (output == u"org.kde.dolphin.desktop"))
         {
-            QProcess::startDetached(u"dolphin"_s, {u"--select"_s, path.toString()});
+            startDetachedOrFallback(u"dolphin"_s, {u"--select"_s, path.toString()}, path);
         }
         else if ((output == u"nautilus.desktop") || (output == u"org.gnome.Nautilus.desktop")
             || (output == u"nautilus-folder-handler.desktop"))
@@ -205,23 +247,23 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
                 const QString pathParam = (Fs::isDir(path) ? path.parentPath() : path).toString();
 
                 if (NautilusVersion::fromString(nautilusVerStr, {1, 0, 0}) > NautilusVersion(3, 28, 0))
-                    QProcess::startDetached(u"nautilus"_s, {pathParam});
+                    startDetachedOrFallback(u"nautilus"_s, {pathParam}, path);
                 else
-                    QProcess::startDetached(u"nautilus"_s, {u"--no-desktop"_s, pathParam});
+                    startDetachedOrFallback(u"nautilus"_s, {u"--no-desktop"_s, pathParam}, path);
             });
             deProcess->start(u"nautilus"_s, {u"--version"_s});
         }
         else if (output == u"nemo.desktop")
         {
-            QProcess::startDetached(u"nemo"_s, {u"--no-desktop"_s, (Fs::isDir(path) ? path.parentPath() : path).toString()});
+            startDetachedOrFallback(u"nemo"_s, {u"--no-desktop"_s, (Fs::isDir(path) ? path.parentPath() : path).toString()}, path);
         }
         else if ((output == u"konqueror.desktop") || (output == u"kfmclient_dir.desktop"))
         {
-            QProcess::startDetached(u"konqueror"_s, {u"--select"_s, path.toString()});
+            startDetachedOrFallback(u"konqueror"_s, {u"--select"_s, path.toString()}, path);
         }
         else if (output == u"thunar.desktop")
         {
-            QProcess::startDetached(u"thunar"_s, {path.toString()});
+            startDetachedOrFallback(u"thunar"_s, {path.toString()}, path);
         }
         else
         {

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -51,6 +51,7 @@
 #include <QRegularExpression>
 #include <QScreen>
 #include <QSize>
+#include <QStandardPaths>
 #include <QStyle>
 #include <QStringList>
 #include <QThread>
@@ -208,28 +209,39 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
 
     const int lineMaxLength = 64;
 
+    const auto startFileManager = [path](const QString &command, const QStringList args)
+    {
+        if (!QProcess::startDetached(command, args))
+            openPath(path.parentPath());
+    };
+
     auto lookupProc = new QProcess(parent);
     lookupProc->setProcessChannelMode(QProcess::ForwardedErrorChannel);
     lookupProc->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
     QObject::connect(lookupProc, &QProcess::finished, lookupProc
-        , [parent, path, lookupProc]([[maybe_unused]] const int exitCode, [[maybe_unused]] const QProcess::ExitStatus exitStatus)
+        , [parent, path, startFileManager, lookupProc]([[maybe_unused]] const int exitCode, [[maybe_unused]] const QProcess::ExitStatus exitStatus)
     {
         lookupProc->deleteLater();
 
         const auto output = QString::fromLocal8Bit(lookupProc->readLine(lineMaxLength).simplified());
-        bool isFileManagerStarted = false;
         if ((output == u"dolphin.desktop") || (output == u"org.kde.dolphin.desktop"))
         {
-            isFileManagerStarted = QProcess::startDetached(u"dolphin"_s, {u"--select"_s, path.toString()});
+            startFileManager(u"dolphin"_s, {u"--select"_s, path.toString()});
         }
         else if ((output == u"nautilus.desktop") || (output == u"org.gnome.Nautilus.desktop")
             || (output == u"nautilus-folder-handler.desktop"))
         {
+            if (QStandardPaths::findExecutable(u"nautilus"_s).isEmpty())
+            {
+                openPath(path.parentPath());
+                return;
+            }
+
             auto deProcess = new QProcess(parent);
             deProcess->setProcessChannelMode(QProcess::ForwardedErrorChannel);
             deProcess->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
             QObject::connect(deProcess, &QProcess::finished, deProcess
-                , [deProcess, path]([[maybe_unused]] const int exitCode, [[maybe_unused]] const QProcess::ExitStatus exitStatus)
+                , [deProcess, path, startFileManager]([[maybe_unused]] const int exitCode, [[maybe_unused]] const QProcess::ExitStatus exitStatus)
             {
                 deProcess->deleteLater();
 
@@ -238,45 +250,30 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
                 using NautilusVersion = Utils::Version<3>;
                 const QString pathParam = (Fs::isDir(path) ? path.parentPath() : path).toString();
 
-                bool isFileManagerStarted = false;
                 if (NautilusVersion::fromString(nautilusVerStr, {1, 0, 0}) > NautilusVersion(3, 28, 0))
-                    isFileManagerStarted = QProcess::startDetached(u"nautilus"_s, {pathParam});
+                    startFileManager(u"nautilus"_s, {pathParam});
                 else
-                    isFileManagerStarted = QProcess::startDetached(u"nautilus"_s, {u"--no-desktop"_s, pathParam});
-
-                if (!isFileManagerStarted)
-                {
-                    if (!showItemsInFileManager(path))
-                        openPath(path.parentPath());
-                }
+                    startFileManager(u"nautilus"_s, {u"--no-desktop"_s, pathParam});
             });
             deProcess->start(u"nautilus"_s, {u"--version"_s});
-            return;
         }
         else if (output == u"nemo.desktop")
         {
-            isFileManagerStarted = QProcess::startDetached(u"nemo"_s
+            startFileManager(u"nemo"_s
                     , {u"--no-desktop"_s, (Fs::isDir(path) ? path.parentPath() : path).toString()});
         }
         else if ((output == u"konqueror.desktop") || (output == u"kfmclient_dir.desktop"))
         {
-            isFileManagerStarted = QProcess::startDetached(u"konqueror"_s, {u"--select"_s, path.toString()});
+            startFileManager(u"konqueror"_s, {u"--select"_s, path.toString()});
         }
         else if (output == u"thunar.desktop")
         {
-            isFileManagerStarted = QProcess::startDetached(u"thunar"_s, {path.toString()});
+            startFileManager(u"thunar"_s, {path.toString()});
         }
         else
         {
             // "caja" manager can't pinpoint the file, see: https://github.com/qbittorrent/qBittorrent/issues/5003
             openPath(path.parentPath());
-            return;
-        }
-
-        if (!isFileManagerStarted)
-        {
-            if (!showItemsInFileManager(path))
-                openPath(path.parentPath());
         }
     });
     lookupProc->start(u"xdg-mime"_s, {u"query"_s, u"default"_s, u"inode/directory"_s});

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -51,7 +51,6 @@
 #include <QRegularExpression>
 #include <QScreen>
 #include <QSize>
-#include <QStandardPaths>
 #include <QStringList>
 #include <QStyle>
 #include <QThread>
@@ -231,12 +230,6 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
         else if ((output == u"nautilus.desktop") || (output == u"org.gnome.Nautilus.desktop")
             || (output == u"nautilus-folder-handler.desktop"))
         {
-            if (QStandardPaths::findExecutable(u"nautilus"_s).isEmpty())
-            {
-                openPath(path.parentPath());
-                return;
-            }
-
             auto deProcess = new QProcess(parent);
             deProcess->setProcessChannelMode(QProcess::ForwardedErrorChannel);
             deProcess->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -52,8 +52,8 @@
 #include <QScreen>
 #include <QSize>
 #include <QStandardPaths>
-#include <QStyle>
 #include <QStringList>
+#include <QStyle>
 #include <QThread>
 #include <QUrl>
 #include <QWidget>
@@ -76,7 +76,7 @@ namespace
     }
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    bool showItemsInFileManager(const Path &path)
+    bool showItemInFileManager(const Path &path)
     {
         QDBusInterface fileManager {u"org.freedesktop.FileManager1"_s
                 , u"/org/freedesktop/FileManager1"_s
@@ -204,7 +204,7 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
     QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    if (showItemsInFileManager(path))
+    if (showItemInFileManager(path))
         return;
 
     const int lineMaxLength = 64;

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -85,20 +85,8 @@ namespace
             return false;
 
         const QStringList urls {pathToFileUrl(path).toString()};
-        const QDBusMessage reply = fileManager.call(u"ShowItems"_s, urls, QString {});
+        const QDBusMessage reply = fileManager.call(u"ShowItems"_s, urls, QString());
         return (reply.type() == QDBusMessage::ReplyMessage);
-    }
-
-    void openFolderSelectFallback(const Path &path)
-    {
-        if (!showItemsInFileManager(path))
-            Utils::Gui::openPath(path.parentPath());
-    }
-
-    void startDetachedOrFallback(const QString &program, const QStringList &arguments, const Path &path)
-    {
-        if (!QProcess::startDetached(program, arguments))
-            openFolderSelectFallback(path);
     }
 #endif
 }
@@ -226,9 +214,10 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
         lookupProc->deleteLater();
 
         const auto output = QString::fromLocal8Bit(lookupProc->readLine(lineMaxLength).simplified());
+        bool isFileManagerStarted = false;
         if ((output == u"dolphin.desktop") || (output == u"org.kde.dolphin.desktop"))
         {
-            startDetachedOrFallback(u"dolphin"_s, {u"--select"_s, path.toString()}, path);
+            isFileManagerStarted = QProcess::startDetached(u"dolphin"_s, {u"--select"_s, path.toString()});
         }
         else if ((output == u"nautilus.desktop") || (output == u"org.gnome.Nautilus.desktop")
             || (output == u"nautilus-folder-handler.desktop"))
@@ -246,29 +235,45 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
                 using NautilusVersion = Utils::Version<3>;
                 const QString pathParam = (Fs::isDir(path) ? path.parentPath() : path).toString();
 
+                bool isFileManagerStarted = false;
                 if (NautilusVersion::fromString(nautilusVerStr, {1, 0, 0}) > NautilusVersion(3, 28, 0))
-                    startDetachedOrFallback(u"nautilus"_s, {pathParam}, path);
+                    isFileManagerStarted = QProcess::startDetached(u"nautilus"_s, {pathParam});
                 else
-                    startDetachedOrFallback(u"nautilus"_s, {u"--no-desktop"_s, pathParam}, path);
+                    isFileManagerStarted = QProcess::startDetached(u"nautilus"_s, {u"--no-desktop"_s, pathParam});
+
+                if (!isFileManagerStarted)
+                {
+                    if (!showItemsInFileManager(path))
+                        openPath(path.parentPath());
+                }
             });
             deProcess->start(u"nautilus"_s, {u"--version"_s});
+            return;
         }
         else if (output == u"nemo.desktop")
         {
-            startDetachedOrFallback(u"nemo"_s, {u"--no-desktop"_s, (Fs::isDir(path) ? path.parentPath() : path).toString()}, path);
+            isFileManagerStarted = QProcess::startDetached(u"nemo"_s
+                    , {u"--no-desktop"_s, (Fs::isDir(path) ? path.parentPath() : path).toString()});
         }
         else if ((output == u"konqueror.desktop") || (output == u"kfmclient_dir.desktop"))
         {
-            startDetachedOrFallback(u"konqueror"_s, {u"--select"_s, path.toString()}, path);
+            isFileManagerStarted = QProcess::startDetached(u"konqueror"_s, {u"--select"_s, path.toString()});
         }
         else if (output == u"thunar.desktop")
         {
-            startDetachedOrFallback(u"thunar"_s, {path.toString()}, path);
+            isFileManagerStarted = QProcess::startDetached(u"thunar"_s, {path.toString()});
         }
         else
         {
             // "caja" manager can't pinpoint the file, see: https://github.com/qbittorrent/qBittorrent/issues/5003
             openPath(path.parentPath());
+            return;
+        }
+
+        if (!isFileManagerStarted)
+        {
+            if (!showItemsInFileManager(path))
+                openPath(path.parentPath());
         }
     });
     lookupProc->start(u"xdg-mime"_s, {u"query"_s, u"default"_s, u"inode/directory"_s});

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -51,6 +51,7 @@
 #include <QRegularExpression>
 #include <QScreen>
 #include <QSize>
+#include <QStandardPaths>
 #include <QStyle>
 #include <QStringList>
 #include <QThread>
@@ -222,6 +223,13 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
         else if ((output == u"nautilus.desktop") || (output == u"org.gnome.Nautilus.desktop")
             || (output == u"nautilus-folder-handler.desktop"))
         {
+            if (QStandardPaths::findExecutable(u"nautilus"_s).isEmpty())
+            {
+                if (!showItemsInFileManager(path))
+                    openPath(path.parentPath());
+                return;
+            }
+
             auto deProcess = new QProcess(parent);
             deProcess->setProcessChannelMode(QProcess::ForwardedErrorChannel);
             deProcess->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -51,7 +51,6 @@
 #include <QRegularExpression>
 #include <QScreen>
 #include <QSize>
-#include <QStandardPaths>
 #include <QStyle>
 #include <QStringList>
 #include <QThread>
@@ -204,6 +203,9 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
     QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    if (showItemsInFileManager(path))
+        return;
+
     const int lineMaxLength = 64;
 
     auto lookupProc = new QProcess(parent);
@@ -223,13 +225,6 @@ void Utils::Gui::openFolderSelect(const Path &path, [[maybe_unused]] QObject *pa
         else if ((output == u"nautilus.desktop") || (output == u"org.gnome.Nautilus.desktop")
             || (output == u"nautilus-folder-handler.desktop"))
         {
-            if (QStandardPaths::findExecutable(u"nautilus"_s).isEmpty())
-            {
-                if (!showItemsInFileManager(path))
-                    openPath(path.parentPath());
-                return;
-            }
-
             auto deProcess = new QProcess(parent);
             deProcess->setProcessChannelMode(QProcess::ForwardedErrorChannel);
             deProcess->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);


### PR DESCRIPTION
Closes #24229.

The Linux folder-selection helper shells out to desktop-specific file manager commands such as `dolphin --select`. In Flatpak environments the default file manager can still be available through portals/DBus while the desktop binary itself is not available inside the sandbox, so the command fails and folder-opening actions do nothing.

This keeps the existing desktop-specific command path when it can be started, and falls back to `org.freedesktop.FileManager1.ShowItems` when the command is missing. If FileManager1 is unavailable too, it falls back to opening the parent folder as before.

Validation:
- git diff --check origin/master..HEAD

I did not run a full C++ build because this checkout has no configured build directory.

Maintainer edits are welcome.

If this PR is squashed or reworked, please preserve author attribution or include: Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
