### PR TITLE
WebAPI: Allow seeding lifetime stats on torrent add

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -2,6 +2,8 @@
 
 ## 2.16.0
 
+* [#24326](https://github.com/qbittorrent/qBittorrent/pull/24326)
+  * `torrents/add` endpoint accepts optional `stats` JSON object to seed lifetime statistics (`total_uploaded`, `total_downloaded`, `added_time`, `completed_time`, `last_seen_complete`, `last_upload`, `last_download`, `active_time`, `finished_time`, `seeding_time`)
 * [#24724](https://github.com/qbittorrent/qBittorrent/pull/24724)
   * `torrents/add` endpoint accepts `seedMode` (bool) parameter
   * `torrents/add` endpoint no longer accepts `skip_checking` parameter

--- a/src/base/bittorrent/addtorrentparams.cpp
+++ b/src/base/bittorrent/addtorrentparams.cpp
@@ -143,7 +143,8 @@ BitTorrent::AddTorrentParams BitTorrent::parseAddTorrentParams(const QJsonObject
             .certificate = QSslCertificate(jsonObj.value(PARAM_SSL_CERTIFICATE).toString().toLatin1()),
             .privateKey = Utils::SSLKey::load(jsonObj.value(PARAM_SSL_PRIVATEKEY).toString().toLatin1()),
             .dhParams = jsonObj.value(PARAM_SSL_DHPARAMS).toString().toLatin1()
-        }
+        },
+        .initialStats = {}
     };
     return params;
 }

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -50,16 +50,16 @@ namespace BitTorrent
     // Optional lifetime stats to seed on torrent add
     struct InitialTorrentStats
     {
-        std::optional<qint64> totalUploaded;
-        std::optional<qint64> totalDownloaded;
-        std::optional<qint64> addedTime;          // posix seconds
-        std::optional<qint64> completedTime;      // posix seconds
-        std::optional<qint64> lastSeenComplete;   // posix seconds
-        std::optional<qint64> lastUpload;         // posix seconds
-        std::optional<qint64> lastDownload;       // posix seconds
-        std::optional<int> activeTime;            // seconds
-        std::optional<int> finishedTime;          // seconds
-        std::optional<int> seedingTime;           // seconds
+        qint64 totalUploaded = 0;
+        qint64 totalDownloaded = 0;
+        qint64 addedTime = 0;          // posix seconds
+        qint64 completedTime = 0;      // posix seconds
+        qint64 lastSeenComplete = 0;   // posix seconds
+        qint64 lastUpload = 0;         // posix seconds
+        qint64 lastDownload = 0;       // posix seconds
+        int activeTime = 0;            // seconds
+        int finishedTime = 0;          // seconds
+        int seedingTime = 0;           // seconds
 
         friend bool operator==(const InitialTorrentStats &lhs, const InitialTorrentStats &rhs) = default;
     };

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -47,6 +47,23 @@ namespace BitTorrent
 {
     enum class DownloadPriority;
 
+    // Optional lifetime stats to seed on torrent add
+    struct InitialTorrentStats
+    {
+        std::optional<qint64> totalUploaded;
+        std::optional<qint64> totalDownloaded;
+        std::optional<qint64> addedTime;          // posix seconds
+        std::optional<qint64> completedTime;      // posix seconds
+        std::optional<qint64> lastSeenComplete;   // posix seconds
+        std::optional<qint64> lastUpload;         // posix seconds
+        std::optional<qint64> lastDownload;       // posix seconds
+        std::optional<int> activeTime;            // seconds
+        std::optional<int> finishedTime;          // seconds
+        std::optional<int> seedingTime;           // seconds
+
+        friend bool operator==(const InitialTorrentStats &lhs, const InitialTorrentStats &rhs) = default;
+    };
+
     struct AddTorrentParams
     {
         QString name;
@@ -70,6 +87,7 @@ namespace BitTorrent
         int downloadLimit = -1;
         ShareLimits shareLimits;
         SSLParameters sslParameters;
+        std::optional<InitialTorrentStats> initialStats;
 
         friend bool operator==(const AddTorrentParams &lhs, const AddTorrentParams &rhs) = default;
     };

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -48,7 +48,7 @@ namespace BitTorrent
     enum class DownloadPriority;
 
     // Optional lifetime stats to seed on torrent add
-    struct InitialTorrentStats
+    struct TorrentStats
     {
         qint64 totalUploaded = 0;
         qint64 totalDownloaded = 0;
@@ -61,7 +61,7 @@ namespace BitTorrent
         int finishedTime = 0;          // seconds
         int seedingTime = 0;           // seconds
 
-        friend bool operator==(const InitialTorrentStats &lhs, const InitialTorrentStats &rhs) = default;
+        friend bool operator==(const TorrentStats &lhs, const TorrentStats &rhs) = default;
     };
 
     struct AddTorrentParams
@@ -87,7 +87,7 @@ namespace BitTorrent
         int downloadLimit = -1;
         ShareLimits shareLimits;
         SSLParameters sslParameters;
-        std::optional<InitialTorrentStats> initialStats;
+        std::optional<TorrentStats> initialStats;
 
         friend bool operator==(const AddTorrentParams &lhs, const AddTorrentParams &rhs) = default;
     };

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2861,6 +2861,13 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &torrentDescr, const A
     {
         // a duplicate torrent is being added
 
+        if (addTorrentParams.initialStats)
+        {
+            LogMsg(tr("Initial stats supplied for an already-existing torrent were ignored."
+                      " Existing torrent: \"%1\". Torrent infohash: %2")
+                    .arg(torrent->name(), torrent->infoHash().toString()), Log::WARNING);
+        }
+
         if (hasMetadata)
         {
             // Trying to set metadata to existing torrent in case if it has none
@@ -3062,6 +3069,32 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &torrentDescr, const A
     p.flags |= lt::torrent_flags::duplicate_is_error;
 
     p.added_time = std::time(nullptr);
+
+    // Seed optional lifetime stats
+    if (addTorrentParams.initialStats)
+    {
+        const InitialTorrentStats &s = *addTorrentParams.initialStats;
+        if (s.totalUploaded)
+            p.total_uploaded = *s.totalUploaded;
+        if (s.totalDownloaded)
+            p.total_downloaded = *s.totalDownloaded;
+        if (s.addedTime)
+            p.added_time = static_cast<std::time_t>(*s.addedTime);
+        if (s.completedTime)
+            p.completed_time = static_cast<std::time_t>(*s.completedTime);
+        if (s.lastSeenComplete)
+            p.last_seen_complete = static_cast<std::time_t>(*s.lastSeenComplete);
+        if (s.lastUpload)
+            p.last_upload = static_cast<std::time_t>(*s.lastUpload);
+        if (s.lastDownload)
+            p.last_download = static_cast<std::time_t>(*s.lastDownload);
+        if (s.activeTime)
+            p.active_time = *s.activeTime;
+        if (s.finishedTime)
+            p.finished_time = *s.finishedTime;
+        if (s.seedingTime)
+            p.seeding_time = *s.seedingTime;
+    }
 
     // Limits
     p.max_connections = maxConnectionsPerTorrent();

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -3074,26 +3074,16 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &torrentDescr, const A
     if (addTorrentParams.initialStats)
     {
         const InitialTorrentStats &s = *addTorrentParams.initialStats;
-        if (s.totalUploaded)
-            p.total_uploaded = *s.totalUploaded;
-        if (s.totalDownloaded)
-            p.total_downloaded = *s.totalDownloaded;
-        if (s.addedTime)
-            p.added_time = static_cast<std::time_t>(*s.addedTime);
-        if (s.completedTime)
-            p.completed_time = static_cast<std::time_t>(*s.completedTime);
-        if (s.lastSeenComplete)
-            p.last_seen_complete = static_cast<std::time_t>(*s.lastSeenComplete);
-        if (s.lastUpload)
-            p.last_upload = static_cast<std::time_t>(*s.lastUpload);
-        if (s.lastDownload)
-            p.last_download = static_cast<std::time_t>(*s.lastDownload);
-        if (s.activeTime)
-            p.active_time = *s.activeTime;
-        if (s.finishedTime)
-            p.finished_time = *s.finishedTime;
-        if (s.seedingTime)
-            p.seeding_time = *s.seedingTime;
+        p.total_uploaded = s.totalUploaded;
+        p.total_downloaded = s.totalDownloaded;
+        p.added_time = static_cast<std::time_t>(s.addedTime);
+        p.completed_time = static_cast<std::time_t>(s.completedTime);
+        p.last_seen_complete = static_cast<std::time_t>(s.lastSeenComplete);
+        p.last_upload = static_cast<std::time_t>(s.lastUpload);
+        p.last_download = static_cast<std::time_t>(s.lastDownload);
+        p.active_time = s.activeTime;
+        p.finished_time = s.finishedTime;
+        p.seeding_time = s.seedingTime;
     }
 
     // Limits

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -3073,7 +3073,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &torrentDescr, const A
     // Seed optional lifetime stats
     if (addTorrentParams.initialStats)
     {
-        const InitialTorrentStats &s = *addTorrentParams.initialStats;
+        const TorrentStats &s = *addTorrentParams.initialStats;
         p.total_uploaded = s.totalUploaded;
         p.total_downloaded = s.totalDownloaded;
         p.added_time = static_cast<std::time_t>(s.addedTime);

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -36,7 +36,9 @@
 #include <QFileInfo>
 #include <QFuture>
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonValue>
 #include <QList>
 #include <QRegularExpression>
 #include <QUrl>
@@ -1078,6 +1080,53 @@ void TorrentsController::pieceAvailabilityAction()
     setResult(pieceAvailability);
 }
 
+namespace
+{
+    std::optional<BitTorrent::InitialTorrentStats> parseInitialStats(const QString &rawJson)
+    {
+        if (rawJson.isEmpty())
+            return std::nullopt;
+
+        QJsonParseError parseError;
+        const QJsonDocument doc = QJsonDocument::fromJson(rawJson.toUtf8(), &parseError);
+        if (parseError.error != QJsonParseError::NoError)
+            throw APIError(APIErrorType::BadParams, u"`stats` must be a JSON object: "_s + parseError.errorString());
+        if (!doc.isObject())
+            throw APIError(APIErrorType::BadParams, u"`stats` must be a JSON object"_s);
+
+        const QJsonObject obj = doc.object();
+        BitTorrent::InitialTorrentStats stats;
+
+        const auto readInt64 = [&obj](const QString &key) -> std::optional<qint64>
+        {
+            const QJsonValue v = obj.value(key);
+            if (v.isUndefined() || v.isNull())
+                return std::nullopt;
+            return v.toVariant().toLongLong();
+        };
+        const auto readInt = [&obj](const QString &key) -> std::optional<int>
+        {
+            const QJsonValue v = obj.value(key);
+            if (v.isUndefined() || v.isNull())
+                return std::nullopt;
+            return v.toVariant().toInt();
+        };
+
+        stats.totalUploaded = readInt64(u"total_uploaded"_s);
+        stats.totalDownloaded = readInt64(u"total_downloaded"_s);
+        stats.addedTime = readInt64(u"added_time"_s);
+        stats.completedTime = readInt64(u"completed_time"_s);
+        stats.lastSeenComplete = readInt64(u"last_seen_complete"_s);
+        stats.lastUpload = readInt64(u"last_upload"_s);
+        stats.lastDownload = readInt64(u"last_download"_s);
+        stats.activeTime = readInt(u"active_time"_s);
+        stats.finishedTime = readInt(u"finished_time"_s);
+        stats.seedingTime = readInt(u"seeding_time"_s);
+
+        return stats;
+    }
+}
+
 void TorrentsController::addAction()
 {
     const QStringList urls = params()[u"urls"_s].split(u'\n', Qt::SkipEmptyParts);
@@ -1112,6 +1161,8 @@ void TorrentsController::addAction()
     const std::optional<BitTorrent::TorrentContentLayout> contentLayout = (!contentLayoutParam.isEmpty()
             ? Utils::String::toEnum(contentLayoutParam, BitTorrent::TorrentContentLayout::Original)
             : std::optional<BitTorrent::TorrentContentLayout> {});
+
+    const std::optional<BitTorrent::InitialTorrentStats> initialStats = parseInitialStats(params()[u"stats"_s]);
 
     const DataMap &torrents = data();
 
@@ -1172,7 +1223,8 @@ void TorrentsController::addAction()
             .certificate = QSslCertificate(params()[KEY_PROP_SSL_CERTIFICATE].toLatin1()),
             .privateKey = Utils::SSLKey::load(params()[KEY_PROP_SSL_PRIVATEKEY].toLatin1()),
             .dhParams = params()[KEY_PROP_SSL_DHPARAMS].toLatin1()
-        }
+        },
+        .initialStats = initialStats
     };
 
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1090,9 +1090,9 @@ namespace
         QJsonParseError parseError;
         const QJsonDocument doc = QJsonDocument::fromJson(rawJson.toUtf8(), &parseError);
         if (parseError.error != QJsonParseError::NoError)
