### PR TITLE
Support multiple recipients for email notifications

### DIFF
--- a/src/base/net/smtpclient.cpp
+++ b/src/base/net/smtpclient.cpp
@@ -151,11 +151,10 @@ void Net::SMTPClient::sendMail(const QString &from, const QString &to
 {
     QString normalizedTo = to;
     const QStringList groupList = normalizedTo.remove(u' ').split(u';', Qt::SkipEmptyParts);
-    QStringListIterator groupListIterator {groupList};
-    while (groupListIterator.hasNext())
+    for (const QString &group : groupList)
     {
         [[maybe_unused]] auto *obj = new SMTPClient(from
-            , groupListIterator.next().split(u',', Qt::SkipEmptyParts)
+            , group.split(u',', Qt::SkipEmptyParts)
             , subject, body, context);
     }
 }

--- a/src/base/net/smtpclient.cpp
+++ b/src/base/net/smtpclient.cpp
@@ -37,7 +37,6 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QHostInfo>
-#include <QRegularExpression>
 #include <QSslSocket>
 
 #include "base/global.h"
@@ -150,16 +149,23 @@ const int SOCKETERROR_TYPEID = qRegisterMetaType<QAbstractSocket::SocketError>()
 void Net::SMTPClient::sendMail(const QString &from, const QString &to
         , const QString &subject, const QString &body, QObject *context)
 {
-    const QStringList groupList = to.split(u';', Qt::SkipEmptyParts);
-    for (int i = 0; i < groupList.size(); ++i)
-        [[maybe_unused]] auto *obj = new SMTPClient(from, groupList[i], subject, body, context);
+    QString normalizedTo = to;
+    const QStringList groupList = normalizedTo.remove(u' ').split(u';', Qt::SkipEmptyParts);
+    QStringListIterator groupListIterator {groupList};
+    while (groupListIterator.hasNext())
+    {
+        [[maybe_unused]] auto *obj = new SMTPClient(from
+            , groupListIterator.next().split(u',', Qt::SkipEmptyParts)
+            , subject, body, context);
+    }
 }
 
-Net::SMTPClient::SMTPClient(const QString &from, const QString &to
+Net::SMTPClient::SMTPClient(const QString &sender, const QStringList &recipients
         , const QString &subject, const QString &body, QObject *parent)
     : QObject(parent)
-    , m_sender {from}
-    , m_recipients {to.split(QRegularExpression(u"[, ]"_s), Qt::SkipEmptyParts)}
+    , m_sender {sender}
+    , m_recipients {recipients}
+    , m_recipientsIterator {m_recipients}
 {
     m_socket = new QSslSocket(this);
 
@@ -312,22 +318,21 @@ void Net::SMTPClient::readyRead()
         case Rcpt:
             if (code[0] == '2')
             {
-                const int recipientsSize = m_recipients.size();
-                if (m_recipientsIndex < recipientsSize)
+                if (m_recipientsIterator.hasNext())
                 {
-                    m_socket->write("rcpt to:<" + m_recipients[m_recipientsIndex++].toLatin1() + ">\r\n");
+                    m_socket->write("rcpt to:<" + m_recipientsIterator.next().toLatin1() + ">\r\n");
                     m_socket->flush();
                 }
 
-                if (m_recipientsIndex >= recipientsSize)
+                if (!m_recipientsIterator.hasNext())
                     m_state = Data;
             }
             else
             {
-                if (m_recipientsIndex == 0)
-                    logError(tr("<mail from> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
-                else
+                if (m_recipientsIterator.hasPrevious())
                     logError(tr("<rcpt to> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
+                else
+                    logError(tr("<mail from> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
                 m_state = Close;
             }
             break;

--- a/src/base/net/smtpclient.cpp
+++ b/src/base/net/smtpclient.cpp
@@ -37,7 +37,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QHostInfo>
-#include <QStringList>
+#include <QRegularExpression>
 #include <QSslSocket>
 
 #include "base/global.h"
@@ -150,14 +150,16 @@ const int SOCKETERROR_TYPEID = qRegisterMetaType<QAbstractSocket::SocketError>()
 void Net::SMTPClient::sendMail(const QString &from, const QString &to
         , const QString &subject, const QString &body, QObject *context)
 {
-    [[maybe_unused]] auto *obj = new SMTPClient(from, to, subject, body, context);
+    const QStringList groupList = to.split(u';', Qt::SkipEmptyParts);
+    for (int i = 0; i < groupList.size(); ++i)
+        [[maybe_unused]] auto *obj = new SMTPClient(from, groupList[i], subject, body, context);
 }
 
 Net::SMTPClient::SMTPClient(const QString &from, const QString &to
         , const QString &subject, const QString &body, QObject *parent)
     : QObject(parent)
-    , m_from {from}
-    , m_rcpt {to}
+    , m_sender {from}
+    , m_recipients {to.split(QRegularExpression(u"[, ]"_s), Qt::SkipEmptyParts)}
 {
     m_socket = new QSslSocket(this);
 
@@ -174,9 +176,9 @@ Net::SMTPClient::SMTPClient(const QString &from, const QString &to
     const Preferences *const pref = Preferences::instance();
 
     m_message = "Date: " + getCurrentDateTime().toLatin1() + "\r\n"
-            + encodeMimeHeader(u"From"_s, u"qBittorrent <%1>"_s.arg(from))
+            + encodeMimeHeader(u"From"_s, u"qBittorrent <%1>"_s.arg(m_sender))
             + encodeMimeHeader(u"Subject"_s, subject)
-            + encodeMimeHeader(u"To"_s, to)
+            + encodeMimeHeader(u"To"_s, m_recipients.join(u", "_s))
             + "MIME-Version: 1.0\r\n"
             + "Content-Type: text/plain; charset=UTF-8\r\n"
             + "Content-Transfer-Encoding: base64\r\n"
@@ -296,7 +298,7 @@ void Net::SMTPClient::readyRead()
             if (code[0] == '2')
             {
                 qDebug() << "Sending <mail from>...";
-                m_socket->write("mail from:<" + m_from.toLatin1() + ">\r\n");
+                m_socket->write("mail from:<" + m_sender.toLatin1() + ">\r\n");
                 m_socket->flush();
                 m_state = Rcpt;
             }
@@ -310,13 +312,22 @@ void Net::SMTPClient::readyRead()
         case Rcpt:
             if (code[0] == '2')
             {
-                m_socket->write("rcpt to:<" + m_rcpt.toLatin1() + ">\r\n");
-                m_socket->flush();
-                m_state = Data;
+                const int recipientsSize = m_recipients.size();
+                if (m_recipientsIndex < recipientsSize)
+                {
+                    m_socket->write("rcpt to:<" + m_recipients[m_recipientsIndex++].toLatin1() + ">\r\n");
+                    m_socket->flush();
+                }
+
+                if (m_recipientsIndex >= recipientsSize)
+                    m_state = Data;
             }
             else
             {
-                logError(tr("<mail from> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
+                if (m_recipientsIndex == 0)
+                    logError(tr("<mail from> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
+                else
+                    logError(tr("<rcpt to> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
                 m_state = Close;
             }
             break;
@@ -329,7 +340,7 @@ void Net::SMTPClient::readyRead()
             }
             else
             {
-                logError(tr("<Rcpt to> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
+                logError(tr("<rcpt to> was rejected by server, msg: %1").arg(QString::fromUtf8(line)));
                 m_state = Close;
             }
             break;

--- a/src/base/net/smtpclient.h
+++ b/src/base/net/smtpclient.h
@@ -38,6 +38,7 @@
 #include <QHash>
 #include <QObject>
 #include <QString>
+#include <QStringList>
 
 class QSslSocket;
 
@@ -104,8 +105,9 @@ namespace Net
 
         QByteArray m_message;
         QSslSocket *m_socket = nullptr;
-        QString m_from;
-        QString m_rcpt;
+        QString m_sender;
+        QStringList m_recipients;
+        int m_recipientsIndex = 0;
         QString m_response;
         States m_state = Init;
         QHash<QString, QString> m_extensions;

--- a/src/base/net/smtpclient.h
+++ b/src/base/net/smtpclient.h
@@ -89,7 +89,7 @@ namespace Net
             AuthCramMD5
         };
 
-        SMTPClient(const QString &from, const QString &to, const QString &subject
+        SMTPClient(const QString &sender, const QStringList &recipients, const QString &subject
                    , const QString &body, QObject *parent = nullptr);
         ~SMTPClient() override;
 
@@ -107,7 +107,7 @@ namespace Net
         QSslSocket *m_socket = nullptr;
         QString m_sender;
         QStringList m_recipients;
-        int m_recipientsIndex = 0;
+        QStringListIterator m_recipientsIterator;
         QString m_response;
         States m_state = Init;
         QHash<QString, QString> m_extensions;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -669,9 +669,17 @@ void OptionsDialog::loadDownloadsTabOptions()
     m_ui->senderEmailTxt->setText(pref->getMailNotificationSender());
     m_ui->senderEmailTxt->setToolTip(tr("Provide the sending email address."));
     m_ui->lineEditDestEmail->setText(pref->getMailNotificationEmail());
-    m_ui->lineEditDestEmail->setToolTip(tr("Provide the recipient email address.")
+    m_ui->lineEditDestEmail->setToolTip(tr("Provide the recipient email address or addresses.")
         + u"\n\n"
-        + tr("Note: only a single recipient email address can be specified."));
+        + tr("Separate multiple emails with a semicolon.")
+        + u"\n"
+        + tr("Separate multiple email addresses within each email with a comma.")
+        + u"\n\n"
+        + tr("Example:")
+        + u"\n"
+        + tr("a@a.com;b@b.com,c@c.com - send two emails: the first to just a@a.com, the second to both b@b.com and c@c.com")
+        + u"\n\n"
+        + tr("Note: b&b.com & c@c.com will both see each other's email addresses, whereas a&a.com will not see them nor be seen."));
     m_ui->lineEditSMTPServer->setText(pref->getMailNotificationSMTP());
     m_ui->lineEditSMTPServer->setToolTip(tr("Provide the SMTP server address for sending email notifications.")
         + u"\n\n"

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -343,9 +343,15 @@
                         <label for="dest_email_txt">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="dest_email_txt" style="width: 40em;" title="QBT_TR(Provide the recipient email address.)QBT_TR[CONTEXT=OptionsDialog]
+                        <input type="text" id="dest_email_txt" style="width: 40em;" title="QBT_TR(Provide the recipient email address or addresses.)QBT_TR[CONTEXT=OptionsDialog]
 
-QBT_TR(Note: only a single recipient email address can be specified.)QBT_TR[CONTEXT=OptionsDialog]">
+QBT_TR(Separate multiple emails with a semicolon.)QBT_TR[CONTEXT=OptionsDialog]
+QBT_TR(Separate multiple email addresses within each email with a comma.)QBT_TR[CONTEXT=OptionsDialog]
+
+QBT_TR(Example:)QBT_TR[CONTEXT=OptionsDialog]
+QBT_TR(a@a.com;b@b.com,c@c.com - send two emails: the first to just a@a.com, the second to both b@b.com and c@c.com)QBT_TR[CONTEXT=OptionsDialog]
+
+QBT_TR(Note: b&b.com & c@c.com will both see each other's email addresses, whereas a&a.com will not see them nor be seen.)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Closes #18739.

Refactor SMTPClient to handle multiple groups of recipients and multiple recipients within each group.
Support for group sending by splitting the initial "to" argument by semicolons and creating separate SMTPClient instances per group.
Support multiple recipients by splitting the "to" field by comma into a list and sending "rcpt to" for each address.
Update email header construction and error logging accordingly.

The recipient list is split in turn using separator characters (semicolon and then comma), all of which are illegal characters in email addresses so shouldn't be there. The last split also removes spaces by adding it to the separator characters via RegEx and removing any empty values.
The semicolon is split at the beginning, to create groups of recipients and then an individual email is sent to each group by calling the SMTPClient multiple times.
I reassemble it correctly for the `MimeHeader` using commas.
It's then a matter of staying within the `Rcpt` phase of the "state machine" to keep emitting the individual email addresses.

This allows flexibility in the way emails are sent to multiple recipients.
Using comma separation allows efficiently sending single emails, but each recipient will see the other recipient in the email headers.
Using semicolon separation allows privacy by sending individual emails to each recipient (or sub-group of recipients) so they do not see each other in the email headers, but at the expense of sending multiple near-identical emails.

### GUI
<img width="608" height="200" alt="image" src="https://github.com/user-attachments/assets/0da00980-14d6-4ab1-91b9-9c5924ea4c68" />

### WebGUI
<img width="626" height="195" alt="image" src="https://github.com/user-attachments/assets/8143da0a-60af-49fb-adf0-07879c4c3e6a" />
