### PR TITLE
WebUI: Fix error when submitting magnet before metadata loads

### DIFF
--- a/src/webui/www/private/scripts/file-tree.js
+++ b/src/webui/www/private/scripts/file-tree.js
@@ -99,6 +99,8 @@ window.qBittorrent.FileTree ??= (() => {
          * Returns the nodes in DFS in-order
          */
         toArray() {
+            if (this.#root === null)
+                return [];
             const ret = [];
             const stack = this.#root.children.toReversed();
             while (stack.length > 0) {


### PR DESCRIPTION
`FileTree.toArray()` dereferenced `#root.children` unconditionally, but `#root` is `null` until `setRoot()` runs, which only happens after metadata arrives with a file list. Submitting a magnet on the Add Torrent dialog before then crashed `submitForm()` via `getFileTreeArray()`.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
