### PR TITLE
Rename QtLocalPeer to LocalPeer

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -39,7 +39,7 @@ target_sources(qbt_app PRIVATE
     cmdoptions.h
     filelogger.h
     legalnotice.h
-    qtlocalpeer/qtlocalpeer.h
+    localpeer.h
     signalhandler.h
     upgrade.h
 
@@ -49,8 +49,8 @@ target_sources(qbt_app PRIVATE
     cmdoptions.cpp
     filelogger.cpp
     legalnotice.cpp
+    localpeer.cpp
     main.cpp
-    qtlocalpeer/qtlocalpeer.cpp
     signalhandler.cpp
     upgrade.cpp
 

--- a/src/app/applicationinstancemanager.cpp
+++ b/src/app/applicationinstancemanager.cpp
@@ -38,14 +38,14 @@
 #endif
 
 #include "base/path.h"
-#include "qtlocalpeer/qtlocalpeer.h"
+#include "localpeer.h"
 
 ApplicationInstanceManager::ApplicationInstanceManager(const Path &instancePath, QObject *parent)
-    : QObject {parent}
-    , m_peer {new QtLocalPeer(instancePath.data(), this)}
+    : QObject(parent)
+    , m_peer {new LocalPeer(instancePath.data(), this)}
     , m_isFirstInstance {!m_peer->isClient()}
 {
-    connect(m_peer, &QtLocalPeer::messageReceived, this, &ApplicationInstanceManager::messageReceived);
+    connect(m_peer, &LocalPeer::messageReceived, this, &ApplicationInstanceManager::messageReceived);
 
 #ifdef Q_OS_WIN
     const QString sharedMemoryKey = instancePath.data() + u"/shared-memory";

--- a/src/app/applicationinstancemanager.h
+++ b/src/app/applicationinstancemanager.h
@@ -32,7 +32,7 @@
 
 #include "base/pathfwd.h"
 
-class QtLocalPeer;
+class LocalPeer;
 
 class ApplicationInstanceManager final : public QObject
 {
@@ -51,6 +51,6 @@ signals:
     void messageReceived(const QString &message);
 
 private:
-    QtLocalPeer *m_peer = nullptr;
+    LocalPeer *m_peer = nullptr;
     const bool m_isFirstInstance;
 };

--- a/src/app/localpeer.cpp
+++ b/src/app/localpeer.cpp
@@ -67,7 +67,7 @@
 ****************************************************************************
 */
 
-#include "qtlocalpeer.h"
+#include "localpeer.h"
 
 #include <QtSystemDetection>
 
@@ -88,7 +88,7 @@
 
 const QByteArray ACK = QByteArrayLiteral("ack");
 
-QtLocalPeer::QtLocalPeer(const QString &path, QObject *parent)
+LocalPeer::LocalPeer(const QString &path, QObject *parent)
     : QObject(parent)
     , m_socketName {path + u"/ipc-socket"}
     , m_server {new QLocalServer(this)}
@@ -98,7 +98,7 @@ QtLocalPeer::QtLocalPeer(const QString &path, QObject *parent)
     m_lockFile.setStaleLockTime(0);
 }
 
-bool QtLocalPeer::isClient()
+bool LocalPeer::isClient()
 {
     if (m_lockFile.isLocked())
         return false;
@@ -139,11 +139,11 @@ bool QtLocalPeer::isClient()
     if (!res)
         qWarning("QtSingleCoreApplication: listen on local socket failed, %s", qUtf8Printable(m_server->errorString()));
 
-    connect(m_server, &QLocalServer::newConnection, this, &QtLocalPeer::receiveConnection);
+    connect(m_server, &QLocalServer::newConnection, this, &LocalPeer::receiveConnection);
     return false;
 }
 
-bool QtLocalPeer::sendMessage(const QString &message, const int timeout)
+bool LocalPeer::sendMessage(const QString &message, const int timeout)
 {
     if (!isClient())
         return false;
@@ -181,7 +181,7 @@ bool QtLocalPeer::sendMessage(const QString &message, const int timeout)
     return res;
 }
 
-void QtLocalPeer::receiveConnection()
+void LocalPeer::receiveConnection()
 {
     QLocalSocket *socket = m_server->nextPendingConnection();
     if (!socket)
@@ -238,7 +238,7 @@ void QtLocalPeer::receiveConnection()
     emit messageReceived(message); //### (might take a long time to return)
 }
 
-std::optional<QtLocalPeer::LockInfo> QtLocalPeer::getLockInfo() const
+std::optional<LocalPeer::LockInfo> LocalPeer::getLockInfo() const
 {
     const auto readResult = Utils::IO::readFile(Path(m_lockFile.fileName()), 1024);
     if (!readResult)

--- a/src/app/localpeer.h
+++ b/src/app/localpeer.h
@@ -77,13 +77,13 @@
 
 class QLocalServer;
 
-class QtLocalPeer final : public QObject
+class LocalPeer final : public QObject
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(QtLocalPeer)
+    Q_DISABLE_COPY_MOVE(LocalPeer)
 
 public:
-    QtLocalPeer(const QString &path, QObject *parent = nullptr);
+    LocalPeer(const QString &path, QObject *parent = nullptr);
 
     bool isClient();
     bool sendMessage(const QString &message, int timeout);


### PR DESCRIPTION
This borrowed class is no longer part of Qt.
