### PR TITLE
Provide option for email notification when torrent added

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -4,6 +4,11 @@
 * [#24346](https://github.com/qbittorrent/qBittorrent/pull/24346)
   * `torrentcreator/addTask` endpoint accepts a new bool option `ignoreDotfiles` to control whether dotfiles are ignored
   * `torrentcreator/status` endpoint returns a new bool field `ignoreDotfiles` for reporting whether dotfiles were ignored
+* [#24289](https://github.com/qbittorrent/qBittorrent/pull/24289)
+  * `app/preferences` endpoint includes `mail_notification_on_add` option
+  * `app/preferences` endpoint includes `mail_notification_on_end` option
+  * `app/setPreferences` endpoint allows to set `mail_notification_on_add` option
+  * `app/setPreferences` endpoint allows to set `mail_notification_on_end` option
 * [#24246](https://github.com/qbittorrent/qBittorrent/pull/24246)
   * `torrents/fetchMetadata` and `torrents/parseMetadata` endpoints include file `priority` when excluded file names apply
 * [#24210](https://github.com/qbittorrent/qBittorrent/pull/24210)

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -733,7 +733,22 @@ void Application::runExternalProgram(const QString &programTemplate, const BitTo
 #endif
 }
 
-void Application::sendNotificationEmail(const BitTorrent::Torrent *torrent)
+void Application::sendNotificationEmailAdded(const BitTorrent::Torrent *torrent)
+{
+    // Prepare mail content
+    const QString content = tr("Torrent name: %1").arg(torrent->name()) + u'\n'
+        + tr("Torrent size: %1").arg(Utils::Misc::friendlyUnit(torrent->wantedSize())) + u'\n'
+        + tr("Save path: %1").arg(torrent->savePath().toString()) + u"\n\n"
+        + tr("The torrent has been added.") + u"\n\n\n"
+        + tr("Thank you for using qBittorrent.") + u'\n';
+
+    // Send the notification email
+    const Preferences* pref = Preferences::instance();
+    Net::SMTPClient::sendMail(pref->getMailNotificationSender(), pref->getMailNotificationEmail()
+            , tr("Torrent \"%1\" has been added").arg(torrent->name()), content, this);
+}
+
+void Application::sendNotificationEmailFinished(const BitTorrent::Torrent *torrent)
 {
     // Prepare mail content
     const QString content = tr("Torrent name: %1").arg(torrent->name()) + u'\n'
@@ -764,13 +779,20 @@ void Application::sendTestEmail()
     }
 }
 
-void Application::torrentAdded(const BitTorrent::Torrent *torrent) const
+void Application::torrentAdded(const BitTorrent::Torrent *torrent)
 {
     const Preferences *pref = Preferences::instance();
 
     // AutoRun program
     if (pref->isAutoRunOnTorrentAddedEnabled())
         runExternalProgram(pref->getAutoRunOnTorrentAddedProgram().trimmed(), torrent);
+
+    // Mail notification
+    if (pref->isMailNotificationEnabled() && pref->isMailNotificationOnAdd())
+    {
+        LogMsg(tr("Torrent: %1, sending added mail notification").arg(torrent->name()));
+        sendNotificationEmailAdded(torrent);
+    }
 }
 
 void Application::torrentFinished(const BitTorrent::Torrent *torrent)
@@ -782,10 +804,10 @@ void Application::torrentFinished(const BitTorrent::Torrent *torrent)
         runExternalProgram(pref->getAutoRunOnTorrentFinishedProgram().trimmed(), torrent);
 
     // Mail notification
-    if (pref->isMailNotificationEnabled())
+    if (pref->isMailNotificationEnabled() && pref->isMailNotificationOnEnd())
     {
-        LogMsg(tr("Torrent: %1, sending mail notification").arg(torrent->name()));
-        sendNotificationEmail(torrent);
+        LogMsg(tr("Torrent: %1, sending finished mail notification").arg(torrent->name()));
+        sendNotificationEmailFinished(torrent);
     }
 
 #ifndef DISABLE_GUI

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -149,7 +149,7 @@ public:
 
 private slots:
     void processMessage(const QString &message);
-    void torrentAdded(const BitTorrent::Torrent *torrent) const;
+    void torrentAdded(const BitTorrent::Torrent *torrent);
     void torrentFinished(const BitTorrent::Torrent *torrent);
     void allTorrentsFinished();
     void cleanup();
@@ -167,7 +167,8 @@ private:
     void initializeTranslation();
     void processParams(const QBtCommandLineParameters &params);
     void runExternalProgram(const QString &programTemplate, const BitTorrent::Torrent *torrent) const;
-    void sendNotificationEmail(const BitTorrent::Torrent *torrent);
+    void sendNotificationEmailAdded(const BitTorrent::Torrent *torrent);
+    void sendNotificationEmailFinished(const BitTorrent::Torrent *torrent);
 
 #if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
     void applyMemoryWorkingSetLimit() const;

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -542,6 +542,32 @@ void Preferences::setMailNotificationEnabled(const bool enabled)
     setValue(u"Preferences/MailNotification/enabled"_s, enabled);
 }
 
+bool Preferences::isMailNotificationOnAdd() const
+{
+    return value(u"Preferences/MailNotification/SendOnAdd"_s, false);
+}
+
+void Preferences::setMailNotificationOnAdd(const bool enabled)
+{
+    if (enabled == isMailNotificationOnAdd())
+        return;
+
+    setValue(u"Preferences/MailNotification/SendOnAdd"_s, enabled);
+}
+
+bool Preferences::isMailNotificationOnEnd() const
+{
+    return value(u"Preferences/MailNotification/SendOnEnd"_s, true);
+}
+
+void Preferences::setMailNotificationOnEnd(const bool enabled)
+{
+    if (enabled == isMailNotificationOnEnd())
+        return;
+
+    setValue(u"Preferences/MailNotification/SendOnEnd"_s, enabled);
+}
+
 QString Preferences::getMailNotificationSender() const
 {
     return value<QString>(u"Preferences/MailNotification/sender"_s);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -137,6 +137,10 @@ public:
     void setScanDirsLastPath(const Path &path);
     bool isMailNotificationEnabled() const;
     void setMailNotificationEnabled(bool enabled);
+    bool isMailNotificationOnAdd() const;
+    void setMailNotificationOnAdd(bool enabled);
+    bool isMailNotificationOnEnd() const;
+    void setMailNotificationOnEnd(bool enabled);
     QString getMailNotificationSender() const;
     void setMailNotificationSender(const QString &mail);
     QString getMailNotificationEmail() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -666,6 +666,11 @@ void OptionsDialog::loadDownloadsTabOptions()
     m_ui->textExcludedFileNames->setPlainText(session->excludedFileNames().join(u'\n'));
 
     m_ui->groupMailNotification->setChecked(pref->isMailNotificationEnabled());
+    m_ui->checkMailOnAdd->setChecked(pref->isMailNotificationOnAdd());
+    m_ui->checkMailOnAdd->setToolTip(tr("Send email notification when a torrent is added."));
+    m_ui->checkMailOnEnd->setChecked(pref->isMailNotificationOnEnd());
+    m_ui->checkMailOnEnd->setToolTip(tr("Send email notification when a torrent has finished downloading."));
+    updateMailWhenToSendStates();
     m_ui->senderEmailTxt->setText(pref->getMailNotificationSender());
     m_ui->senderEmailTxt->setToolTip(tr("Provide the sending email address."));
     m_ui->lineEditDestEmail->setText(pref->getMailNotificationEmail());
@@ -784,6 +789,10 @@ void OptionsDialog::loadDownloadsTabOptions()
     connect(m_ui->removeWatchedFolderButton, &QAbstractButton::clicked, this, &ThisType::enableApplyButton);
 
     connect(m_ui->groupMailNotification, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkMailOnAdd, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkMailOnAdd, &QAbstractButton::toggled, this, &ThisType::updateMailWhenToSendStates);
+    connect(m_ui->checkMailOnEnd, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkMailOnEnd, &QAbstractButton::toggled, this, &ThisType::updateMailWhenToSendStates);
     connect(m_ui->senderEmailTxt, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->lineEditDestEmail, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->lineEditSMTPServer, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -850,6 +859,8 @@ void OptionsDialog::saveDownloadsTabOptions() const
     session->setExcludedFileNames(m_ui->textExcludedFileNames->toPlainText().split(u'\n', Qt::SkipEmptyParts));
 
     pref->setMailNotificationEnabled(m_ui->groupMailNotification->isChecked());
+    pref->setMailNotificationOnAdd(m_ui->checkMailOnAdd->isChecked());
+    pref->setMailNotificationOnEnd(m_ui->checkMailOnEnd->isChecked());
     pref->setMailNotificationSender(m_ui->senderEmailTxt->text());
     pref->setMailNotificationEmail(m_ui->lineEditDestEmail->text());
     pref->setMailNotificationSMTP(m_ui->lineEditSMTPServer->text());
@@ -1908,6 +1919,16 @@ void OptionsDialog::changeSMTPEncryptionPortInfoLabel()
         break;
     }
     m_ui->labelSMTPEncryptionPortInfo->setText(tr("Default port: %1").arg(QString::number(port)));
+}
+
+void OptionsDialog::updateMailWhenToSendStates()
+{
+    const bool isMailNotificationOnAddChecked = m_ui->checkMailOnAdd->isChecked();
+    const bool isMailNotificationOnEndChecked = m_ui->checkMailOnEnd->isChecked();
+    if (!isMailNotificationOnAddChecked && !isMailNotificationOnEndChecked)
+        return;
+    m_ui->checkMailOnAdd->setEnabled(isMailNotificationOnEndChecked);
+    m_ui->checkMailOnEnd->setEnabled(isMailNotificationOnAddChecked);
 }
 
 bool OptionsDialog::isSplashScreenDisabled() const

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -85,6 +85,7 @@ public slots:
 private slots:
     void adjustProxyOptions();
     void changeSMTPEncryptionPortInfoLabel();
+    void updateMailWhenToSendStates();
     void on_buttonBox_accepted();
     void on_buttonBox_rejected();
     void enableApplyButton();

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1593,7 +1593,7 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
             <item>
              <widget class="QGroupBox" name="groupMailNotification">
               <property name="title">
-               <string>Email notification &amp;upon download completion</string>
+               <string>Email notification</string>
               </property>
               <property name="checkable">
                <bool>true</bool>
@@ -1602,6 +1602,29 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                <bool>false</bool>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_171">
+               <item>
+                <widget class="QGroupBox" name="groupMailNotificationWhen">
+                 <property name="title">
+                  <string>Send when</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="groupMailNotificationWhenLayout">
+                  <item>
+                   <widget class="QCheckBox" name="checkMailOnAdd">
+                    <property name="text">
+                     <string>Torrent Added</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="checkMailOnEnd">
+                    <property name="text">
+                     <string>Torrent Finished</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
                <item>
                 <layout class="QGridLayout" name="gridLayout_9">
                  <item row="0" column="0">

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -216,6 +216,8 @@ void AppController::preferencesAction()
 
     // Email notification upon download completion
     data[u"mail_notification_enabled"_s] = pref->isMailNotificationEnabled();
+    data[u"mail_notification_on_add"_s] = pref->isMailNotificationOnAdd();
+    data[u"mail_notification_on_end"_s] = pref->isMailNotificationOnEnd();
     data[u"mail_notification_sender"_s] = pref->getMailNotificationSender();
     data[u"mail_notification_email"_s] = pref->getMailNotificationEmail();
     data[u"mail_notification_smtp"_s] = pref->getMailNotificationSMTP();
@@ -680,6 +682,10 @@ void AppController::setPreferencesAction()
     // Email notification upon download completion
     if (hasKey(u"mail_notification_enabled"_s))
         pref->setMailNotificationEnabled(it.value().toBool());
+    if (hasKey(u"mail_notification_on_add"_s))
+        pref->setMailNotificationOnAdd(it.value().toBool());
+    if (hasKey(u"mail_notification_on_end"_s))
+        pref->setMailNotificationOnEnd(it.value().toBool());
     if (hasKey(u"mail_notification_sender"_s))
         pref->setMailNotificationSender(it.value().toString());
     if (hasKey(u"mail_notification_email"_s))

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -326,8 +326,19 @@
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="mail_notification_checkbox" onclick="qBittorrent.Preferences.updateMailNotification();">
-            <label for="mail_notification_checkbox">QBT_TR(Email notification upon download completion)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="mail_notification_checkbox">QBT_TR(Email notification)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
+        <fieldset class="settings">
+            <legend>QBT_TR(Send when)QBT_TR[CONTEXT=OptionsDialog]</legend>
+            <div class="formRow">
+                <input type="checkbox" id="mailNotificationOnAddCheckbox" title="QBT_TR(Send email notification when a torrent is added.)QBT_TR[CONTEXT=OptionsDialog]" onclick="qBittorrent.Preferences.updateMailWhenToSend();">
+                <label id="mailNotificationOnAddLabel" for="mailNotificationOnAddCheckbox">QBT_TR(Torrent Added)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </div>
+            <div class="formRow">
+                <input type="checkbox" id="mailNotificationOnEndCheckbox" title="QBT_TR(Send email notification when a torrent has finished downloading.)QBT_TR[CONTEXT=OptionsDialog]" onclick="qBittorrent.Preferences.updateMailWhenToSend();">
+                <label id="mailNotificationOnEndLabel" for="mailNotificationOnEndCheckbox">QBT_TR(Torrent Finished)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </div>
+        </fieldset>
         <table>
             <tbody>
                 <tr>
@@ -1866,6 +1877,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateExcludedFileNamesEnabled: updateExcludedFileNamesEnabled,
                 changeWatchFolderSelect: changeWatchFolderSelect,
                 updateMailNotification: updateMailNotification,
+                updateMailWhenToSend: updateMailWhenToSend,
                 updateMailAuthSettings: updateMailAuthSettings,
                 sendTestEmail: sendTestEmail,
                 updateAutoRun: updateAutoRun,
@@ -2029,17 +2041,29 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
         const updateMailNotification = () => {
             const isMailNotificationEnabled = document.getElementById("mail_notification_checkbox").checked;
+            document.getElementById("mailNotificationOnAddCheckbox").disabled = !isMailNotificationEnabled;
+            document.getElementById("mailNotificationOnEndCheckbox").disabled = !isMailNotificationEnabled;
             document.getElementById("src_email_txt").disabled = !isMailNotificationEnabled;
             document.getElementById("dest_email_txt").disabled = !isMailNotificationEnabled;
             document.getElementById("smtp_server_txt").disabled = !isMailNotificationEnabled;
             document.getElementById("mailNotificationEncryptionCombobox").disabled = !isMailNotificationEnabled;
             document.getElementById("mail_auth_checkbox").disabled = !isMailNotificationEnabled;
             document.getElementById("mail_test_button").disabled = !isMailNotificationEnabled;
-
+            if (isMailNotificationEnabled)
+                updateMailWhenToSend();
             if (!isMailNotificationEnabled) {
                 document.getElementById("mail_auth_checkbox").checked = !isMailNotificationEnabled;
                 updateMailAuthSettings();
             }
+        };
+
+        const updateMailWhenToSend = () => {
+            const isMailNotificationOnAddChecked = document.getElementById("mailNotificationOnAddCheckbox").checked;
+            const isMailNotificationOnEndChecked = document.getElementById("mailNotificationOnEndCheckbox").checked;
+            if (!isMailNotificationOnAddChecked && !isMailNotificationOnEndChecked)
+                return;
+            document.getElementById("mailNotificationOnAddCheckbox").disabled = !isMailNotificationOnEndChecked;
+            document.getElementById("mailNotificationOnEndCheckbox").disabled = !isMailNotificationOnAddChecked;
         };
 
         const updateMailAuthSettings = () => {
@@ -2466,6 +2490,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
                     // Email notification upon download completion
                     document.getElementById("mail_notification_checkbox").checked = pref.mail_notification_enabled;
+                    document.getElementById("mailNotificationOnAddCheckbox").checked = pref.mail_notification_on_add;
+                    document.getElementById("mailNotificationOnEndCheckbox").checked = pref.mail_notification_on_end;
                     document.getElementById("src_email_txt").value = pref.mail_notification_sender;
                     document.getElementById("dest_email_txt").value = pref.mail_notification_email;
                     document.getElementById("smtp_server_txt").value = pref.mail_notification_smtp;
@@ -2868,6 +2894,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
             // Email notification upon download completion
             settings["mail_notification_enabled"] = document.getElementById("mail_notification_checkbox").checked;
+            settings["mail_notification_on_add"] = document.getElementById("mailNotificationOnAddCheckbox").checked;
+            settings["mail_notification_on_end"] = document.getElementById("mailNotificationOnEndCheckbox").checked;
             settings["mail_notification_sender"] = document.getElementById("src_email_txt").value;
             settings["mail_notification_email"] = document.getElementById("dest_email_txt").value;
             settings["mail_notification_smtp"] = document.getElementById("smtp_server_txt").value;


### PR DESCRIPTION
Provide the options to send email notifications when a torrent is added and when a torrent finishes.
Currently an email notification is only sent when a torrent finishes.
If you are running qBittorrent with automations, such as RSS feeds & rules, then it is very useful to receive an email when a torrent is added as well as when it finishes, so you can track the progress remotely: receiving an email for a torrent being added that isn't followed by an email saying the torrent is completed alerts you that something needs investigated.
It's personally something I find very useful and I added to my local build of qBittorrent as soon as I made code modifications.

I've arranged them as checkboxes so that it can be extended in the future for other torrent events, if desired.
I've added logic checks so that if only one checkbox is ticked, it is disabled to prevent it being unticked itself, ensuring that at least one options is ticked. It is re-enabled when the other option is ticked.
There is logic to capture the case that someone manages to set both options off (hand edit the config file, or similar), and then it doesn't disable any boxes until something is selected.
Also, a future option could be to have buttons beside each option that allows for customising the email message (perhaps parsed in a similar way to the Run External Program just below).

### GUI
<img width="618" height="493" alt="image" src="https://github.com/user-attachments/assets/9cdf5d04-dfbd-45bc-bbc9-62c0e64c15be" />

### WebGUI
<img width="575" height="475" alt="image" src="https://github.com/user-attachments/assets/67357efa-7232-4ed6-a39b-a5f9060051eb" />
