### PR TITLE
Check GeoIP file size only if it exists

### DIFF
--- a/src/base/net/geoipdatabase.cpp
+++ b/src/base/net/geoipdatabase.cpp
@@ -86,16 +86,16 @@ GeoIPDatabase *GeoIPDatabase::load(const Path &filename, QString &error)
 {
     QFile file {filename.data()};
 
+    if (!file.open(QFile::ReadOnly))
+    {
+        error = file.errorString();
+        return nullptr;
+    }
+
     const qint64 fileSize = file.size();
     if ((fileSize <= 0) || (fileSize > MAX_FILE_SIZE))
     {
         error = tr("Unsupported database file size.");
-        return nullptr;
-    }
-
-    if (!file.open(QFile::ReadOnly))
-    {
-        error = file.errorString();
         return nullptr;
     }
 


### PR DESCRIPTION
Fixes [this regression](https://github.com/qbittorrent/qBittorrent/pull/24087#issuecomment-4477942656).