### PR TITLE
Fix Windows ARM build

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -122,8 +122,8 @@ namespace
 
     const std::chrono::seconds PREVENT_SUSPEND_INTERVAL {60};
 
-#ifdef Q_OS_WIN
-#ifdef Q_PROCESSOR_X86_64
+#if defined(Q_OS_WIN)
+#if defined(Q_PROCESSOR_X86_64)
     const QString PYTHON_INSTALLER_URL = u"https://www.python.org/ftp/python/3.14.5/python-3.14.5-amd64.exe"_s;
     const QByteArray PYTHON_INSTALLER_SHA2_256 = QByteArrayLiteral("f9c09f5ed6f796fd1a8bc5ddfa41715a494b453c4781f0e35d5077cf9fa58f6d");
 #elif defined(Q_PROCESSOR_ARM_64)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -126,7 +126,7 @@ namespace
 #ifdef Q_PROCESSOR_X86_64
     const QString PYTHON_INSTALLER_URL = u"https://www.python.org/ftp/python/3.14.5/python-3.14.5-amd64.exe"_s;
     const QByteArray PYTHON_INSTALLER_SHA2_256 = QByteArrayLiteral("f9c09f5ed6f796fd1a8bc5ddfa41715a494b453c4781f0e35d5077cf9fa58f6d");
-#elif Q_PROCESSOR_ARM_64
+#elif defined(Q_PROCESSOR_ARM_64)
     const QString PYTHON_INSTALLER_URL = u"https://www.python.org/ftp/python/3.14.5/python-3.14.5-arm64.exe"_s;
     const QByteArray PYTHON_INSTALLER_SHA2_256 = QByteArrayLiteral("f4a7df6ab4fa375cd7296127ff6b9a14fbd1313f51864ce020185deba10144fa");
 #endif


### PR DESCRIPTION
This pull request fixes a Windows ARM build issue with mainwindow.cpp:

src/gui/mainwindow.cpp:129 used #elif Q_PROCESSOR_ARM_64 (no defined()). Qt defines Q_PROCESSOR_ARM_64 as an empty macro, so the #elif expanded to a blank expression, which MSVC rejects with C1017. On x64 the bug was invisible because #ifdef Q_PROCESSOR_X86_64 matched first and the #elif line was never evaluated. On ARM64, the #elif line gets evaluated, and the build dies.

Original old pull request for reference:

https://github.com/qbittorrent/qBittorrent/pull/24328

Closes #24176.