### PR TITLE
Delete stale lockfile when hostname mismatch

### DIFF
--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -80,7 +80,6 @@
 #include <QFileInfo>
 #include <QLocalServer>
 #include <QLocalSocket>
-#include <QSysInfo>
 
 #include "base/path.h"
 #include "base/utils/bytearray.h"
@@ -112,11 +111,10 @@ bool QtLocalPeer::isClient()
         if (m_lockFile.error() != QLockFile::LockFailedError)
             return true;
 
-        if (const std::optional<LockInfo> lockInfo = getLockInfo())
+        if (getLockInfo())
         {
-            if (lockInfo->hostid == QSysInfo::machineUniqueId())
-                return true;
-
+            // Containers can inherit the same machine ID while changing hostnames
+            // across recreations. Let QLockFile decide whether the lock is stale.
             if (!m_lockFile.removeStaleLockFile() || !m_lockFile.tryLock())
                 return true;
         }

--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -80,6 +80,7 @@
 #include <QFileInfo>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <QSysInfo>
 
 #include "base/path.h"
 #include "base/utils/bytearray.h"
@@ -111,10 +112,14 @@ bool QtLocalPeer::isClient()
         if (m_lockFile.error() != QLockFile::LockFailedError)
             return true;
 
-        if (getLockInfo())
+        if (const std::optional<LockInfo> lockInfo = getLockInfo())
         {
-            // Containers can inherit the same machine ID while changing hostnames
-            // across recreations. Let QLockFile decide whether the lock is stale.
+            if ((lockInfo->hostid == QSysInfo::machineUniqueId())
+                    && (lockInfo->hostname == QSysInfo::machineHostName()))
+            {
+                return true;
+            }
+
             if (!m_lockFile.removeStaleLockFile() || !m_lockFile.tryLock())
                 return true;
         }


### PR DESCRIPTION
## Summary
- allow stale single-instance lock files to be removed even when the stored machine ID matches the current host
- avoid treating matching machine ID alone as proof that another qBittorrent instance is still alive
- keep relying on `QLockFile::removeStaleLockFile()` to preserve live lock behavior

Closes #24357.

## Validation
- `git diff --check`

I could not reproduce the Docker recreation scenario directly in this environment.
