### PR TITLE
Bump Python version minimum requirement

### DIFF
--- a/.github/workflows/ci_python.yaml
+++ b/.github/workflows/ci_python.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup python (search engine)
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.13'
 
       - name: Install tools (search engine)
         working-directory: src/searchengine/nova3

--- a/INSTALL
+++ b/INSTALL
@@ -18,7 +18,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
   - CMake >= 3.16
       * Compile-time only
 
-  - Python >= 3.9.0
+  - Python >= 3.13.0
       * Optional, run-time only
       * Used by the bundled search engine
 

--- a/src/base/utils/foreignapps.h
+++ b/src/base/utils/foreignapps.h
@@ -50,7 +50,7 @@ namespace Utils::ForeignApps
         Path executablePath;
         Version version;
 
-        inline static const Version MINIMUM_SUPPORTED_VERSION {3, 9, 0};
+        inline static const Version MINIMUM_SUPPORTED_VERSION {3, 13, 0};
     };
 
     PythonInfo pythonInfo();

--- a/src/searchengine/nova3/justfile
+++ b/src/searchengine/nova3/justfile
@@ -22,8 +22,7 @@ check files=PY_FILES: fetch_aux
 fetch_aux:
     #!/usr/bin/sh
     if [ ! -f 'socks.pyi' ]; then
-        # TODO: use `https://raw.githubusercontent.com/python/typeshed/refs/heads/main/stubs/PySocks/socks.pyi` after bumping python required version >= 3.10
-        curl -L -o socks.pyi "https://raw.githubusercontent.com/python/typeshed/61107f2860a525a1e868610dec030e1b59e3f21e/stubs/PySocks/socks.pyi"
+        curl -L -o socks.pyi "https://raw.githubusercontent.com/python/typeshed/refs/heads/main/stubs/PySocks/socks.pyi"
     fi
 
 # Apply formatting


### PR DESCRIPTION
The new minimum supported version is `3.13.0`.
