### PR TITLE
Conditional rename/open file on double click

### DIFF
--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -98,6 +98,7 @@ TorrentContentWidget::TorrentContentWidget(QWidget *parent)
     setItemDelegate(itemDelegate);
 
     connect(this, &QAbstractItemView::clicked, this, qOverload<const QModelIndex &>(&QAbstractItemView::edit));
+    connect(this, &QAbstractItemView::clicked, this, &TorrentContentWidget::onItemClicked);
     connect(this, &QAbstractItemView::doubleClicked, this, &TorrentContentWidget::onItemDoubleClicked);
     connect(this, &QWidget::customContextMenuRequested, this, &TorrentContentWidget::displayContextMenu);
     connect(header(), &QWidget::customContextMenuRequested, this, &TorrentContentWidget::displayColumnHeaderMenu);
@@ -536,6 +537,45 @@ Path TorrentContentWidget::getFullPath(const QModelIndex &index) const
     return fullPath;
 }
 
+void TorrentContentWidget::onItemClicked(const QModelIndex &index)
+{
+    if (!index.isValid())
+        return;
+
+    const auto *contentHandler = m_model->contentHandler();
+    Q_ASSERT(contentHandler && contentHandler->hasMetadata());
+
+    if (!contentHandler || !contentHandler->hasMetadata()) [[unlikely]]
+        return;
+
+    if (m_lastClickedIndex != index)
+    {
+        m_lastClickedIndex = index;
+        m_lastClickTime = QDateTime::currentMSecsSinceEpoch();
+        return;
+    }
+
+    const qint64 elapsed = QDateTime::currentMSecsSinceEpoch() - m_lastClickTime;
+
+    // Without this check, we will hijack the double-click event
+    if (elapsed <= QApplication::doubleClickInterval())
+    {
+        return;
+    }
+
+    // First click "expires". Default double-click interval is 400ms so after 4s. Otherwise a double-click attempt would trigger rename on its first click
+    if (elapsed > (QApplication::doubleClickInterval() * 10))
+    {
+        m_lastClickedIndex = QModelIndex();
+        return;
+    }
+
+    m_lastClickTime = QDateTime::currentMSecsSinceEpoch();
+    m_lastClickedIndex = QModelIndex();
+
+    renameSelectedFile();
+}
+
 void TorrentContentWidget::onItemDoubleClicked(const QModelIndex &index)
 {
     const auto *contentHandler = m_model->contentHandler();
@@ -544,6 +584,7 @@ void TorrentContentWidget::onItemDoubleClicked(const QModelIndex &index)
     if (!contentHandler || !contentHandler->hasMetadata()) [[unlikely]]
         return;
 
+    m_lastClickedIndex = QModelIndex();
     if (m_doubleClickAction == DoubleClickAction::Rename)
         renameSelectedFile();
     else

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QDateTime>
 #include <QTreeView>
 
 #include "base/bittorrent/downloadpriority.h"
@@ -124,6 +125,7 @@ private:
     void applyPrioritiesByOrder();
     Path getFullPath(const QModelIndex &index) const;
     void onItemDoubleClicked(const QModelIndex &index);
+    void onItemClicked(const QModelIndex &index);
     // Expand single-item folders recursively.
     // This will trigger sorting and filtering so do it after all relevant data is loaded.
     void expandRecursively();
@@ -134,6 +136,8 @@ private:
     ColumnsVisibilityMode m_columnsVisibilityMode = ColumnsVisibilityMode::Editable;
     QShortcut *m_openFileHotkeyEnter = nullptr;
     QShortcut *m_openFileHotkeyReturn = nullptr;
+    QModelIndex m_lastClickedIndex;
+    qint64 m_lastClickTime;
 
     bool m_contentDragAllowed = false;
     bool m_contentDragEnabled = false;


### PR DESCRIPTION
Closes #6086.

# Description

This PR changes the double-click logic in the desktop/app.
While currently the action is one and the same for all files in content (rename if on the "add torrent" dialog and open if in the "content" tab of already started torrent) the suggested changes will make it so that double clicking (in the "Content" tab only, we do not alter "Add Torrent") on a complete file would "Open" it and double clicking on an "ignored"/dont-download or still downloading file would open the "Rename" dialog.

In order to keep the "Add Torrent" logic a check is introduced, if the parent has explicitly set the double click action, we assume that the parent knows best and skip the newly introduced logic.

PS: In defense of OP's issue (and those changes), while i know there are formats that can be opened even if the file is not complete, i do believe that the intention of double clicking an incomplete file is *not* to open it.