### PR TITLE
Add column showing files count

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,6 +1,8 @@
 # WebAPI Changelog
 
 ## 2.16.0
+* [#24318](https://github.com/qbittorrent/qBittorrent/pull/24318)
+  * Add `files_count` and `wanted_files_count` to the response of `api/v2/sync/maindata`
 * [#24346](https://github.com/qbittorrent/qBittorrent/pull/24346)
   * `torrentcreator/addTask` endpoint accepts a new bool option `ignoreDotfiles` to control whether dotfiles are ignored
   * `torrentcreator/status` endpoint returns a new bool field `ignoreDotfiles` for reporting whether dotfiles were ignored

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -144,6 +144,7 @@ namespace BitTorrent
         virtual qlonglong pieceLength() const = 0;
         virtual qlonglong wastedSize() const = 0;
         virtual QString currentTracker() const = 0;
+        virtual int wantedFilesCount() const = 0;
 
         // 1. savePath() - the path where all the files and subfolders of torrent are stored.
         // 1.1 downloadPath() - the path where all the files and subfolders of torrent are stored until torrent has finished downloading.

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -3025,6 +3025,12 @@ void TorrentImpl::prioritizeFiles(const QList<DownloadPriority> &priorities)
     manageActualFilePaths();
 }
 
+int TorrentImpl::wantedFilesCount() const
+{
+    return std::ranges::count_if(asConst(filePriorities())
+        , [](const BitTorrent::DownloadPriority priority) { return priority != BitTorrent::DownloadPriority::Ignored; });
+}
+
 template <typename Func>
 QFuture<std::invoke_result_t<Func>> TorrentImpl::invokeAsync(Func &&func) const
 {

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -135,6 +135,7 @@ namespace BitTorrent
         void removeAllTags() override;
 
         int filesCount() const override;
+        int wantedFilesCount() const override;
         int piecesCount() const override;
         int piecesHave() const override;
         qreal progress() const override;

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,6 +196,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
+            case TR_FILES_COUNT: return tr("Files count", "i.e. number of files in the torrent");
             default: return {};
             }
         }
@@ -233,6 +234,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_LAST_ACTIVITY:
             case TR_AVAILABILITY:
             case TR_REANNOUNCE:
+            case TR_FILES_COUNT:
                 return QVariant(Qt::AlignRight | Qt::AlignVCenter);
             default:
                 return QAbstractListModel::headerData(section, orientation, role);
@@ -447,6 +449,10 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return reannounceString(torrent->nextAnnounce());
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
+    case TR_FILES_COUNT:
+        return torrent->hasMetadata()
+            ? u"%1 (%2)"_s.arg(torrent->wantedFilesCount()).arg(torrent->filesCount())
+            : tr("N/A");
     }
 
     return {};
@@ -532,6 +538,10 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->nextAnnounce();
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
+    case TR_FILES_COUNT:
+        return torrent->hasMetadata()
+            ? QVariant::fromValue(std::make_pair(torrent->wantedFilesCount(), torrent->filesCount()))
+            : QVariant();
     }
 
     return {};
@@ -602,6 +612,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
         case TR_LAST_ACTIVITY:
         case TR_AVAILABILITY:
         case TR_REANNOUNCE:
+        case TR_FILES_COUNT:
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
         }
         break;

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -88,6 +88,7 @@ public:
         TR_REANNOUNCE,
         TR_PRIVATE,
         TR_CREATE_DATE,
+        TR_FILES_COUNT,
 
         NB_COLUMNS
     };

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -286,6 +286,9 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
             return threeWayCompare(totalL, totalR);
         }
 
+    case TransferListModel::TR_FILES_COUNT:
+        return threeWayCompare(leftValue.value<std::pair<int,int>>(), rightValue.value<std::pair<int,int>>());
+
     default:
         Q_ASSERT_X(false, Q_FUNC_INFO, "Missing comparison case");
         break;

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -182,6 +182,8 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
-        {KEY_TORRENT_COMMENT, torrent.comment()}
+        {KEY_TORRENT_COMMENT, torrent.comment()},
+        {KEY_TORRENT_FILES_COUNT, torrent.filesCount()},
+        {KEY_TORRENT_WANTED_FILES_COUNT, torrent.wantedFilesCount()}
     };
 }

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -106,5 +106,7 @@ inline const QString KEY_TORRENT_PIECE_SIZE = u"piece_size"_s;
 inline const QString KEY_TORRENT_PIECES_HAVE = u"pieces_have"_s;
 inline const QString KEY_TORRENT_CREATED_BY = u"created_by"_s;
 inline const QString KEY_TORRENT_CREATION_DATE = u"creation_date"_s;
+inline const QString KEY_TORRENT_FILES_COUNT = u"files_count"_s;
+inline const QString KEY_TORRENT_WANTED_FILES_COUNT = u"wanted_files_count"_s;
 
 QVariantMap serialize(const BitTorrent::Torrent &torrent);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1181,12 +1181,14 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("files_count", "", "QBT_TR(Files count)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");
             this.columns["num_seeds"].dataProperties.push("num_complete");
             this.columns["num_leechs"].dataProperties.push("num_incomplete");
             this.columns["time_active"].dataProperties.push("seeding_time");
+            this.columns["files_count"].dataProperties = ["wanted_files_count", "files_count"];
 
             this.initColumnsFunctions();
         }
@@ -1578,6 +1580,40 @@ window.qBittorrent.DynamicTable ??= (() => {
                     : "QBT_TR(N/A)QBT_TR[CONTEXT=PropertiesWidget]";
                 td.textContent = string;
                 td.title = string;
+            };
+
+            this.columns["files_count"].updateTd = function(td, row) {
+                const hasMetadata = row["full_data"].has_metadata;
+                if (!hasMetadata) {
+                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
+                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
+                    return;
+                }
+
+                const wantedFilesCount = this.getRowValue(row, 0);
+                const allFilesCount = this.getRowValue(row, 1);
+                const value = `${wantedFilesCount} (${allFilesCount})`;
+                td.textContent = value;
+                td.title = value;
+            };
+            this.columns["files_count"].compareRows = function(row1, row2) {
+                const hasMetadata1 = row1["full_data"].has_metadata;
+                const hasMetadata2 = row2["full_data"].has_metadata;
+                if (!hasMetadata1 || !hasMetadata2) {
+                    if (!hasMetadata1)
+                        return !hasMetadata2 ? 0 : 1;
+                    return -1;
+                }
+
+                const wanted1 = this.getRowValue(row1, 0);
+                const wanted2 = this.getRowValue(row2, 0);
+                const result = compareNumbers(wanted1, wanted2);
+                if (result !== 0)
+                    return result;
+
+                const total1 = this.getRowValue(row1, 1);
+                const total2 = this.getRowValue(row2, 1);
+                return compareNumbers(total1, total2);
             };
         }
 


### PR DESCRIPTION
Closes: #22129 (and its child probably)

# Description

Adds a column that displays the "wanted" (priority different from `IGNORED`) and total files count for a torrent
The two numbers are displayed as `wanted_files_count (total_files_count)` in both app and webui
The idea for displaying both numbers comes from the child issue of 22129 (the child is 4531)
For their visualization in the WebUI, 2 new fields are passed from the api `wanted_files_count` and `all_files_count`

# UI Images

Right-most column titled `Files`

App:
<img width="451" height="163" alt="image" src="https://github.com/user-attachments/assets/8d4f946d-29ae-4dde-b480-7a749d5b231e" />

WebUI:
<img width="626" height="199" alt="image" src="https://github.com/user-attachments/assets/d69685e7-c0a2-4c32-add7-256fca900c8f" />

