### PR TITLE
Use proper API for checking exit status

### DIFF
--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -67,7 +67,7 @@ namespace
         proc.setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
 #endif
         proc.start(exePath.data(), {u"--version"_s}, QIODevice::ReadOnly);
-        if (proc.waitForFinished() && (proc.exitCode() == QProcess::NormalExit))
+        if (proc.waitForFinished() && (proc.exitStatus() == QProcess::NormalExit))
         {
             QByteArray procOutput = proc.readAllStandardOutput();
             if (procOutput.isEmpty())


### PR DESCRIPTION
Previously `QProcess::exitCode` was returning `int` and we actually want `QProcess::ExitStatus`.

