### PR TITLE
Refactor SMTP client implementation

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -77,7 +77,7 @@
 #include "base/net/geoipmanager.h"
 #include "base/net/proxyconfigurationmanager.h"
 #include "base/net/reverseresolution.h"
-#include "base/net/smtp.h"
+#include "base/net/smtpclient.h"
 #include "base/preferences.h"
 #include "base/profile.h"
 #include "base/rss/rss_autodownloader.h"
@@ -745,14 +745,11 @@ void Application::sendNotificationEmail(const BitTorrent::Torrent *torrent)
 
     // Send the notification email
     const Preferences *pref = Preferences::instance();
-    auto *smtp = new Net::Smtp(this);
-    smtp->sendMail(pref->getMailNotificationSender(),
-                     pref->getMailNotificationEmail(),
-                     tr("Torrent \"%1\" has finished downloading").arg(torrent->name()),
-                     content);
+    Net::SMTPClient::sendMail(pref->getMailNotificationSender(), pref->getMailNotificationEmail()
+            , tr("Torrent \"%1\" has finished downloading").arg(torrent->name()), content, this);
 }
 
-void Application::sendTestEmail() const
+void Application::sendTestEmail()
 {
     const Preferences *pref = Preferences::instance();
     if (pref->isMailNotificationEnabled())
@@ -762,11 +759,8 @@ void Application::sendTestEmail() const
             + tr("Thank you for using qBittorrent.") + u'\n';
 
         // Send the notification email
-        auto *smtp = new Net::Smtp();
-        smtp->sendMail(pref->getMailNotificationSender(),
-                        pref->getMailNotificationEmail(),
-                        tr("Test email"),
-                        content);
+        Net::SMTPClient::sendMail(pref->getMailNotificationSender(), pref->getMailNotificationEmail()
+            , tr("Test email"), content, this);
     }
 }
 

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -129,7 +129,7 @@ public:
     int memoryWorkingSetLimit() const override;
     void setMemoryWorkingSetLimit(int size) override;
 
-    void sendTestEmail() const override;
+    void sendTestEmail() override;
 
 #ifdef Q_OS_WIN
     MemoryPriority processMemoryPriority() const override;

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -83,7 +83,7 @@ add_library(qbt_base STATIC
     net/proxyconfigurationmanager.h
     net/proxytype.h
     net/reverseresolution.h
-    net/smtp.h
+    net/smtpclient.h
     net/smtpencryptiontype.h
     orderedset.h
     path.h
@@ -185,7 +185,7 @@ add_library(qbt_base STATIC
     net/portforwarder.cpp
     net/proxyconfigurationmanager.cpp
     net/reverseresolution.cpp
-    net/smtp.cpp
+    net/smtpclient.cpp
     path.cpp
     preferences.cpp
     profile.cpp

--- a/src/base/interfaces/iapplication.h
+++ b/src/base/interfaces/iapplication.h
@@ -86,7 +86,7 @@ public:
     virtual int memoryWorkingSetLimit() const = 0;
     virtual void setMemoryWorkingSetLimit(int size) = 0;
 
-    virtual void sendTestEmail() const = 0;
+    virtual void sendTestEmail() = 0;
 
 #ifdef Q_OS_WIN
     virtual MemoryPriority processMemoryPriority() const = 0;

--- a/src/base/net/smtpclient.cpp
+++ b/src/base/net/smtpclient.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -30,7 +31,7 @@
  * This code is based on QxtSmtp from libqxt (http://libqxt.org)
  */
 
-#include "smtp.h"
+#include "smtpclient.h"
 
 #include <QCryptographicHash>
 #include <QDateTime>
@@ -43,6 +44,7 @@
 #include "base/logger.h"
 #include "base/preferences.h"
 #include "base/utils/string.h"
+#include "smtpencryptiontype.h"
 
 namespace
 {
@@ -87,57 +89,104 @@ namespace
             return ch > QChar(0xff);
         });
     }
-} // namespace
 
