### PR TITLE
Avoid storage move for equivalent save paths

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -513,8 +513,18 @@ void TorrentImpl::setSavePath(const Path &path)
     const Path basePath = m_session->useCategoryPathsInManualMode()
             ? m_session->categorySavePath(category()) : m_session->savePath();
     const Path resolvedPath = (path.isAbsolute() ? path : (basePath / path));
-    if (resolvedPath == savePath())
+    const Path currentSavePath = savePath();
+    if (resolvedPath == currentSavePath)
         return;
+
+    const Path canonicalPath = Utils::Fs::toCanonicalPath(resolvedPath);
+    if (!canonicalPath.isEmpty() && (canonicalPath == Utils::Fs::toCanonicalPath(currentSavePath)))
+    {
+        m_savePath = resolvedPath;
+        m_session->handleTorrentSavePathChanged(this);
+        deferredRequestResumeData();
+        return;
+    }
 
     if (isFinished() || m_hasFinishedStatus || downloadPath().isEmpty())
     {


### PR DESCRIPTION
## Summary
- detect save-path changes that resolve to the same canonical directory
- update the stored save path and resume data without scheduling a storage move in that case
- avoid the redundant move/recheck when switching between a symlink path and its target path

Closes #24282.

## Validation
- `git diff --check`

I could not run the full torrent move scenario in this environment.
