### PR TITLE
Add "Force start torrents" to filter context menus

### DIFF
--- a/src/gui/transferlistfilters/categoryfilterwidget.cpp
+++ b/src/gui/transferlistfilters/categoryfilterwidget.cpp
@@ -134,6 +134,8 @@ void CategoryFilterWidget::showMenu()
     menu->addSeparator();
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s), tr("Start torrents")
         , this, &CategoryFilterWidget::actionStartTorrentsTriggered);
+    menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start-forced"_s, u"media-playback-start"_s), tr("Force start torrents")
+        , this, &CategoryFilterWidget::actionForceStartTorrentsTriggered);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_s, u"media-playback-pause"_s), tr("Stop torrents")
         , this, &CategoryFilterWidget::actionStopTorrentsTriggered);
     menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_s), tr("Remove torrents")

--- a/src/gui/transferlistfilters/categoryfilterwidget.h
+++ b/src/gui/transferlistfilters/categoryfilterwidget.h
@@ -43,6 +43,7 @@ public:
 signals:
     void categoryChanged(const QString &categoryName);
     void actionStartTorrentsTriggered();
+    void actionForceStartTorrentsTriggered();
     void actionStopTorrentsTriggered();
     void actionDeleteTorrentsTriggered();
 

--- a/src/gui/transferlistfilters/statusfilterwidget.cpp
+++ b/src/gui/transferlistfilters/statusfilterwidget.cpp
@@ -218,6 +218,8 @@ void StatusFilterWidget::showMenu()
 
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s), tr("Start torrents")
         , transferList(), &TransferListWidget::startVisibleTorrents);
+    menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start-forced"_s, u"media-playback-start"_s), tr("Force start torrents")
+        , transferList(), &TransferListWidget::forceStartVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_s, u"media-playback-pause"_s), tr("Stop torrents")
         , transferList(), &TransferListWidget::stopVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_s), tr("Remove torrents")

--- a/src/gui/transferlistfilters/tagfilterwidget.cpp
+++ b/src/gui/transferlistfilters/tagfilterwidget.cpp
@@ -119,6 +119,8 @@ void TagFilterWidget::showMenu()
     menu->addSeparator();
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s), tr("Start torrents")
         , this, &TagFilterWidget::actionStartTorrentsTriggered);
+    menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start-forced"_s, u"media-playback-start"_s), tr("Force start torrents")
+        , this, &TagFilterWidget::actionForceStartTorrentsTriggered);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_s, u"media-playback-pause"_s), tr("Stop torrents")
         , this, &TagFilterWidget::actionStopTorrentsTriggered);
     menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_s), tr("Remove torrents")

--- a/src/gui/transferlistfilters/tagfilterwidget.h
+++ b/src/gui/transferlistfilters/tagfilterwidget.h
@@ -46,6 +46,7 @@ public:
 signals:
     void tagChanged(const std::optional<Tag> &tag);
     void actionStartTorrentsTriggered();
+    void actionForceStartTorrentsTriggered();
     void actionStopTorrentsTriggered();
     void actionDeleteTorrentsTriggered();
 

--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -550,6 +550,8 @@ void TrackersFilterWidget::showMenu()
 
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s), tr("Start torrents")
         , transferList(), &TransferListWidget::startVisibleTorrents);
+    menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start-forced"_s, u"media-playback-start"_s), tr("Force start torrents")
+        , transferList(), &TransferListWidget::forceStartVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_s, u"media-playback-pause"_s), tr("Stop torrents")
         , transferList(), &TransferListWidget::stopVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_s), tr("Remove torrents")

--- a/src/gui/transferlistfilters/trackerstatusfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackerstatusfilterwidget.cpp
@@ -145,6 +145,8 @@ void TrackerStatusFilterWidget::showMenu()
 
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s), tr("Start torrents")
         , transferList(), &TransferListWidget::startVisibleTorrents);
+    menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-start-forced"_s, u"media-playback-start"_s), tr("Force start torrents")
+        , transferList(), &TransferListWidget::forceStartVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_s, u"media-playback-pause"_s), tr("Stop torrents")
         , transferList(), &TransferListWidget::stopVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_s), tr("Remove torrents")

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -79,6 +79,8 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
                 , transferList, &TransferListWidget::stopVisibleTorrents);
         connect(categoryFilterWidget, &CategoryFilterWidget::actionStartTorrentsTriggered
                 , transferList, &TransferListWidget::startVisibleTorrents);
