### PR TITLE
Replace deprecated `Q_OS_MAC` macro

### DIFF
--- a/src/gui/log/loglistview.cpp
+++ b/src/gui/log/loglistview.cpp
@@ -140,7 +140,7 @@ LogListView::LogListView(QWidget *parent)
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     setItemDelegate(new LogItemDelegate(this));
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
 }

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -442,7 +442,7 @@ void OptionsDialog::loadBehaviorTabOptions()
     m_ui->assocPanel->hide();
 #endif
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     m_ui->defaultProgramPanel->hide();
 #endif
 


### PR DESCRIPTION
`Q_OS_MAC` is deprecated and the replacement is `Q_OS_MACOS`.

https://doc.qt.io/qt-6/qtsystemdetection.html#Q_OS_MAC

Follow-up to #11195