### PR TITLE
WebUI: Allow cross-origin links to webroot

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -690,7 +690,10 @@ void WebApplication::processRequest(const Http::Request &request, const Http::En
     try
     {
         // block suspicious requests
-        if ((!isUsingApiKey && m_isCSRFProtectionEnabled && isCrossSiteRequest(m_request))
+        // CSRF check is skipped for the webroot so that cross-origin hyperlinks to
+        // the WebUI succeed; the root document is static and has no side effects.
+        const bool isWebRoot = (request.path == u"/") || (request.path == INDEX_HTML);
+        if ((!isUsingApiKey && m_isCSRFProtectionEnabled && !isWebRoot && isCrossSiteRequest(m_request))
             || (m_isHostHeaderValidationEnabled && !validateHostHeader(m_domainList)))
         {
             throw UnauthorizedHTTPError();


### PR DESCRIPTION
The CSRF check rejects `GET /` from a different origin with 401, which breaks plain hyperlinks to the WebUI from other sites. The webroot serves only the static index document, so exempting it from the Origin/Referer check has no effect on attack surface.

Closes #23782.
