### PR TITLE
CI: Add Windows ARM build

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -35,6 +35,9 @@ jobs:
         - os: windows-latest
           arch: x64
           qt_arch: win64_msvc2022_64
+        - os: windows-11-arm
+          arch: arm64
+          qt_arch: win64_msvc2022_arm64
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -126,7 +126,7 @@ namespace
 #ifdef Q_PROCESSOR_X86_64
     const QString PYTHON_INSTALLER_URL = u"https://www.python.org/ftp/python/3.14.5/python-3.14.5-amd64.exe"_s;
     const QByteArray PYTHON_INSTALLER_SHA2_256 = QByteArrayLiteral("f9c09f5ed6f796fd1a8bc5ddfa41715a494b453c4781f0e35d5077cf9fa58f6d");
-#elif Q_PROCESSOR_ARM_64
+#elif defined(Q_PROCESSOR_ARM_64)
     const QString PYTHON_INSTALLER_URL = u"https://www.python.org/ftp/python/3.14.5/python-3.14.5-arm64.exe"_s;
     const QByteArray PYTHON_INSTALLER_SHA2_256 = QByteArrayLiteral("f4a7df6ab4fa375cd7296127ff6b9a14fbd1313f51864ce020185deba10144fa");
 #endif


### PR DESCRIPTION
The following pull request was incomplete, it didn't actually build/create any GitHub Windows ARM artifacts:
https://github.com/qbittorrent/qBittorrent/pull/23328

This pull requests fixes that and also fixes a build issue with mainwindow.cpp:

src/gui/mainwindow.cpp:129 used #elif Q_PROCESSOR_ARM_64 (no defined()). Qt defines Q_PROCESSOR_ARM_64 as an empty macro, so the #elif expanded to a blank expression, which MSVC rejects with C1017. On x64 the bug was invisible because #ifdef Q_PROCESSOR_X86_64 matched first and the #elif line was never evaluated. On ARM64, the #elif line gets evaluated, and the build dies.
 
This will also resolve the following open issue:
https://github.com/qbittorrent/qBittorrent/issues/24176

Note: On a clean Windows Sandbox environment the Visual C++ runtime for Windows ARM must be installed:
https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
https://aka.ms/vc14/vc_redist.arm64.exe

I tested/installed/ran all 3 Windows ARM installers built by GitHub (1.2.20, 2.0.12, and 2.1.0-rc1) on my fork.

Screenshot proof of the application running and downloading a Linux ISO torrent as native Windows ARM binary on a Asus Zenbook A16 Snapdragon X2 Elite running Windows 11 ARM 26H1 under a Windows Sandbox environment: 

<img width="824" height="541" alt="image" src="https://github.com/user-attachments/assets/e0262c2d-c203-4697-b22f-bdf2cfab0271" />
