### PR TITLE
Fix MIME header encoding in email to require ASCII

### DIFF
--- a/src/base/net/smtpclient.cpp
+++ b/src/base/net/smtpclient.cpp
@@ -82,11 +82,11 @@ namespace
         return hostname.toLocal8Bit();
     }
 
-    bool canEncodeAsLatin1(const QStringView string)
+    bool canEncodeAsASCII(const QStringView string)
     {
         return std::ranges::none_of(string, [](const QChar &ch)
         {
-            return ch > QChar(0xff);
+            return ch > QChar(0x7f);
         });
     }
 
@@ -104,7 +104,7 @@ namespace
         QByteArray rv = "";
         QByteArray line = key.toLatin1() + ": ";
         if (!prefix.isEmpty()) line += prefix;
-        if (!value.contains(u"=?") && canEncodeAsLatin1(value))
+        if (!value.contains(u"=?") && canEncodeAsASCII(value))
         {
             bool firstWord = true;
             for (const QByteArray &word : asConst(value.toLatin1().split(' ')))
@@ -123,7 +123,7 @@ namespace
         }
         else
         {
-            // The text cannot be losslessly encoded as Latin-1. Therefore, we
+            // The text contains non-ASCII characters. Therefore, we
             // must use base64 encoding.
             const QByteArray utf8 = value.toUtf8();
             // Use base64 encoding


### PR DESCRIPTION
`encodeMimeHeader` was using `canEncodeAsLatin1` to decide whether a
header value could be passed unencoded. This allowed characters in the
range 0x80–0xFF (e.g. accented letters like `é`, `ü`) to appear raw
in the wire format.

Per RFC 2822 §2.2, only US-ASCII characters are permitted unencoded in
header fields. Characters outside that range must be encoded, e.g. as
RFC 2047 encoded-words (the `=?utf-8?b?...?=` form already used by
this code for non-Latin-1 characters). Unencoded characters in the non-ASCII
half of ISO Latin-1 won't display correctly in compliant email readers such
as Thunderbird.

Fix by tightening the threshold from `0xFF` to `0x7F`, so any
non-ASCII character triggers the base64 encoded-word path.