### PR TITLE
WebUI: Fix Safari transfer list header misalignment

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -580,7 +580,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             column["caption"] = caption;
             column["style"] = style;
             if (defaultWidth !== -1)
-                column["width"] = localPreferences.get(`column_${name}_width_${this.dynamicTableDivId}`, defaultWidth);
+                column["width"] = Number(localPreferences.get(`column_${name}_width_${this.dynamicTableDivId}`, defaultWidth));
             column["dataProperties"] = [name];
             column["getRowValue"] = function(row, pos) {
                 if (pos === undefined)


### PR DESCRIPTION
`localPreferences.get` returns a string for values loaded from localStorage, so `column.width` became a string after the first user-initiated column resize. In Safari this caused the fixed header table to render ~26px wider than the body on initial page load; hovering, scrolling, or resizing forced a layout pass that corrected it. Other browsers were not affected.

![Screenshot 2026-05-24 at 20 33 12](https://github.com/user-attachments/assets/b44b980e-53a7-4065-bae8-9114340686c8)