-            throw APIError(APIErrorType::BadParams, u"`stats` must be a JSON object: "_s + parseError.errorString());
+            throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats` must be a JSON object: %1").arg(parseError.errorString()));
         if (!doc.isObject())
-            throw APIError(APIErrorType::BadParams, u"`stats` must be a JSON object"_s);
+            throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats` must be a JSON object"));
 
         const QJsonObject obj = doc.object();
 
@@ -1100,14 +1100,14 @@ namespace
         {
             const QJsonValue v = obj.value(key);
             if (v.isUndefined() || v.isNull())
-                throw APIError(APIErrorType::BadParams, u"`stats.%1` is required"_s.arg(key));
+                throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats.%1` is required").arg(key));
             return v.toVariant().toLongLong();
         };
         const auto readInt = [&obj](const QString &key) -> int
         {
             const QJsonValue v = obj.value(key);
             if (v.isUndefined() || v.isNull())
-                throw APIError(APIErrorType::BadParams, u"`stats.%1` is required"_s.arg(key));
+                throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats.%1` is required").arg(key));
             return v.toVariant().toInt();
         };
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1095,23 +1095,23 @@ namespace
             throw APIError(APIErrorType::BadParams, u"`stats` must be a JSON object"_s);
 
         const QJsonObject obj = doc.object();
