### PR TITLE
Fix macOS maximized window geometry restore

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1643,6 +1643,21 @@ void Preferences::setMainGeometry(const QByteArray &geometry)
     setValue(u"MainWindow/geometry"_s, geometry);
 }
 
+#ifdef Q_OS_MACOS
+bool Preferences::isMainWindowMaximized() const
+{
+    return value<bool>(u"MainWindow/maximized"_s);
+}
+
+void Preferences::setMainWindowMaximized(const bool value)
+{
+    if (value == isMainWindowMaximized())
+        return;
+
+    setValue(u"MainWindow/maximized"_s, value);
+}
+#endif // Q_OS_MACOS
+
 bool Preferences::isFiltersSidebarVisible() const
 {
     return value(u"GUI/MainWindow/FiltersSidebarVisible"_s, true);

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1643,6 +1643,26 @@ void Preferences::setMainGeometry(const QByteArray &geometry)
     setValue(u"MainWindow/geometry"_s, geometry);
 }
 
+#ifdef Q_OS_MACOS
+bool Preferences::hasMainWindowMaximizedSetting() const
+{
+    return SettingsStorage::instance()->hasKey(u"MainWindow/maximized"_s);
+}
+
+bool Preferences::isMainWindowMaximized() const
+{
+    return value<bool>(u"MainWindow/maximized"_s);
+}
+
+void Preferences::setMainWindowMaximized(const bool value)
+{
+    if (value == isMainWindowMaximized())
+        return;
+
+    setValue(u"MainWindow/maximized"_s, value);
+}
+#endif // Q_OS_MACOS
+
 bool Preferences::isFiltersSidebarVisible() const
 {
     return value(u"GUI/MainWindow/FiltersSidebarVisible"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -356,6 +356,10 @@ public:
     void setDNSLastIP(const QString &ip);
     QByteArray getMainGeometry() const;
     void setMainGeometry(const QByteArray &geometry);
+#ifdef Q_OS_MACOS
+    bool isMainWindowMaximized() const;
+    void setMainWindowMaximized(bool value);
+#endif // Q_OS_MACOS
     bool isFiltersSidebarVisible() const;
     void setFiltersSidebarVisible(bool value);
     int getFiltersSidebarWidth() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -356,6 +356,11 @@ public:
     void setDNSLastIP(const QString &ip);
     QByteArray getMainGeometry() const;
     void setMainGeometry(const QByteArray &geometry);
+#ifdef Q_OS_MACOS
+    bool hasMainWindowMaximizedSetting() const;
+    bool isMainWindowMaximized() const;
+    void setMainWindowMaximized(bool value);
+#endif // Q_OS_MACOS
     bool isFiltersSidebarVisible() const;
     void setFiltersSidebarVisible(bool value);
     int getFiltersSidebarWidth() const;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -51,11 +51,17 @@
 #include <QMimeData>
 #include <QProcess>
 #include <QPushButton>
+#ifdef Q_OS_MACOS
+#include <QScreen>
+#endif
 #include <QShortcut>
 #include <QSplitter>
 #include <QStatusBar>
 #include <QString>
 #include <QTimer>
+#ifdef Q_OS_MACOS
+#include <QWindow>
+#endif
 
 #ifdef Q_OS_WIN
 #include <QCryptographicHash>
@@ -131,6 +137,30 @@ namespace
     const QByteArray PYTHON_INSTALLER_SHA2_256 = QByteArrayLiteral("f4a7df6ab4fa375cd7296127ff6b9a14fbd1313f51864ce020185deba10144fa");
 #endif
 #endif // Q_OS_WIN
+
+#ifdef Q_OS_MACOS
+    bool isCloseTo(const int value, const int reference, const int tolerance)
+    {
+        return ((value >= (reference - tolerance)) && (value <= (reference + tolerance)));
+    }
+
+    bool isFillingAvailableGeometry(const QWidget *window)
+    {
+        const QWindow *const windowHandle = window->windowHandle();
+        const QScreen *const screen = windowHandle ? windowHandle->screen() : window->screen();
+        if (!screen)
+            return false;
+
+        const QRect frameGeometry = window->frameGeometry();
+        const QRect availableGeometry = screen->availableGeometry();
+        const int tolerance = 4;
+
+        return isCloseTo(frameGeometry.left(), availableGeometry.left(), tolerance)
+            && isCloseTo(frameGeometry.top(), availableGeometry.top(), tolerance)
+            && isCloseTo(frameGeometry.right(), availableGeometry.right(), tolerance)
+            && isCloseTo(frameGeometry.bottom(), availableGeometry.bottom(), tolerance);
+    }
+#endif // Q_OS_MACOS
 }
 
 MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, const QString &titleSuffix)
@@ -449,7 +479,11 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 #ifdef Q_OS_MACOS
     if (initialState == WindowState::Normal)
     {
-        show();
+        if (pref->isMainWindowMaximized())
+            showMaximized();
+        else
+            show();
+
         activateWindow();
         raise();
     }
