### PR TITLE
Prevent SSRF via HTTP redirection

### DIFF
--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -233,7 +233,7 @@ void Net::DownloadHandlerImpl::handleRedirection(const QUrl &newUrl)
     const QString scheme = resolvedUrl.scheme();
     if ((scheme != u"http") && (scheme != u"https"))
     {
-        setError(tr("Redirect to unsupported or dangerous protocol: %1").arg(scheme));
+        setError(tr("Redirect to unsupported or dangerous protocol: '%1'.").arg(scheme));
         finish();
         return;
     }

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -217,21 +217,23 @@ void Net::DownloadHandlerImpl::handleRedirection(const QUrl &newUrl)
     // Resolve relative urls
     const QUrl resolvedUrl = newUrl.isRelative() ? m_reply->url().resolved(newUrl) : newUrl;
     const QString newUrlString = resolvedUrl.toString();
+    qDebug("Redirecting from %s to %s...", qUtf8Printable(m_reply->url().toString()), qUtf8Printable(newUrlString));
 
-    // BLOCKED SSRF
-    const QString scheme = resolvedUrl.scheme().toLower();
-    if (scheme != u"http" && scheme != u"https")
-    {
-        setError(tr("Redirect to unsupported or dangerous protocol: %1").arg(scheme));
-        finish();
-        return;
-    }
     // Redirect to magnet workaround
     if (newUrlString.startsWith(u"magnet:", Qt::CaseInsensitive))
     {
         m_result.status = Net::DownloadStatus::RedirectedToMagnet;
         m_result.magnetURI = newUrlString;
         m_result.errorString = tr("Redirected to magnet URI");
+        finish();
+        return;
+    }
+
+    // SSRF protection: strict scheme whitelist
+    const QString scheme = resolvedUrl.scheme().toLower();
+    if ((scheme != u"http") && (scheme != u"https"))
+    {
+        setError(tr("Redirect to unsupported or dangerous protocol: %1").arg(scheme));
         finish();
         return;
     }

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -220,7 +220,7 @@ void Net::DownloadHandlerImpl::handleRedirection(const QUrl &newUrl)
 
     // BLOCKED SSRF
     const QString scheme = resolvedUrl.scheme().toLower();
-    if ((scheme != u"http") && (scheme != u"https") && (scheme != u"magnet"))
+    if (scheme != u"http" && scheme != u"https")
     {
         setError(tr("Redirect to unsupported or dangerous protocol: %1").arg(scheme));
         finish();

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -230,7 +230,7 @@ void Net::DownloadHandlerImpl::handleRedirection(const QUrl &newUrl)
     }
 
     // SSRF protection: strict scheme whitelist
-    const QString scheme = resolvedUrl.scheme().toLower();
+    const QString scheme = resolvedUrl.scheme();
     if ((scheme != u"http") && (scheme != u"https"))
     {
         setError(tr("Redirect to unsupported or dangerous protocol: %1").arg(scheme));

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -217,8 +217,15 @@ void Net::DownloadHandlerImpl::handleRedirection(const QUrl &newUrl)
     // Resolve relative urls
     const QUrl resolvedUrl = newUrl.isRelative() ? m_reply->url().resolved(newUrl) : newUrl;
     const QString newUrlString = resolvedUrl.toString();
-    qDebug("Redirecting from %s to %s...", qUtf8Printable(m_reply->url().toString()), qUtf8Printable(newUrlString));
 
+    // BLOCKED SSRF
+    const QString scheme = resolvedUrl.scheme().toLower();
+    if ((scheme != u"http") && (scheme != u"https") && (scheme != u"magnet"))
+    {
+        setError(tr("Redirect to unsupported or dangerous protocol: %1").arg(scheme));
+        finish();
+        return;
+    }
     // Redirect to magnet workaround
     if (newUrlString.startsWith(u"magnet:", Qt::CaseInsensitive))
     {


### PR DESCRIPTION
Fixed a High-level SSRF vulnerability in Net::DownloadHandlerImpl::handleRedirection. The code was manually handling HTTP redirects without validating the scheme of the new URL. An attacker could provide a malicious redirect (e.g., to file:// or ftp://) to access local files or internal network resources. Changes:
Added a check to ensure the redirected URL scheme is either http, https, or magnet. Invalid schemes now trigger an error and terminate the download process.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
