### PR TITLE
WebUI: Preserve torrent URL source encoding

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -2180,16 +2180,15 @@ void TorrentsController::fetchMetadataAction()
 {
     requireParams({u"source"_s});
 
-    const QString sourceParam = params()[u"source"_s].trimmed();
+    const QString source = params()[u"source"_s].trimmed();
     // must provide some value to parse
-    if (sourceParam.isEmpty())
+    if (source.isEmpty())
         throw APIError(APIErrorType::BadParams, tr("Must specify URI or hash"));
 
     const QString downloaderParam = params()[u"downloader"_s];
     if (!downloaderParam.isEmpty() && !SearchPluginManager::instance()->allPlugins().contains(downloaderParam))
         throw APIError(APIErrorType::BadParams, tr("downloader must be a valid search plugin"));
 
-    const QString source = QUrl::fromPercentEncoding(sourceParam.toLatin1());
     const auto sourceTorrentDescr = BitTorrent::TorrentDescriptor::parse(source);
 
     const BitTorrent::InfoHash infoHash = sourceTorrentDescr ? sourceTorrentDescr.value().infoHash() : m_torrentSourceCache.value(source);
@@ -2289,11 +2288,9 @@ void TorrentsController::saveMetadataAction()
 {
     requireParams({u"source"_s});
 
-    const QString sourceParam = params()[u"source"_s].trimmed();
-    if (sourceParam.isEmpty())
+    const QString source = params()[u"source"_s].trimmed();
+    if (source.isEmpty())
         throw APIError(APIErrorType::BadParams, tr("Must specify URI or hash"));
-
-    const QString source = QUrl::fromPercentEncoding(sourceParam.toLatin1());
 
     BitTorrent::InfoHash infoHash;
     if (const auto iter = m_torrentSourceCache.constFind(source); iter != m_torrentSourceCache.constEnd())


### PR DESCRIPTION
Closes #24303.

Preserves the WebUI torrent source string after request parsing so URLs containing escaped characters stay stable between metadata fetch/save and the final add request. This avoids decoding `%20` into a literal space before the source is fetched or matched against cached metadata.

Manual UI validation:
- macOS 27.0 (26A5353q), arm64; qBittorrent v5.3.0alpha1 WebUI-enabled Debug build.
- Served a synthetic `.torrent` file at `http://127.0.0.1:18084/test%20space.torrent`.
- Added it through WebUI Add Torrent Link, confirmed the second Add Torrent dialog loaded the torrent metadata and file list, then submitted Add Torrent.
- Confirmed the torrent appeared in the WebUI transfer list and `/api/v2/torrents/info` reported `qbt-24303-space-url-data.txt` with metadata.
