### PR TITLE
Clean up size comparison

### DIFF
--- a/src/base/http/responsewriterimpl.cpp
+++ b/src/base/http/responsewriterimpl.cpp
@@ -560,7 +560,7 @@ void Http::ResponseWriterImpl::Worker::run()
 QByteArray Http::ResponseWriterImpl::Worker::fetchData(const qint64 maxSize)
 {
     const QReadLocker locker {&m_bufferLock};
-    const qint64 sizeToFetch = std::min(maxSize, m_buffer.size());
+    const qint64 sizeToFetch = std::min(maxSize, static_cast<qint64>(m_buffer.size()));
     const QByteArray data = m_buffer.first(sizeToFetch);
     m_buffer.remove(0, sizeToFetch);
     m_bufferSemaphore.release(sizeToFetch);

--- a/src/base/http/responsewriterimpl.cpp
+++ b/src/base/http/responsewriterimpl.cpp
@@ -560,7 +560,7 @@ void Http::ResponseWriterImpl::Worker::run()
 QByteArray Http::ResponseWriterImpl::Worker::fetchData(const qint64 maxSize)
 {
     const QReadLocker locker {&m_bufferLock};
-    const qint64 sizeToFetch = std::min(maxSize, static_cast<qint64>(m_buffer.size()));
+    const auto sizeToFetch = std::min<qint64>(maxSize, m_buffer.size());
     const QByteArray data = m_buffer.first(sizeToFetch);
     m_buffer.remove(0, sizeToFetch);
     m_bufferSemaphore.release(sizeToFetch);


### PR DESCRIPTION
## Summary
- cast the response writer buffer size to `qint64` before comparing it with a `qint64` fetch limit
- keeps the `std::min()` operands the same type
