### PR TITLE
CI: Support older Python in grid order hook

### DIFF
--- a/.github/workflows/helper/pre-commit/check_grid_items_order.py
+++ b/.github/workflows/helper/pre-commit/check_grid_items_order.py
@@ -73,7 +73,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             ElementTree.indent(root, ' ')
 
             # workaround_1: cannot use `xml_declaration=True` since it uses single quotes instead of Qt preferred double quotes
-            ret = f'<?xml version="1.0" encoding="UTF-8"?>\n{ElementTree.tostring(root, 'unicode')}\n'
+            ret = f'<?xml version="1.0" encoding="UTF-8"?>\n{ElementTree.tostring(root, "unicode")}\n'
 
             # workaround_2b: ElementTree will turn `&quot;` into `&amp;quot;`, so revert it back
             ret = ret.replace('&amp;quot;', '&quot;')


### PR DESCRIPTION
## Summary
- avoid Python 3.12-only f-string syntax in the grid item order pre-commit hook
- keep the hook behavior unchanged while allowing it to parse on older Python versions commonly used by local Windows setups

Closes #24263.

## Validation
- `python3 -m py_compile .github/workflows/helper/pre-commit/check_grid_items_order.py`
- `git diff --check`
