### PR TITLE
Remove last remaining OpenSSL preprocessor check

### DIFF
--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -133,11 +133,7 @@ void DNSUpdater::updateDNSService()
 QString DNSUpdater::getUpdateUrl() const
 {
     QUrl url;
-#ifdef QT_NO_OPENSSL
-    url.setScheme(u"http"_s);
-#else
     url.setScheme(u"https"_s);
-#endif
     url.setUserName(m_username);
     url.setPassword(m_password);
 


### PR DESCRIPTION
Remove the last preprocessor conditional compilation directive based on OpenSSL availability (QT_NO_OPENSSL) in the code base.
Code tidy as the check is redundant since OpenSSL has been required for a while.