+        connect(categoryFilterWidget, &CategoryFilterWidget::actionForceStartTorrentsTriggered
+                , transferList, &TransferListWidget::forceStartVisibleTorrents);
         connect(categoryFilterWidget, &CategoryFilterWidget::categoryChanged
                 , transferList, &TransferListWidget::applyCategoryFilter);
 
@@ -100,6 +102,8 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
                 , transferList, &TransferListWidget::stopVisibleTorrents);
         connect(tagFilterWidget, &TagFilterWidget::actionStartTorrentsTriggered
                 , transferList, &TransferListWidget::startVisibleTorrents);
+        connect(tagFilterWidget, &TagFilterWidget::actionForceStartTorrentsTriggered
+                , transferList, &TransferListWidget::forceStartVisibleTorrents);
         connect(tagFilterWidget, &TagFilterWidget::tagChanged
                 , transferList, &TransferListWidget::applyTagFilter);
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -398,6 +398,12 @@ void TransferListWidget::startVisibleTorrents()
         torrent->start();
 }
 
+void TransferListWidget::forceStartVisibleTorrents()
+{
+    for (BitTorrent::Torrent *const torrent : asConst(getVisibleTorrents()))
+        torrent->start(BitTorrent::TorrentOperatingMode::Forced);
+}
+
 void TransferListWidget::stopSelectedTorrents()
 {
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -73,6 +73,7 @@ public slots:
     void startSelectedTorrents();
     void forceStartSelectedTorrents();
     void startVisibleTorrents();
+    void forceStartVisibleTorrents();
     void stopSelectedTorrents();
     void stopVisibleTorrents();
     void softDeleteSelectedTorrents();

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -234,6 +234,7 @@
     </ul>
     <ul id="statusesFilterMenu" class="contextMenu">
         <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Start torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
+        <li><a href="#forceStartTorrents"><img src="images/torrent-start-forced.svg" alt="QBT_TR(Force start torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Force start torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
         <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Stop torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
         <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Remove torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
     </ul>
@@ -244,6 +245,7 @@
         <li><a href="#deleteCategory"><img src="images/list-remove.svg" alt="QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
         <li><a href="#deleteUnusedCategories" class="separatorBottom"><img src="images/list-remove.svg" alt="QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
         <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#forceStartTorrents"><img src="images/torrent-start-forced.svg" alt="QBT_TR(Force start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Force start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
         <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
         <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
     </ul>
@@ -252,12 +254,14 @@
         <li><a href="#deleteTag"><img src="images/list-remove.svg" alt="QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
         <li><a href="#deleteUnusedTags" class="separatorBottom"><img src="images/list-remove.svg" alt="QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
         <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#forceStartTorrents"><img src="images/torrent-start-forced.svg" alt="QBT_TR(Force start torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Force start torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
         <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
         <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
     </ul>
     <ul id="trackersFilterMenu" class="contextMenu">
         <li><a href="#deleteTracker" class="separatorBottom"><img src="images/edit-clear.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
         <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#forceStartTorrents"><img src="images/torrent-start-forced.svg" alt="QBT_TR(Force start torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Force start torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
         <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
         <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
     </ul>

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -316,6 +316,7 @@ window.qBittorrent.ContextMenu ??= (() => {
         updateTorrentActions() {
             const torrentsVisible = torrentsTable.tableBody.children.length > 0;
             this.setEnabled("startTorrents", torrentsVisible)
+                .setEnabled("forceStartTorrents", torrentsVisible)
                 .setEnabled("stopTorrents", torrentsVisible)
                 .setEnabled("deleteTorrents", torrentsVisible);
         }

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -131,6 +131,7 @@ let setLocationFN = () => {};
 let renameFN = () => {};
 let renameFilesFN = () => {};
 let startVisibleTorrentsFN = () => {};
+let forceStartVisibleTorrentsFN = () => {};
 let stopVisibleTorrentsFN = () => {};
 let deleteVisibleTorrentsFN = () => {};
 let torrentNewCategoryFN = () => {};
@@ -764,6 +765,28 @@ const initializeWindows = () => {
                     method: "POST",
                     body: new URLSearchParams({
                         hashes: hashes.join("|")
+                    })
+                })
+                .then((response) => {
+                    if (!response.ok) {
+                        alert("QBT_TR(Unable to start torrents.)QBT_TR[CONTEXT=HttpServer]");
+                        return;
+                    }
+
+                    updateMainData();
+                    updatePropertiesPanel();
+                });
+        }
+    };
+
+    forceStartVisibleTorrentsFN = () => {
+        const hashes = torrentsTable.getFilteredTorrentsHashes(selectedStatus, selectedCategory, selectedTag, selectedTracker);
+        if (hashes.length > 0) {
+            fetch("api/v2/torrents/setForceStart", {
+                    method: "POST",
+                    body: new URLSearchParams({
+                        hashes: hashes.join("|"),
+                        value: "true"
                     })
                 })
                 .then((response) => {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -791,7 +791,7 @@ const initializeWindows = () => {
                 })
                 .then((response) => {
                     if (!response.ok) {
-                        alert("QBT_TR(Unable to start torrents.)QBT_TR[CONTEXT=HttpServer]");
+                        alert("QBT_TR(Unable to force start torrents.)QBT_TR[CONTEXT=HttpServer]");
                         return;
                     }
 

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -96,6 +96,9 @@
                 startTorrents: (element, ref) => {
                     startVisibleTorrentsFN();
                 },
+                forceStartTorrents: (element, ref) => {
+                    forceStartVisibleTorrentsFN();
+                },
                 stopTorrents: (element, ref) => {
                     stopVisibleTorrentsFN();
                 },
@@ -138,6 +141,9 @@
                 startTorrents: (element, ref) => {
                     startVisibleTorrentsFN();
                 },
+                forceStartTorrents: (element, ref) => {
+                    forceStartVisibleTorrentsFN();
+                },
                 stopTorrents: (element, ref) => {
                     stopVisibleTorrentsFN();
                 },
@@ -174,6 +180,9 @@
                 startTorrents: (element, ref) => {
                     startVisibleTorrentsFN();
                 },
+                forceStartTorrents: (element, ref) => {
+                    forceStartVisibleTorrentsFN();
+                },
                 stopTorrents: (element, ref) => {
                     stopVisibleTorrentsFN();
                 },
@@ -203,6 +212,9 @@
                 },
                 startTorrents: (element, ref) => {
                     startVisibleTorrentsFN();
+                },
+                forceStartTorrents: (element, ref) => {
+                    forceStartVisibleTorrentsFN();
                 },
                 stopTorrents: (element, ref) => {
                     stopVisibleTorrentsFN();


### PR DESCRIPTION
This adds a "Force start torrents" option to the filter context menus on the left in addition to the normal Start and Stop options.

Being able to start torrents from these context menus is nice (ex. start all torrents in a certain category or tag) but can fall short if you want to start regardless of ratios (i.e., force) after initial share ratios have already been hit. This is especially problematic with WebUI on mobile where I believe the only option to force-start is from the torrent list's context menu (and since you can't select multiple on mobile, you must force-start torrents one at a time).

Screenshots:
<details>

<summary>Desktop...</summary>

<img width="285" height="254" alt="core-status" src="https://github.com/user-attachments/assets/791ded0a-d9c7-4e6b-852c-a324c537789e" /><br>
<img width="316" height="191" alt="core-categories" src="https://github.com/user-attachments/assets/b66963c6-ebe8-4850-a2c7-8d36a02a4152" /><br>
<img width="294" height="194" alt="core-tags" src="https://github.com/user-attachments/assets/56e16e61-b1cf-44bd-bb8c-0727ac8fcb5f" /><br>
<img width="276" height="194" alt="core-trackers" src="https://github.com/user-attachments/assets/b4fd7a0c-5015-4bad-8b61-3d225fa2bc19" /><br>

</details>

<details>

<summary>WebUI...</summary>

<img width="289" height="242" alt="webui-status" src="https://github.com/user-attachments/assets/20977deb-1a02-4186-bfd8-52613a42114c" /><br>
<img width="332" height="274" alt="webui-categories" src="https://github.com/user-attachments/assets/26933948-57e4-4218-b345-d16e6c750d02" /><br>
<img width="284" height="262" alt="webui-tags" src="https://github.com/user-attachments/assets/63eb5e0c-3a44-4e9b-9346-f1252cabe67b" /><br>
<img width="264" height="274" alt="webui-trackers" src="https://github.com/user-attachments/assets/0fb7f752-e333-4fdf-afa2-44cfd1b2d27c" /><br>

</details>

Note that the desktop app and WebUI seem to handle enabling/disabling context menu items differently, which is reflected in my screenshots. Everything is always enabled in the desktop screenshots, including the existing Start/Stop options that I didn't add, whereas WebUI only enables options when there are "visible" torrents (after filtering) to perform the actions on (ex. last two screenshots are filtered by Untagged but there aren't any untagged torrents so no options are enabled).