@@ -834,6 +868,12 @@ void MainWindow::tabChanged([[maybe_unused]] const int newTab)
 void MainWindow::saveSettings() const
 {
     auto *pref = Preferences::instance();
+
+#ifdef Q_OS_MACOS
+    const bool isMaximizedLayout = isMaximized() || isFillingAvailableGeometry(this);
+    pref->setMainWindowMaximized(isMaximizedLayout);
+    if (!isMaximizedLayout)
+#endif
     pref->setMainGeometry(saveGeometry());
     m_propertiesWidget->saveSettings();
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -51,11 +51,17 @@
 #include <QMimeData>
 #include <QProcess>
 #include <QPushButton>
+#ifdef Q_OS_MACOS
+#include <QScreen>
+#endif
 #include <QShortcut>
 #include <QSplitter>
 #include <QStatusBar>
 #include <QString>
 #include <QTimer>
+#ifdef Q_OS_MACOS
+#include <QWindow>
+#endif
 
 #ifdef Q_OS_WIN
 #include <QCryptographicHash>
@@ -131,6 +137,30 @@ namespace
     const QByteArray PYTHON_INSTALLER_SHA2_256 = QByteArrayLiteral("f4a7df6ab4fa375cd7296127ff6b9a14fbd1313f51864ce020185deba10144fa");
 #endif
 #endif // Q_OS_WIN
+
+#ifdef Q_OS_MACOS
+    bool isCloseTo(const int value, const int reference, const int tolerance)
+    {
+        return ((value >= (reference - tolerance)) && (value <= (reference + tolerance)));
+    }
+
+    bool isFillingAvailableGeometry(const QWidget *window)
+    {
+        const QWindow *const windowHandle = window->windowHandle();
+        const QScreen *const screen = windowHandle ? windowHandle->screen() : window->screen();
+        if (!screen)
+            return false;
+
+        const QRect frameGeometry = window->frameGeometry();
+        const QRect availableGeometry = screen->availableGeometry();
+        const int tolerance = 4;
+
+        return isCloseTo(frameGeometry.left(), availableGeometry.left(), tolerance)
+            && isCloseTo(frameGeometry.top(), availableGeometry.top(), tolerance)
+            && isCloseTo(frameGeometry.right(), availableGeometry.right(), tolerance)
+            && isCloseTo(frameGeometry.bottom(), availableGeometry.bottom(), tolerance);
+    }
+#endif // Q_OS_MACOS
 }
 
 MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, const QString &titleSuffix)
@@ -447,15 +477,21 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     });
 
 #ifdef Q_OS_MACOS
+    const bool isMainWindowMaximized = pref->isMainWindowMaximized();
     if (initialState == WindowState::Normal)
     {
-        show();
+        if (isMainWindowMaximized)
+            showMaximized();
+        else
+            show();
+
         activateWindow();
         raise();
     }
     else
     {
         // Make sure the Window is visible if we don't have a tray icon
+        m_maximizeWhenRestored = isMainWindowMaximized;
         showMinimized();
     }
 #else
@@ -834,6 +870,12 @@ void MainWindow::tabChanged([[maybe_unused]] const int newTab)
 void MainWindow::saveSettings() const
 {
     auto *pref = Preferences::instance();
+
+#ifdef Q_OS_MACOS
+    const bool isMaximizedLayout = m_maximizeWhenRestored || isMaximized() || isFillingAvailableGeometry(this);
+    pref->setMainWindowMaximized(isMaximizedLayout);
+    if (!isMaximizedLayout)
+#endif
     pref->setMainGeometry(saveGeometry());
     m_propertiesWidget->saveSettings();
 }
@@ -876,11 +918,34 @@ void MainWindow::cleanup()
 
 void MainWindow::loadSettings()
 {
-    const auto *pref = Preferences::instance();
+    auto *pref = Preferences::instance();
+
+#ifdef Q_OS_MACOS
+    const QRect initialGeometry = geometry();
+#endif
 
     if (const QByteArray mainGeo = pref->getMainGeometry();
         !mainGeo.isEmpty() && restoreGeometry(mainGeo))
     {
+#ifdef Q_OS_MACOS
+        if (!pref->hasMainWindowMaximizedSetting() && isMaximized())
+        {
+            setWindowState(Qt::WindowNoState);
+            if (isFillingAvailableGeometry(this))
+            {
+                setGeometry(initialGeometry);
+                pref->setMainGeometry({});
+            }
+            else
+            {
+                pref->setMainGeometry(saveGeometry());
+                m_posInitialized = true;
+            }
+
+            pref->setMainWindowMaximized(true);
+            return;
+        }
+#endif
         m_posInitialized = true;
     }
 }
@@ -1266,7 +1331,13 @@ void MainWindow::createTorrentTriggered(const Path &path)
 
 bool MainWindow::event(QEvent *e)
 {
-#ifndef Q_OS_MACOS
+#ifdef Q_OS_MACOS
+    if ((e->type() == QEvent::WindowStateChange) && m_maximizeWhenRestored && !isMinimized())
+    {
+        m_maximizeWhenRestored = false;
+        QMetaObject::invokeMethod(this, &QWidget::showMaximized, Qt::QueuedConnection);
+    }
+#else
     switch (e->type())
     {
     case QEvent::WindowStateChange:

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -215,6 +215,9 @@ private:
     QString m_uploadRate;
     bool m_posInitialized = false;
     bool m_neverShown = true;
+#ifdef Q_OS_MACOS
+    bool m_maximizeWhenRestored = false;
+#endif // Q_OS_MACOS
 
     QFileSystemWatcher *m_executableWatcher = nullptr;
     // GUI related


### PR DESCRIPTION
Closes #24362.

Store macOS Fill/maximized state separately from normal window geometry, migrate existing saved state, and preserve it across normal and minimized startup.