### PR TITLE
Close fullscreen window correctly on macOS

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1181,8 +1181,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
 #ifdef Q_OS_MACOS
     if (!m_forceExit)
     {
-        hide();
-        e->ignore();
+        e->accept();
         return;
     }
 #else


### PR DESCRIPTION
This PR fixes #24245. As I have previously explained it in the issue: 

> The issue is that when you open qbit on fullscreen - macOS creates a new space and when you click on close button it hides the qbit window but doesn't destroy the space, and in result we get a black screen dedicated to hidden qbit. Which is obviously an incorrect behavior, when you close fullscreened application on macOS it must destroy the space and hide the app.

Tested on macOS 26.4.1

I have explicitly tested all the behaviours, such as: 
- Fullscreen window closed by clicking 'x' button;
- Fullscreen window closed by clicking 'Close Window' inside 'File' menu;
- Fullscreen window closed by CMD+W;
- As well as the same behaviour in normal mode.