### PR TITLE
WebAPI: Don't store API result between calls

### DIFF
--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -29,6 +29,7 @@
 #include "apicontroller.h"
 
 #include <algorithm>
+#include <utility>
 
 #include <QHash>
 #include <QJsonDocument>
@@ -61,7 +62,7 @@ APIResult APIController::run(const QString &action, const StringMap &params, con
     if (!QMetaObject::invokeMethod(this, methodName.constData()))
         throw APIError(APIErrorType::NotFound, tr("Endpoint does not exist"));
 
-    return m_result;
+    return std::exchange(m_result, {});
 }
 
 const StringMap &APIController::params() const

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -34,6 +34,7 @@
 #include <QJsonDocument>
 #include <QList>
 #include <QMetaObject>
+#include <QScopeGuard>
 
 #include "base/global.h"
 #include "apierror.h"
@@ -47,6 +48,11 @@ APIResult APIController::run(const QString &action, const StringMap &params, con
 {
     m_params = params;
     m_data = data;
+    [[maybe_unused]] const auto inputsGuard = qScopeGuard([this]
+    {
+        m_params = {};
+        m_data = {};
+    });
 
     const QByteArray methodName = action.toLatin1() + "Action";
     if (!QMetaObject::invokeMethod(this, methodName.constData()))

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -28,7 +28,6 @@
 
 #include "apicontroller.h"
 
-#include <algorithm>
 #include <utility>
 
 #include <QHash>
@@ -39,14 +38,6 @@
 #include "base/global.h"
 #include "apierror.h"
 
-void APIResult::clear()
-{
-    data.clear();
-    mimeType.clear();
-    filename.clear();
-    status = APIStatus::Ok;
-}
-
 APIController::APIController(IApplication *app, QObject *parent)
     : ApplicationComponent(app, parent)
 {
@@ -54,7 +45,6 @@ APIController::APIController(IApplication *app, QObject *parent)
 
 APIResult APIController::run(const QString &action, const StringMap &params, const DataMap &data)
 {
-    m_result.clear(); // clear result
     m_params = params;
     m_data = data;
 

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -45,8 +45,6 @@ struct APIResult
     QString mimeType;
     QString filename;
     APIStatus status = APIStatus::Ok;
-
-    void clear();
 };
 
 class APIController : public ApplicationComponent<QObject>


### PR DESCRIPTION
This fixes how `m_result` is handled in `APIController::run()`. The result was copied to the caller while the `m_result` member keeps holding it until the next call to `run()` clears it via `m_result.clear()`.

If the controller is not called again, the last `APIResult` payload remains alive for the entire idle period of the session. For JSON endpoints with non-trivial output, such as, `QJsonDocument` of a few MBs this potentially pins the memory.

This become an issue in the case of libraries that make use of the qBittorrent API and create a new session for every request instead of holding a cookie jar. These requests keep piling up many session with stale result data.

This PR fixes this behavior using `std::exchange`. From my understanding, `m_params` and `m_data` could also be cleared, for example, with a `qScopeGuard` but since they have public getters I left them like they are now.