### PR TITLE
WebUI: Replace alerts for test email with custom notification

### DIFF
--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2048,17 +2048,33 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             document.getElementById("mail_password_text").disabled = !isMailAuthEnabled;
         };
 
+        const testEmailNotificationDialog = (notificationText, notificationWidth, notificationHeight, notificationDuration) => {
+            new MochaUI.Window({
+                id: "testEmailNotificationDialog",
+                icon: "images/qbittorrent-tray.svg",
+                title: "QBT_TR(Notification)QBT_TR[CONTEXT=OptionsDialog]",
+                loadMethod: "html",
+                closeAfter: notificationDuration,
+                type: "notification",
+                addClass: "notification",
+                content: notificationText,
+                width: notificationWidth,
+                height: notificationHeight,
+                padding: { top: 10, right: 12, bottom: 10, left: 12 },
+            });
+        };
+
         const sendTestEmail = () => {
             fetch("api/v2/app/sendTestEmail", {
                     method: "POST"
                 })
                 .then((response) => {
                     if (!response.ok) {
-                        alert("QBT_TR(Could not contact qBittorrent.)QBT_TR[CONTEXT=HttpServer]");
+                        testEmailNotificationDialog("QBT_TR(Could not contact qBittorrent.)QBT_TR[CONTEXT=OptionsDialog]", 300, 60, 5000);
                         return;
                     }
 
-                    alert("QBT_TR(Attempted to send test email.\nCheck your inbox to confirm success.\nCheck the Execution Log for errors.)QBT_TR[CONTEXT=OptionsDialog]");
+                    testEmailNotificationDialog("QBT_TR(Attempted to send test email.<br>Check your inbox to confirm success.<br>Check the Execution Log for errors.)QBT_TR[CONTEXT=OptionsDialog]", 300, 80, 5000);
                 });
         };
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2048,33 +2048,33 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             document.getElementById("mail_password_text").disabled = !isMailAuthEnabled;
         };
 
-        const testEmailNotificationDialog = (notificationText, notificationWidth, notificationHeight, notificationDuration) => {
-            new MochaUI.Window({
-                id: "testEmailNotificationDialog",
-                icon: "images/qbittorrent-tray.svg",
-                title: "QBT_TR(Notification)QBT_TR[CONTEXT=OptionsDialog]",
-                loadMethod: "html",
-                closeAfter: notificationDuration,
-                type: "notification",
-                addClass: "notification",
-                content: notificationText,
-                width: notificationWidth,
-                height: notificationHeight,
-                padding: { top: 10, right: 12, bottom: 10, left: 12 },
-            });
-        };
-
         const sendTestEmail = () => {
+            const showNotification = (text, width, height, duration) => {
+                new MochaUI.Window({
+                    id: "testEmailNotificationDialog",
+                    icon: "images/qbittorrent-tray.svg",
+                    title: "QBT_TR(Notification)QBT_TR[CONTEXT=OptionsDialog]",
+                    loadMethod: "html",
+                    closeAfter: duration,
+                    type: "notification",
+                    addClass: "notification",
+                    content: text,
+                    width: width,
+                    height: height,
+                    padding: { top: 10, right: 12, bottom: 10, left: 12 },
+                });
+            };
+
             fetch("api/v2/app/sendTestEmail", {
                     method: "POST"
                 })
                 .then((response) => {
                     if (!response.ok) {
-                        testEmailNotificationDialog("QBT_TR(Could not contact qBittorrent.)QBT_TR[CONTEXT=OptionsDialog]", 300, 60, 5000);
+                        showNotification("QBT_TR(Could not contact qBittorrent.)QBT_TR[CONTEXT=OptionsDialog]", 300, 60, 5000);
                         return;
                     }
 
-                    testEmailNotificationDialog("QBT_TR(Attempted to send test email.<br>Check your inbox to confirm success.<br>Check the Execution Log for errors.)QBT_TR[CONTEXT=OptionsDialog]", 300, 80, 5000);
+                    showNotification("QBT_TR(Attempted to send test email.<br>Check your inbox to confirm success.<br>Check the Execution Log for errors.)QBT_TR[CONTEXT=OptionsDialog]", 300, 80, 5000);
                 });
         };
 


### PR DESCRIPTION
Replace alert dialogs with a MochaUI.Window-based notification dialog for test email results.
Set the translation context of the each message to the same.

### WebUI

<img width="1200" height="1001" alt="NewTestEmailAlert" src="https://github.com/user-attachments/assets/9b83a206-bb12-4843-8fd5-8cbf7be6ea1d" />
