### PR TITLE
Don't modify source string when search for accepted encoding

### DIFF
--- a/src/base/http/responsewriterimpl.cpp
+++ b/src/base/http/responsewriterimpl.cpp
@@ -73,7 +73,7 @@ namespace
             .append(u" GMT");
     }
 
-    bool acceptsGzipEncoding(QStringView encodings)
+    bool acceptsGzipEncoding(const QStringView encodings)
     {
         // [rfc7231] 5.3.4. Accept-Encoding
 

--- a/src/base/http/responsewriterimpl.cpp
+++ b/src/base/http/responsewriterimpl.cpp
@@ -73,7 +73,7 @@ namespace
             .append(u" GMT");
     }
 
-    bool acceptsGzipEncoding(QString encodings)
+    bool acceptsGzipEncoding(QStringView encodings)
     {
         // [rfc7231] 5.3.4. Accept-Encoding
 
@@ -87,20 +87,22 @@ namespace
                 return true;
 
             // [rfc7231] 5.3.1. Quality Values
-            const QStringView substr = encodingEntry.mid(encoding.size() + 3);  // ex. skip over "gzip;q="
+            const QStringView qualityStr = encodingEntry.sliced(encoding.size() + 1).trimmed();  // ex. skip over "gzip;"
+            if (!qualityStr.startsWith(u"q="))
+                return false;
 
             bool ok = false;
-            const double qvalue = substr.toDouble(&ok);
+            const double qvalue = qualityStr.sliced(2).toDouble(&ok);
             if (ok && (qvalue > 0))
                 return true;
 
             return false;
         };
 
-        encodings.remove(u' ').remove(u'\t');
         return std::ranges::any_of(qTokenize(encodings, u',', Qt::SkipEmptyParts)
-                , [&matchEncoding](const QStringView encodingEntry)
+                , [&matchEncoding](QStringView encodingEntry)
         {
+            encodingEntry = encodingEntry.trimmed();
             return matchEncoding(encodingEntry, u"gzip") || matchEncoding(encodingEntry, u"*");
         });
     }


### PR DESCRIPTION
A catch-up to #24286 is a change to improve performance.