### PR TITLE
UI: macos, exit fullscreen mode and hide window on close

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1181,7 +1181,16 @@ void MainWindow::closeEvent(QCloseEvent *e)
 #ifdef Q_OS_MACOS
     if (!m_forceExit)
     {
-        hide();
+        if (isFullScreen())
+        {
+            showNormal();
+            close();
+        }
+        else
+        {
+            hide();
+        }
+
         e->ignore();
         return;
     }


### PR DESCRIPTION
<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->

Closes #24245

On MacOS, when qBittorrent is in full screen mode and user clicks the close button (red button on the upper left corner of the app window), the qBittorrent window hides but still in full screen mode and user sees an empty blank screen.

This PR, makes qBittorrent exit full screen mode and `close()` the window to prevent seeing the empty blank screen.

Somehow doing 

```
showNormal();
hide();
```

leaves an empty qBittorrent window so im using the `close()` function.