### PR TITLE
Add support for magnet link 'so' parameter

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2868,13 +2868,17 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         const lt::file_storage internalFiles = torrentInfo.nativeInfo()->files();
 #endif
         const int internalFilesCount = internalFiles.num_files(); // including .pad files
-        // Use qBittorrent default priority rather than libtorrent's (4)
-        p.file_priorities = std::vector(internalFilesCount, LT::toNative(DownloadPriority::Normal));
-
         if (!filePriorities.isEmpty())
         {
+            // Use qBittorrent default priority rather than libtorrent's (4)
+            p.file_priorities = std::vector(internalFilesCount, LT::toNative(DownloadPriority::Normal));
             for (qsizetype i = 0; i < filePriorities.size(); ++i)
                 p.file_priorities[LT::toUnderlyingType(nativeIndexes[i])] = LT::toNative(filePriorities[i]);
+        }
+        else if (p.file_priorities.empty())
+        {
+            // Use qBittorrent default priority rather than libtorrent's (4)
+            p.file_priorities = std::vector(internalFilesCount, LT::toNative(DownloadPriority::Normal));
         }
 
         Q_ASSERT(p.ti);

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -53,6 +53,7 @@
 #include "base/bittorrent/addtorrentparams.h"
 #include "base/bittorrent/downloadpriority.h"
 #include "base/bittorrent/infohash.h"
+#include "base/bittorrent/lttypecast.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/torrentcontenthandler.h"
@@ -928,6 +929,27 @@ void AddNewTorrentDialog::setupTreeview()
     BitTorrent::AddTorrentParams &addTorrentParams = m_currentContext->torrentParams;
     if (addTorrentParams.filePaths.isEmpty())
         addTorrentParams.filePaths = torrentInfo.filePaths();
+
+    if (addTorrentParams.filePriorities.isEmpty())
+    {
+        lt::add_torrent_params p = torrentDescr.ltAddTorrentParams();
+        if (p.file_priorities.empty())
+        {
+            // Use qBittorrent default priority rather than libtorrent's (4)
+            addTorrentParams.filePriorities.resize(torrentInfo.filesCount(), BitTorrent::DownloadPriority::Normal);
+        }
+        else
+        {
+            addTorrentParams.filePriorities.resize(torrentInfo.filesCount(), BitTorrent::DownloadPriority::Ignored);
+            const auto nativeIndexes = torrentInfo.nativeIndexes();
+            for (qsizetype i = 0; i < nativeIndexes.size(); ++i)
+            {
+                const auto ordIndex = static_cast<std::size_t>(BitTorrent::LT::toUnderlyingType(nativeIndexes[i]));
+                if (ordIndex < p.file_priorities.size())
+                    addTorrentParams.filePriorities[i] = BitTorrent::LT::fromNative(p.file_priorities[ordIndex]);
+            }
+        }
+    }
 
     m_contentAdaptor = std::make_unique<TorrentContentAdaptor>(torrentInfo, addTorrentParams.filePaths
             , addTorrentParams.filePriorities, [this] { updateDiskSpaceLabel(); });


### PR DESCRIPTION
So now it supports an `so` parameter that specifies the files pre-selected for download.

Note that file indexes provided by `so` parameter are considered as "internal" file indexes that can refer to "hidden" pad files.