-        BitTorrent::InitialTorrentStats stats;
 
-        const auto readInt64 = [&obj](const QString &key) -> std::optional<qint64>
+        const auto readInt64 = [&obj](const QString &key) -> qint64
         {
             const QJsonValue v = obj.value(key);
             if (v.isUndefined() || v.isNull())
-                return std::nullopt;
+                throw APIError(APIErrorType::BadParams, u"`stats.%1` is required"_s.arg(key));
             return v.toVariant().toLongLong();
         };
-        const auto readInt = [&obj](const QString &key) -> std::optional<int>
+        const auto readInt = [&obj](const QString &key) -> int
         {
             const QJsonValue v = obj.value(key);
             if (v.isUndefined() || v.isNull())
-                return std::nullopt;
+                throw APIError(APIErrorType::BadParams, u"`stats.%1` is required"_s.arg(key));
             return v.toVariant().toInt();
         };
 
+        BitTorrent::InitialTorrentStats stats;
         stats.totalUploaded = readInt64(u"total_uploaded"_s);
         stats.totalDownloaded = readInt64(u"total_downloaded"_s);
         stats.addedTime = readInt64(u"added_time"_s);

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1166,6 +1166,9 @@ void TorrentsController::addAction()
 
     const DataMap &torrents = data();
 