-using namespace Net;
-
-Smtp::Smtp(QObject *parent)
-    : QObject(parent)
-{
-    static bool needToRegisterMetaType = true;
-
-    if (needToRegisterMetaType)
+    QString getCurrentDateTime()
     {
-        qRegisterMetaType<QAbstractSocket::SocketError>();
-        needToRegisterMetaType = false;
+        // [rfc2822] 3.3. Date and Time Specification
+        const auto now = QDateTime::currentDateTime();
+        const QLocale eng {QLocale::English};
+        const QString weekday = eng.dayName(now.date().dayOfWeek(), QLocale::ShortFormat);
+        return (weekday + u", " + now.toString(Qt::RFC2822Date));
     }
 
+    QByteArray encodeMimeHeader(const QString &key, const QString &value, const QByteArray &prefix = {})
+    {
+        QByteArray rv = "";
+        QByteArray line = key.toLatin1() + ": ";
+        if (!prefix.isEmpty()) line += prefix;
+        if (!value.contains(u"=?") && canEncodeAsLatin1(value))
+        {
+            bool firstWord = true;
+            for (const QByteArray &word : asConst(value.toLatin1().split(' ')))
+            {
+                if (line.size() > 78)
+                {
+                    rv = rv + line + "\r\n";
+                    line.clear();
+                }
+                if (firstWord)
+                    line += word;
+                else
+                    line += ' ' + word;
+                firstWord = false;
+            }
+        }
+        else
+        {
+            // The text cannot be losslessly encoded as Latin-1. Therefore, we
+            // must use base64 encoding.
+            const QByteArray utf8 = value.toUtf8();
+            // Use base64 encoding
+            const QByteArray base64 = utf8.toBase64();
+            const qsizetype ct = base64.length();
+            line += "=?utf-8?b?";
+            for (int i = 0; i < ct; i += 4)
+            {
+                /*if (line.length() > 72)
+                {
+                    rv += line + "?\n\r";
+                    line = " =?utf-8?b?";
+                }*/
+                line = line + base64.mid(i, 4);
+            }
+            line += "?="; // end encoded-word atom
+        }
+        return rv + line + "\r\n";
+    }
+} // namespace
+
+const int SOCKETERROR_TYPEID = qRegisterMetaType<QAbstractSocket::SocketError>();
+
+void Net::SMTPClient::sendMail(const QString &from, const QString &to
+        , const QString &subject, const QString &body, QObject *context)
+{
+    [[maybe_unused]] auto *obj = new SMTPClient(from, to, subject, body, context);
+}
+
+Net::SMTPClient::SMTPClient(const QString &from, const QString &to
+        , const QString &subject, const QString &body, QObject *parent)
+    : QObject(parent)
+    , m_from {from}
+    , m_rcpt {to}
+{
     m_socket = new QSslSocket(this);
 
-    connect(m_socket, &QIODevice::readyRead, this, &Smtp::readyRead);
+    connect(m_socket, &QIODevice::readyRead, this, &SMTPClient::readyRead);
     connect(m_socket, &QAbstractSocket::disconnected, this, &QObject::deleteLater);
-    connect(m_socket, &QAbstractSocket::errorOccurred, this, &Smtp::error);
+    connect(m_socket, &QAbstractSocket::errorOccurred, this, &SMTPClient::error);
 
     // Test hmacMD5 function (http://www.faqs.org/rfcs/rfc2202.html)
     Q_ASSERT(hmacMD5("Jefe", "what do ya want for nothing?").toHex()
-             == "750c783e6ab0b503eaa86e310a5db738");
+            == "750c783e6ab0b503eaa86e310a5db738");
     Q_ASSERT(hmacMD5(QByteArray::fromHex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"), "Hi There").toHex()
-             == "9294727a3638bb1c13f48ef8158bfc9d");
-}
+            == "9294727a3638bb1c13f48ef8158bfc9d");
 
