### PR TITLE
Add 'Ignore dotfiles' option in Torrent Creator

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,6 +1,9 @@
 # WebAPI Changelog
 
 ## 2.16.0
+* [#24346](https://github.com/qbittorrent/qBittorrent/pull/24346)
+  * `torrentcreator/addTask` endpoint accepts a new bool option `ignoreDotfiles` to control whether dotfiles are ignored
+  * `torrentcreator/status` endpoint returns a new bool field `ignoreDotfiles` for reporting whether dotfiles were ignored
 * [#24246](https://github.com/qbittorrent/qBittorrent/pull/24246)
   * `torrents/fetchMetadata` and `torrents/parseMetadata` endpoints include file `priority` when excluded file names apply
 * [#24210](https://github.com/qbittorrent/qBittorrent/pull/24210)

--- a/src/base/bittorrent/torrentcreator.cpp
+++ b/src/base/bittorrent/torrentcreator.cpp
@@ -64,6 +64,11 @@ namespace
         return !isDotfile(Path(f));
     }
 
+    bool noopFilter(std::string_view)
+    {
+        return true;
+    }
+
 #ifdef QBT_USES_LIBTORRENT2
     lt::create_flags_t toNativeTorrentFormatFlag(const BitTorrent::TorrentFormat torrentFormat)
     {
@@ -89,7 +94,7 @@ TorrentCreator::TorrentCreator(const TorrentCreatorParams &params, QObject *pare
 {
 }
 
-void TorrentCreator::sendProgressSignal(int currentPieceIdx, int totalPieces)
+void TorrentCreator::sendProgressSignal(const int currentPieceIdx, const int totalPieces)
 {
     emit progressUpdated(static_cast<int>((currentPieceIdx * 100.) / totalPieces));
 }
@@ -128,10 +133,11 @@ void TorrentCreator::run()
 #endif
         if (QFileInfo(m_params.sourcePath.data()).isFile())
         {
+            const auto &filter = m_params.ignoreDotfiles ? fileFilter : noopFilter;
 #if LIBTORRENT_VERSION_NUM >= 20100
-            files = lt::list_files(m_params.sourcePath.toString().toStdString(), fileFilter);
+            files = lt::list_files(m_params.sourcePath.toString().toStdString(), filter);
 #else
-            lt::add_files(files, m_params.sourcePath.toString().toStdString(), fileFilter);
+            lt::add_files(files, m_params.sourcePath.toString().toStdString(), filter);
 #endif
         }
         else
@@ -139,7 +145,7 @@ void TorrentCreator::run()
             // need to sort the file names by natural sort order
             QStringList dirs = {m_params.sourcePath.data()};
 
-            QDirIterator dirIter {m_params.sourcePath.data(), (QDir::AllDirs | QDir::NoDotAndDotDot), QDirIterator::Subdirectories};
+            QDirIterator dirIter {m_params.sourcePath.data(), (QDir::AllDirs | QDir::Hidden | QDir::NoDotAndDotDot), QDirIterator::Subdirectories};
             while (dirIter.hasNext())
             {
                 const QFileInfo dirInfo = dirIter.nextFileInfo();
@@ -152,7 +158,7 @@ void TorrentCreator::run()
 #endif
 
                 const QString dirPath = dirInfo.filePath();
-                if (isDotfile(Path(dirPath)))
+                if (m_params.ignoreDotfiles && isDotfile(Path(dirPath)))
                     continue;
 
                 dirs.append(dirPath);
@@ -166,12 +172,12 @@ void TorrentCreator::run()
             {
                 QStringList tmpNames;  // natural sort files within each dir
 
-                QDirIterator fileIter {dir, QDir::Files};
+                QDirIterator fileIter {dir, (QDir::Files | QDir::Hidden)};
                 while (fileIter.hasNext())
                 {
                     const QFileInfo fileInfo = fileIter.nextFileInfo();
                     const Path filePath {fileInfo.filePath()};
-                    if (isDotfile(filePath))
+                    if (m_params.ignoreDotfiles && isDotfile(filePath))
                         continue;
 
                     qint64 fileSize = fileInfo.size();
@@ -209,6 +215,14 @@ void TorrentCreator::run()
         }
 
         checkInterruptionRequested();
+
+#if LIBTORRENT_VERSION_NUM >= 20100
+        const bool isFilesEmpty = files.empty();
+#else
+        const bool isFilesEmpty = files.num_files() == 0;
+#endif
+        if (m_params.ignoreDotfiles && isFilesEmpty)
+            throw RuntimeError(tr("All files have been filtered out by 'Ignore dotfiles' option"));
 
 #ifdef QBT_USES_LIBTORRENT2
         lt::create_torrent newTorrent {files, m_params.pieceSize, toNativeTorrentFormatFlag(m_params.torrentFormat)};
@@ -299,19 +313,20 @@ const TorrentCreatorParams &TorrentCreator::params() const
 }
 
 #ifdef QBT_USES_LIBTORRENT2
-int TorrentCreator::calculateTotalPieces(const Path &inputPath, const int pieceSize, const TorrentFormat torrentFormat)
+int TorrentCreator::calculateTotalPieces(const Path &inputPath, const int pieceSize, const bool ignoreDotfiles, const TorrentFormat torrentFormat)
 #else
-int TorrentCreator::calculateTotalPieces(const Path &inputPath, const int pieceSize, const bool isAlignmentOptimized, const int paddedFileSizeLimit)
+int TorrentCreator::calculateTotalPieces(const Path &inputPath, const int pieceSize, const bool ignoreDotfiles, const bool isAlignmentOptimized, const int paddedFileSizeLimit)
 #endif
 {
     if (inputPath.isEmpty())
         return 0;
 
+    const auto &filter = ignoreDotfiles ? fileFilter : noopFilter;
 #if LIBTORRENT_VERSION_NUM >= 20100
-    const std::vector<lt::create_file_entry> files = lt::list_files(inputPath.toString().toStdString(), fileFilter);
+    const std::vector<lt::create_file_entry> files = lt::list_files(inputPath.toString().toStdString(), filter);
 #else
     lt::file_storage files;
-    lt::add_files(files, inputPath.toString().toStdString(), fileFilter);
+    lt::add_files(files, inputPath.toString().toStdString(), filter);
 #endif
 
 #ifdef QBT_USES_LIBTORRENT2

--- a/src/base/bittorrent/torrentcreator.h
+++ b/src/base/bittorrent/torrentcreator.h
@@ -51,6 +51,7 @@ namespace BitTorrent
 
     struct TorrentCreatorParams
     {
+        bool ignoreDotfiles = true;
         bool isPrivate = false;
 #ifdef QBT_USES_LIBTORRENT2
         TorrentFormat torrentFormat = TorrentFormat::Hybrid;
@@ -88,10 +89,9 @@ namespace BitTorrent
         void run() override;
 
 #ifdef QBT_USES_LIBTORRENT2
-        static int calculateTotalPieces(const Path &inputPath, int pieceSize, TorrentFormat torrentFormat);
+        static int calculateTotalPieces(const Path &inputPath, int pieceSize, bool ignoreDotfiles, TorrentFormat torrentFormat);
 #else
-        static int calculateTotalPieces(const Path &inputPath, const int pieceSize
-                , const bool isAlignmentOptimized, int paddedFileSizeLimit);
+        static int calculateTotalPieces(const Path &inputPath, int pieceSize, bool ignoreDotfiles, bool isAlignmentOptimized, int paddedFileSizeLimit);
 #endif
 
     public slots:

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -102,6 +102,7 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
     , m_threadPool(this)
     , m_storeDialogSize(SETTINGS_KEY(u"Size"_s))
     , m_storePieceSize(SETTINGS_KEY(u"PieceSize"_s))
+    , m_storeIgnoreDotfiles(SETTINGS_KEY(u"IgnoreDotfiles"_s))
     , m_storePrivateTorrent(SETTINGS_KEY(u"PrivateTorrent"_s))
     , m_storeStartSeeding(SETTINGS_KEY(u"StartSeeding"_s))
     , m_storeIgnoreRatio(SETTINGS_KEY(u"IgnoreRatio"_s))
@@ -237,17 +238,19 @@ void TorrentCreatorDialog::onCalculatePiecesButtonClicked()
 #ifdef QBT_USES_LIBTORRENT2
     PieceCalculationThread::CalcFunc calc = [path = m_ui->textInputPath->selectedPath()
         , pieceSize = getPieceSize()
+        , ignoreDotfiles = m_ui->checkIgnoreDotfiles->isChecked()
         , torrentFormat = getTorrentFormat()]() -> int
         {
-            return BitTorrent::TorrentCreator::calculateTotalPieces(path, pieceSize, torrentFormat);
+            return BitTorrent::TorrentCreator::calculateTotalPieces(path, pieceSize, ignoreDotfiles, torrentFormat);
         };
 #else
     PieceCalculationThread::CalcFunc calc = [path = m_ui->textInputPath->selectedPath()
         , pieceSize = getPieceSize()
+        , ignoreDotfiles = m_ui->checkIgnoreDotfiles->isChecked()
         , isAlignmentOptimized = m_ui->checkOptimizeAlignment->isChecked()
         , paddedFileSizeLimit = getPaddedFileSizeLimit()]() -> int
         {
-            return BitTorrent::TorrentCreator::calculateTotalPieces(path, pieceSize, isAlignmentOptimized, paddedFileSizeLimit);
+            return BitTorrent::TorrentCreator::calculateTotalPieces(path, pieceSize, ignoreDotfiles, isAlignmentOptimized, paddedFileSizeLimit);
         };
 #endif
 
@@ -303,6 +306,7 @@ void TorrentCreatorDialog::onCreateButtonClicked()
         .replace(QRegularExpression(u"\n\n[\n]+"_s), u"\n\n"_s).split(u'\n');
     const BitTorrent::TorrentCreatorParams params
     {
+        .ignoreDotfiles = m_ui->checkIgnoreDotfiles->isChecked(),
         .isPrivate = m_ui->checkPrivate->isChecked(),
 #ifdef QBT_USES_LIBTORRENT2
         .torrentFormat = getTorrentFormat(),
@@ -394,6 +398,7 @@ void TorrentCreatorDialog::setInteractionEnabled(const bool enabled) const
     m_ui->lineEditSource->setEnabled(enabled);
     m_ui->comboPieceSize->setEnabled(enabled);
     m_ui->buttonCalcTotalPieces->setEnabled(enabled);
+    m_ui->checkIgnoreDotfiles->setEnabled(enabled);
     m_ui->checkPrivate->setEnabled(enabled);
     m_ui->checkStartSeeding->setEnabled(enabled);
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enabled);
@@ -411,6 +416,7 @@ void TorrentCreatorDialog::saveSettings()
     m_storeLastAddPath = m_ui->textInputPath->selectedPath();
 
     m_storePieceSize = m_ui->comboPieceSize->currentIndex();
+    m_storeIgnoreDotfiles = m_ui->checkIgnoreDotfiles->isChecked();
     m_storePrivateTorrent = m_ui->checkPrivate->isChecked();
     m_storeStartSeeding = m_ui->checkStartSeeding->isChecked();
     m_storeIgnoreRatio = m_ui->checkIgnoreShareLimits->isChecked();
@@ -434,6 +440,7 @@ void TorrentCreatorDialog::loadSettings()
     m_ui->textInputPath->setSelectedPath(m_storeLastAddPath.get(Utils::Fs::homePath()));
 
     m_ui->comboPieceSize->setCurrentIndex(m_storePieceSize);
+    m_ui->checkIgnoreDotfiles->setChecked(m_storeIgnoreDotfiles.get(true));
     m_ui->checkPrivate->setChecked(m_storePrivateTorrent);
     m_ui->checkStartSeeding->setChecked(m_storeStartSeeding);
     m_ui->checkIgnoreShareLimits->setChecked(m_storeIgnoreRatio);

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -87,6 +87,7 @@ private:
     // settings
     SettingValue<QSize> m_storeDialogSize;
     SettingValue<int> m_storePieceSize;
+    SettingValue<bool> m_storeIgnoreDotfiles;
     SettingValue<bool> m_storePrivateTorrent;
     SettingValue<bool> m_storeStartSeeding;
     SettingValue<bool> m_storeIgnoreRatio;

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -226,6 +226,19 @@
            </layout>
           </item>
           <item>
+           <widget class="QCheckBox" name="checkIgnoreDotfiles">
+            <property name="toolTip">
+             <string>If checked, filenames starting with a period punctuation mark `.` will not be added to the created torrent.</string>
+            </property>
+            <property name="text">
+             <string>Ignore dotfiles</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="checkPrivate">
             <property name="text">
              <string>Private torrent (Won't distribute on DHT network)</string>

--- a/src/webui/api/torrentcreatorcontroller.cpp
+++ b/src/webui/api/torrentcreatorcontroller.cpp
@@ -45,6 +45,7 @@
 const QString KEY_COMMENT = u"comment"_s;
 const QString KEY_ERROR_MESSAGE = u"errorMessage"_s;
 const QString KEY_FORMAT = u"format"_s;
+const QString KEY_IGNORE_DOTFILES = u"ignoreDotfiles"_s;
 const QString KEY_OPTIMIZE_ALIGNMENT = u"optimizeAlignment"_s;
 const QString KEY_PADDED_FILE_SIZE_LIMIT = u"paddedFileSizeLimit"_s;
 const QString KEY_PIECE_SIZE = u"pieceSize"_s;
@@ -131,6 +132,7 @@ void TorrentCreatorController::addTaskAction()
 
     const BitTorrent::TorrentCreatorParams createTorrentParams
     {
+        .ignoreDotfiles = parseBool(params()[KEY_IGNORE_DOTFILES]).value_or(true),
         .isPrivate = parseBool(params()[KEY_PRIVATE]).value_or(false),
 #ifdef QBT_USES_LIBTORRENT2
         .torrentFormat = parseTorrentFormat(params()[KEY_FORMAT].toLower()),
@@ -147,9 +149,9 @@ void TorrentCreatorController::addTaskAction()
         .urlSeeds = parseUrls(params()[KEY_URL_SEEDS])
     };
 
-    bool const startSeeding = parseBool(params()[u"startSeeding"_s]).value_or(createTorrentParams.torrentFilePath.isEmpty());
+    const bool startSeeding = parseBool(params()[u"startSeeding"_s]).value_or(createTorrentParams.torrentFilePath.isEmpty());
 
-    auto task = m_torrentCreationManager->createTask(createTorrentParams, startSeeding);
+    const auto task = m_torrentCreationManager->createTask(createTorrentParams, startSeeding);
     if (!task)
         throw APIError(APIErrorType::Conflict, tr("Too many active tasks"));
 
@@ -174,6 +176,7 @@ void TorrentCreatorController::statusAction()
             {KEY_TASK_ID, task->id()},
             {KEY_SOURCE_PATH, task->params().sourcePath.toString()},
             {KEY_PIECE_SIZE, task->params().pieceSize},
+            {KEY_IGNORE_DOTFILES, task->params().ignoreDotfiles},
             {KEY_PRIVATE, task->params().isPrivate},
             {KEY_TIME_ADDED, Utils::DateTime::toSecsSinceEpoch(task->timeAdded())},
 #ifdef QBT_USES_LIBTORRENT2

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -3562,6 +3562,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("status", "", "QBT_TR(Status)QBT_TR[CONTEXT=TorrentCreator]", 100, true);
             this.newColumn("torrent_format", "", "QBT_TR(Format)QBT_TR[CONTEXT=TorrentCreator]", 100, true);
             this.newColumn("piece_size", "", "QBT_TR(Piece Size)QBT_TR[CONTEXT=TorrentCreator]", 100, true);
+            this.newColumn("ignore_dotfiles", "", "QBT_TR(Ignore Dotfiles)QBT_TR[CONTEXT=TorrentCreator]", 30, true);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TorrentCreator]", 30, true);
             this.newColumn("added_on", "", "QBT_TR(Added On)QBT_TR[CONTEXT=TorrentCreator]", 100, true);
             this.newColumn("start_on", "", "QBT_TR(Started On)QBT_TR[CONTEXT=TorrentCreator]", 100, true);
@@ -3707,14 +3708,22 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = size;
             };
 
+            // ignore dotfiles
+            this.columns["ignore_dotfiles"].updateTd = function(td, row) {
+                const text = this.getRowValue(row)
+                    ? "QBT_TR(Yes)QBT_TR[CONTEXT=TorrentCreator]"
+                    : "QBT_TR(No)QBT_TR[CONTEXT=TorrentCreator]";
+                td.textContent = text;
+                td.title = text;
+            };
+
             // private
             this.columns["private"].updateTd = function(td, row) {
-                const isPrivate = this.getRowValue(row);
-                const string = isPrivate
-                    ? "QBT_TR(Yes)QBT_TR[CONTEXT=PropertiesWidget]"
-                    : "QBT_TR(No)QBT_TR[CONTEXT=PropertiesWidget]";
-                td.textContent = string;
-                td.title = string;
+                const text = this.getRowValue(row)
+                    ? "QBT_TR(Yes)QBT_TR[CONTEXT=TorrentCreator]"
+                    : "QBT_TR(No)QBT_TR[CONTEXT=TorrentCreator]";
+                td.textContent = text;
+                td.title = text;
             };
 
             const displayDate = function(td, row) {

--- a/src/webui/www/private/views/createtorrent.html
+++ b/src/webui/www/private/views/createtorrent.html
@@ -53,21 +53,23 @@
             </select>
         </div>
         <div>
+            <input type="hidden" id="ignoreDotfilesHidden" name="ignoreDotfiles" value="0">
+            <input type="checkbox" id="ignoreDotfiles"><label for="ignoreDotfiles" title="QBT_TR(If checked, filenames starting with a period punctuation mark `.` will not be added to the created torrent.)QBT_TR[CONTEXT=TorrentCreator]">QBT_TR(Ignore dotfiles)QBT_TR[CONTEXT=TorrentCreator]</label>
+        </div>
+        <div>
             <input type="hidden" id="privateTorrentHidden" name="private" value="0">
-            <input type="checkbox" id="privateTorrent"><label for="privateTorrent">QBT_TR(Private
-                torrent (Won't distribute on DHT network))QBT_TR[CONTEXT=TorrentCreator]</label>
+            <input type="checkbox" id="privateTorrent"><label for="privateTorrent">QBT_TR(Private torrent (Won't distribute on DHT network))QBT_TR[CONTEXT=TorrentCreator]</label>
         </div>
         <div>
             <input type="hidden" id="startSeedingHidden" name="startSeeding" value="0">
-            <input type="checkbox" id="startSeeding"><label for="startSeeding">QBT_TR(Start
-                seeding
-                immediately)QBT_TR[CONTEXT=TorrentCreator]</label>
+            <input type="checkbox" id="startSeeding"><label for="startSeeding">QBT_TR(Start seeding immediately)QBT_TR[CONTEXT=TorrentCreator]</label>
         </div>
         <fieldset id="optimizeAlignmentBox">
-            <legend><input type="hidden" id="optimizeAlignmentHidden" name="optimizeAlignment" value="0"><input type="checkbox" id="optimizeAlignment"><label for="optimizeAlignment">QBT_TR(Optimize
-                    alignment)QBT_TR[CONTEXT=TorrentCreator]</label></legend>
-            <label for="paddedFileSizeLimit">QBT_TR(Align to piece boundary for files larger
-                than:)QBT_TR[CONTEXT=TorrentCreator]</label>
+            <legend>
+                <input type="hidden" id="optimizeAlignmentHidden" name="optimizeAlignment" value="0">
+                <input type="checkbox" id="optimizeAlignment"><label for="optimizeAlignment">QBT_TR(Optimize alignment)QBT_TR[CONTEXT=TorrentCreator]</label>
+            </legend>
+            <label for="paddedFileSizeLimit">QBT_TR(Align to piece boundary for files larger than:)QBT_TR[CONTEXT=TorrentCreator]</label>
             <input type="number" id="paddedFileSizeLimit" name="paddedFileSizeLimit" disabled value="0">QBT_TR(KiB)QBT_TR[CONTEXT=OptionsDialog]
         </fieldset>
     </fieldset>
@@ -165,6 +167,7 @@
         };
 
         const submit = () => {
+            document.getElementById("ignoreDotfilesHidden").value = document.getElementById("ignoreDotfiles").checked ? "true" : "false";
             document.getElementById("privateTorrentHidden").value = document.getElementById("privateTorrent").checked ? "true" : "false";
             document.getElementById("startSeedingHidden").value = document.getElementById("startSeeding").checked ? "true" : "false";
             document.getElementById("optimizeAlignmentHidden").value = document.getElementById("optimizeAlignment").checked ? "true" : "false";
@@ -195,6 +198,7 @@
                 sourcePath: document.getElementById("sourcePath").value,
                 torrentFormat: document.getElementById("torrentFormat").value,
                 pieceSize: document.getElementById("pieceSize").value,
+                ignoreDotfiles: document.getElementById("ignoreDotfiles").checked,
                 privateTorrent: document.getElementById("privateTorrent").checked,
                 startSeeding: document.getElementById("startSeeding").checked,
                 optimizeAlignment: document.getElementById("optimizeAlignment").checked,
@@ -213,6 +217,7 @@
             document.getElementById("sourcePath").value = preference.sourcePath ?? "";
             document.getElementById("torrentFormat").value = preference.torrentFormat ?? "hybrid";
             document.getElementById("pieceSize").value = preference.pieceSize ?? 0;
+            document.getElementById("ignoreDotfiles").checked = preference.ignoreDotfiles ?? true;
             document.getElementById("privateTorrent").checked = preference.privateTorrent ?? false;
             document.getElementById("startSeeding").checked = preference.startSeeding ?? false;
             document.getElementById("optimizeAlignment").checked = preference.optimizeAlignment ?? false;

--- a/src/webui/www/private/views/torrentcreator.html
+++ b/src/webui/www/private/views/torrentcreator.html
@@ -248,6 +248,7 @@
                             status: status,
                             torrent_format: entry.format,
                             piece_size: entry.pieceSize,
+                            ignore_dotfiles: entry.ignoreDotfiles,
                             private: entry.private,
                             added_on: entry.timeAdded,
                             start_on: entry.timeStarted,


### PR DESCRIPTION
This option is ON by default.
The idea is to ignore the hidden property of files/folders and just filter the filename. Therefore, a side effect is, hidden files/directories will now be included on Windows.

Screenshot:
<img width="411" height="203" alt="screenshot" src="https://github.com/user-attachments/assets/b4d34486-43d4-40b2-b9df-02bf39285b7f" />


Closes #20790.
Closes #21839.
