### PR TITLE
GHA CI: Add Windows ARM build

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -35,6 +35,9 @@ jobs:
         - os: windows-latest
           arch: x64
           qt_arch: win64_msvc2022_64
+        - os: windows-11-arm
+          arch: arm64
+          qt_arch: win64_msvc2022_arm64
 
     env:
       boost_path: "${{ github.workspace }}/../boost"


### PR DESCRIPTION
The following pull request was incomplete, it didn't actually build/create any GitHub Windows ARM artifacts:
https://github.com/qbittorrent/qBittorrent/pull/23328

This pull requests resolves that.

Note: On a clean Windows Sandbox environment the Visual C++ runtime for Windows ARM must be installed:
https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
https://aka.ms/vc14/vc_redist.arm64.exe

I tested/installed/ran all 3 Windows ARM installers built by GitHub (1.2.20, 2.0.12, and 2.1.0-rc1) on my fork.

Screenshot proof of the application running and downloading a Linux ISO torrent as native Windows ARM binary on a Asus Zenbook A16 Snapdragon X2 Elite running Windows 11 ARM 26H1 under a Windows Sandbox environment: 

<img width="824" height="541" alt="image" src="https://github.com/user-attachments/assets/e0262c2d-c203-4697-b22f-bdf2cfab0271" />

Depends on https://github.com/qbittorrent/qBittorrent/pull/24334. Once that is merged will move this out of draft form.
