### PR TITLE
Fix Windows Python fallback search path

### DIFF
--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -164,7 +164,7 @@ namespace
         const QFileInfoList dirs = QDir(u"C:/"_s).entryInfoList({u"Python*"_s}, QDir::Dirs, (QDir::Name | QDir::Reversed));
         for (const QFileInfo &info : dirs)
         {
-            const Path absPath {info.absolutePath()};
+            const Path absPath {info.absoluteFilePath()};
 
             if (const Path path = (absPath / Path(u"python3.exe"_s)); path.exists())
                 ret.append(path);


### PR DESCRIPTION
Part of #24311.

The Windows fallback Python discovery scans `C:/Python*` directories, but it used `QFileInfo::absolutePath()` for each directory entry. That returns the parent path (`C:/`), so the fallback probed `C:/python3.exe` and `C:/python.exe` instead of the executable inside each Python install directory.

This change uses `absoluteFilePath()` so fallback discovery checks the actual matched directory, e.g. `C:/Python311/python.exe`.

Validation:
- `git diff --check origin/master..HEAD`

I did not run a Windows build locally.
