### PR TITLE
Remove invalid assertion

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2849,7 +2849,6 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
 
         const auto nativeIndexes = torrentInfo.nativeIndexes();
 
-        Q_ASSERT(p.file_priorities.empty());
         Q_ASSERT(addTorrentParams.filePriorities.isEmpty() || (addTorrentParams.filePriorities.size() == nativeIndexes.size()));
         QList<DownloadPriority> filePriorities = addTorrentParams.filePriorities;
 


### PR DESCRIPTION
Closes #24310.

There is a chance `p.file_priorities` will not be empty (if you use a magnet link with `so` param) therefore this Q_ASSERT is invalid and should be removed.

qBittorrent also ignores libtorrent file priorities so adding an assert on  `p.file_priorities`  is redundant.

https://github.com/qbittorrent/qBittorrent/blob/0c5f84ef7c385f3fd5b271627ef60aacab12f213/src/base/bittorrent/sessionimpl.cpp#L2872