-Smtp::~Smtp()
-{
-    qDebug() << Q_FUNC_INFO;
-}
-
-void Smtp::sendMail(const QString &from, const QString &to, const QString &subject, const QString &body)
-{
     const Preferences *const pref = Preferences::instance();
+
     m_message = "Date: " + getCurrentDateTime().toLatin1() + "\r\n"
-                + encodeMimeHeader(u"From"_s, u"qBittorrent <%1>"_s.arg(from))
-                + encodeMimeHeader(u"Subject"_s, subject)
-                + encodeMimeHeader(u"To"_s, to)
-                + "MIME-Version: 1.0\r\n"
-                + "Content-Type: text/plain; charset=UTF-8\r\n"
-                + "Content-Transfer-Encoding: base64\r\n"
-                + "\r\n";
+            + encodeMimeHeader(u"From"_s, u"qBittorrent <%1>"_s.arg(from))
+            + encodeMimeHeader(u"Subject"_s, subject)
+            + encodeMimeHeader(u"To"_s, to)
+            + "MIME-Version: 1.0\r\n"
+            + "Content-Type: text/plain; charset=UTF-8\r\n"
+            + "Content-Transfer-Encoding: base64\r\n"
+            + "\r\n";
     // Encode the body in base64
     QString crlfBody = body;
     const QByteArray b = crlfBody.replace(u"\n"_s, u"\r\n"_s).toUtf8().toBase64();
     for (qsizetype i = 0, end = b.length(); i < end; i += 78)
         m_message += b.mid(i, 78);
-    m_from = from;
-    m_rcpt = to;
+
     // Authentication
     if (pref->getMailNotificationSMTPAuth())
     {
@@ -149,7 +198,6 @@ void Smtp::sendMail(const QString &from, const QString &to, const QString &subje
     const QStringList serverEndpoint = pref->getMailNotificationSMTP().split(u':');
     const QString &serverAddress = serverEndpoint[0];
     const std::optional<int> serverPort = Utils::String::parseInt(serverEndpoint.value(1));
-    m_usingStartTls = false;
 
     // Decide connection method based on requested SMTP encryption type
     switch (pref->getMailNotificationSMTPEncryptionType())
@@ -168,7 +216,12 @@ void Smtp::sendMail(const QString &from, const QString &to, const QString &subje
     }
 }
 
-void Smtp::readyRead()
+Net::SMTPClient::~SMTPClient()
+{
+    qDebug() << Q_FUNC_INFO;
+}
+
+void Net::SMTPClient::readyRead()
 {
     qDebug() << Q_FUNC_INFO;
     const Preferences *const pref = Preferences::instance();
@@ -315,52 +368,7 @@ void Smtp::readyRead()
     }
 }
 
-QByteArray Smtp::encodeMimeHeader(const QString &key, const QString &value, const QByteArray &prefix)
-{
-    QByteArray rv = "";
-    QByteArray line = key.toLatin1() + ": ";
-    if (!prefix.isEmpty()) line += prefix;
-    if (!value.contains(u"=?") && canEncodeAsLatin1(value))
-    {
-        bool firstWord = true;
-        for (const QByteArray &word : asConst(value.toLatin1().split(' ')))
-        {
-            if (line.size() > 78)
-            {
-                rv = rv + line + "\r\n";
-                line.clear();
-            }
-            if (firstWord)
-                line += word;
-            else
-                line += ' ' + word;
-            firstWord = false;
-        }
-    }
-    else
-    {
-        // The text cannot be losslessly encoded as Latin-1. Therefore, we
-        // must use base64 encoding.
-        const QByteArray utf8 = value.toUtf8();
-        // Use base64 encoding
-        const QByteArray base64 = utf8.toBase64();
-        const qsizetype ct = base64.length();
-        line += "=?utf-8?b?";
-        for (int i = 0; i < ct; i += 4)
-        {
-            /*if (line.length() > 72)
-            {
-               rv += line + "?\n\r";
-               line = " =?utf-8?b?";
-               }*/
-            line = line + base64.mid(i, 4);
-        }
-        line += "?="; // end encoded-word atom
-    }
-    return rv + line + "\r\n";
-}
-
-void Smtp::ehlo()
+void Net::SMTPClient::ehlo()
 {
     const QByteArray address = determineFQDN();
     m_socket->write("ehlo " + address + "\r\n");
@@ -368,7 +376,7 @@ void Smtp::ehlo()
     m_state = EhloSent;
 }
 
-void Smtp::helo()
+void Net::SMTPClient::helo()
 {
     const QByteArray address = determineFQDN();
     m_socket->write("helo " + address + "\r\n");
@@ -376,7 +384,7 @@ void Smtp::helo()
     m_state = HeloSent;
 }
 
-void Smtp::parseEhloResponse(const QByteArray &code, const bool continued, const QString &line)
+void Net::SMTPClient::parseEhloResponse(const QByteArray &code, const bool continued, const QString &line)
 {
     const Preferences *const pref = Preferences::instance();
     if (code != "250")
@@ -442,7 +450,7 @@ void Smtp::parseEhloResponse(const QByteArray &code, const bool continued, const
     }
 }
 
-void Smtp::authenticate()
+void Net::SMTPClient::authenticate()
 {
     qDebug() << Q_FUNC_INFO;
     if (!m_extensions.contains(u"AUTH"_s) ||
@@ -490,7 +498,7 @@ void Smtp::authenticate()
     }
 }
 
-void Smtp::startTLS()
+void Net::SMTPClient::startTLS()
 {
     qDebug() << Q_FUNC_INFO;
     m_socket->write("starttls\r\n");
@@ -499,7 +507,7 @@ void Smtp::startTLS()
     m_usingStartTls = true;
 }
 
-void Smtp::authCramMD5(const QByteArray &challenge)
+void Net::SMTPClient::authCramMD5(const QByteArray &challenge)
 {
     if (m_state != AuthRequestSent)
     {
@@ -518,7 +526,7 @@ void Smtp::authCramMD5(const QByteArray &challenge)
     }
 }
 
-void Smtp::authPlain()
+void Net::SMTPClient::authPlain()
 {
     if (m_state != AuthRequestSent)
     {
@@ -538,7 +546,7 @@ void Smtp::authPlain()
     }
 }
 
-void Smtp::authLogin()
+void Net::SMTPClient::authLogin()
 {
     if ((m_state != AuthRequestSent) && (m_state != AuthUsernameSent))
     {
@@ -561,22 +569,13 @@ void Smtp::authLogin()
     }
 }
 
-void Smtp::logError(const QString &msg)
+void Net::SMTPClient::logError(const QString &msg)
 {
     qDebug() << "Email Notification Error:" << msg;
     LogMsg(tr("Email Notification Error: %1").arg(msg), Log::WARNING);
 }
 
-QString Smtp::getCurrentDateTime() const
-{
-    // [rfc2822] 3.3. Date and Time Specification
-    const auto now = QDateTime::currentDateTime();
-    const QLocale eng {QLocale::English};
-    const QString weekday = eng.dayName(now.date().dayOfWeek(), QLocale::ShortFormat);
-    return (weekday + u", " + now.toString(Qt::RFC2822Date));
-}
-
-void Smtp::error(QAbstractSocket::SocketError socketError)
+void Net::SMTPClient::error(QAbstractSocket::SocketError socketError)
 {
     const Preferences *const pref = Preferences::instance();
     // Getting a remote host closed error is apparently normal, even when successfully sending

--- a/src/base/net/smtpclient.h
+++ b/src/base/net/smtpclient.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -38,8 +39,6 @@
 #include <QObject>
 #include <QString>
 
-#include "smtpencryptiontype.h"
-
 class QSslSocket;
 
 namespace Net
@@ -48,16 +47,15 @@ namespace Net
     const short SMTP_DEFAULT_PORT_SSL = 465;
     const short SMTP_DEFAULT_PORT_STARTTLS = 587;
 
-    class Smtp : public QObject
+    class SMTPClient final : public QObject
     {
         Q_OBJECT
-        Q_DISABLE_COPY_MOVE(Smtp)
+        Q_DISABLE_COPY_MOVE(SMTPClient)
 
     public:
-        Smtp(QObject *parent = nullptr);
-        ~Smtp();
-
-        void sendMail(const QString &from, const QString &to, const QString &subject, const QString &body);
+        static void sendMail(const QString &from, const QString &to
+                , const QString &subject, const QString &body
+                , QObject *context = nullptr);
 
     private slots:
         void readyRead();
@@ -90,7 +88,10 @@ namespace Net
             AuthCramMD5
         };
 
-        QByteArray encodeMimeHeader(const QString &key, const QString &value, const QByteArray &prefix = {});
+        SMTPClient(const QString &from, const QString &to, const QString &subject
+                   , const QString &body, QObject *parent = nullptr);
+        ~SMTPClient() override;
+
         void ehlo();
         void helo();
         void parseEhloResponse(const QByteArray &code, bool continued, const QString &line);
@@ -100,7 +101,6 @@ namespace Net
         void authPlain();
         void authLogin();
         void logError(const QString &msg);
-        QString getCurrentDateTime() const;
 
         QByteArray m_message;
         QSslSocket *m_socket = nullptr;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -52,7 +52,7 @@
 #include "base/global.h"
 #include "base/net/portforwarder.h"
 #include "base/net/proxyconfigurationmanager.h"
-#include "base/net/smtp.h"
+#include "base/net/smtpclient.h"
 #include "base/path.h"
 #include "base/preferences.h"
 #include "base/rss/rss_autodownloader.h"


### PR DESCRIPTION
* Now creating SMTP sender object is hidden behind the scenes since it is actually an implementation detail.
* The class is also renamed to a more specific name instead of the very generic `SMTP`.