+    if (initialStats && ((urls.size() + torrents.size()) > 1))
+        throw APIError(APIErrorType::BadParams, tr("Cannot specify stats when adding multiple torrents"));
+
     QList<BitTorrent::DownloadPriority> filePriorities;
     const QStringList filePrioritiesParam = params()[u"filePriorities"_s].split(u',', Qt::SkipEmptyParts);
     if (!filePrioritiesParam.isEmpty())

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <chrono>
 #include <concepts>
+#include <limits>
 
 #include <QBitArray>
 #include <QFileInfo>
@@ -1101,14 +1102,19 @@ namespace
             const QJsonValue v = obj.value(key);
             if (v.isUndefined() || v.isNull())
                 throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats.%1` is required").arg(key));
-            return v.toVariant().toLongLong();
+            if (!v.isDouble())
+                throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats.%1` must be a number").arg(key));
+            const qint64 value = v.toInteger(-1);
+            if (value < 0)
+                throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats.%1` must be a non-negative integer").arg(key));
+            return value;
         };
-        const auto readInt = [&obj](const QString &key) -> int
+        const auto readInt = [&readInt64](const QString &key) -> int
         {
-            const QJsonValue v = obj.value(key);
-            if (v.isUndefined() || v.isNull())
-                throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats.%1` is required").arg(key));
-            return v.toVariant().toInt();
+            const qint64 value = readInt64(key);
+            if (value > std::numeric_limits<int>::max())
+                throw APIError(APIErrorType::BadParams, QCoreApplication::translate("TorrentsController", "`stats.%1` is out of range").arg(key));
+            return static_cast<int>(value);
         };
 
         BitTorrent::InitialTorrentStats stats;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1083,7 +1083,7 @@ void TorrentsController::pieceAvailabilityAction()
 
 namespace
 {
-    std::optional<BitTorrent::InitialTorrentStats> parseInitialStats(const QString &rawJson)
+    std::optional<BitTorrent::TorrentStats> parseInitialStats(const QString &rawJson)
     {
         if (rawJson.isEmpty())
             return std::nullopt;
@@ -1117,7 +1117,7 @@ namespace
             return static_cast<int>(value);
         };
 
-        BitTorrent::InitialTorrentStats stats;
+        BitTorrent::TorrentStats stats;
         stats.totalUploaded = readInt64(u"total_uploaded"_s);
         stats.totalDownloaded = readInt64(u"total_downloaded"_s);
         stats.addedTime = readInt64(u"added_time"_s);
@@ -1168,7 +1168,7 @@ void TorrentsController::addAction()
             ? Utils::String::toEnum(contentLayoutParam, BitTorrent::TorrentContentLayout::Original)
             : std::optional<BitTorrent::TorrentContentLayout> {});
 
-    const std::optional<BitTorrent::InitialTorrentStats> initialStats = parseInitialStats(params()[u"stats"_s]);
+    const std::optional<BitTorrent::TorrentStats> initialStats = parseInitialStats(params()[u"stats"_s]);
 
     const DataMap &torrents = data();
 


### PR DESCRIPTION
### what it does
adds an optional `stats` json object to `POST /api/v2/torrents/add` that populates the lifetime stat fields in `lt::add_torrent_params`

- total_uploaded
- total_downloaded
- added_time
- completed_time
- last_seen_complete
- last_upload
- last_download
- active_time
- finished_time
- seeding_time

these are the same fields libtorrents `read_resume_data()` writes to when loading a `.fastresume` file on session startup, just exposed through the api, tracker announces are unaffected since libtorrents announce uses a separate session counter that always starts at zero and omitting `stats` produces identical behavior to today

### motivation
migrating torrents between qbit instances or from other clients currently requires editing resume data files and restarting qbit to load them, this routes the same data through libtorrents existing fields via the api so external tooling can carry history across without restarting
