### PR TITLE
WebUI: Refresh Add Torrent tree on content layout changes

### DIFF
--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -45,6 +45,7 @@ window.qBittorrent.AddTorrent ??= (() => {
     let windowId = "";
     let source = "";
     let downloader = "";
+    let torrentFiles = [];
 
     const clientData = window.parent.qBittorrent.ClientData;
 
@@ -220,6 +221,85 @@ window.qBittorrent.AddTorrent ??= (() => {
         }
     };
 
+    const findRootFolder = (filePaths) => {
+        let rootFolder = "";
+        for (const filePath of filePaths) {
+            const pathItems = filePath.split(window.qBittorrent.Filesystem.PathSeparator);
+            if (pathItems.length <= 1)
+                return "";
+
+            if (rootFolder === "")
+                rootFolder = pathItems[0];
+            else if (rootFolder !== pathItems[0])
+                return "";
+        }
+
+        return rootFolder;
+    };
+
+    const stripRootFolder = (filePath, rootFolder) => {
+        return filePath.substring(rootFolder.length + window.qBittorrent.Filesystem.PathSeparator.length);
+    };
+
+    const removeExtension = (filePath) => {
+        const filename = window.qBittorrent.Filesystem.fileName(filePath);
+        const dotIndex = filename.lastIndexOf(".");
+        if (dotIndex <= 0)
+            return filePath;
+
+        return filePath.substring(0, (filePath.length - filename.length) + dotIndex);
+    };
+
+    const applyContentLayout = (filePaths) => {
+        const originalRootFolder = findRootFolder(filePaths);
+        const originalContentLayout = (originalRootFolder === "") ? "NoSubfolder" : "Subfolder";
+        const selectedContentLayout = document.getElementById("contentLayout").value;
+        const newContentLayout = (selectedContentLayout === "Original")
+            ? originalContentLayout
+            : selectedContentLayout;
+
+        if (newContentLayout === originalContentLayout)
+            return filePaths;
+
+        if (newContentLayout === "NoSubfolder")
+            return filePaths.map((filePath) => stripRootFolder(filePath, originalRootFolder));
+
+        const rootFolder = (originalContentLayout === "Subfolder")
+            ? originalRootFolder
+            : removeExtension(filePaths[0]);
+
+        return filePaths.map((filePath) => `${rootFolder}${window.qBittorrent.Filesystem.PathSeparator}${filePath}`);
+    };
+
+    const currentFilePriorities = () => {
+        const filePriorities = new Map();
+        if ((table === null) || (table.getRoot() === null))
+            return filePriorities;
+
+        for (const node of table.getFileTreeArray()) {
+            if (!node.isFolder)
+                filePriorities.set(node.fileId, node.priority);
+        }
+
+        return filePriorities;
+    };
+
+    const updateTorrentContent = () => {
+        if (torrentFiles.length === 0)
+            return;
+
+        const filePriorities = currentFilePriorities();
+        const filePaths = applyContentLayout(torrentFiles.map((file) => file.name));
+        const files = torrentFiles.map((file, index) => ({
+            index: file.index,
+            name: filePaths[index],
+            size: file.size,
+            priority: filePriorities.get(file.index) ?? file.priority,
+        }));
+
+        window.qBittorrent.TorrentContent.updateData(files);
+    };
+
     const showFreeSpace = (path) => {
         if (path === "")
             return;
@@ -317,13 +397,13 @@ window.qBittorrent.AddTorrent ??= (() => {
             document.getElementById("comment").textContent = metadata.comment;
 
         if (metadata.info?.files !== undefined) {
-            const files = metadata.info.files.map((file, index) => ({
+            torrentFiles = metadata.info.files.map((file, index) => ({
                 index: index,
                 name: file.path,
                 size: file.length,
                 priority: file.priority ?? window.qBittorrent.FileTree.FilePriority.Normal,
             }));
-            window.qBittorrent.TorrentContent.updateData(files);
+            updateTorrentContent();
         }
     };
 
@@ -370,6 +450,7 @@ window.qBittorrent.AddTorrent ??= (() => {
     });
 
     window.addEventListener("DOMContentLoaded", (event) => {
+        document.getElementById("contentLayout").addEventListener("change", updateTorrentContent);
         document.getElementById("useDownloadPath").addEventListener("change", (e) => changeUseDownloadPath(e.target.checked));
         document.getElementById("tagsSelect").addEventListener("change", (e) => changeTagsSelect(e.target));
         document.getElementById("savepath").addEventListener("input", (event) => { showFreeSpace(event.target.value); });


### PR DESCRIPTION
## Description

Refresh the WebUI Add Torrent file tree when the Content layout selector changes.

The dialog now keeps the original metadata file list, applies the selected layout before rendering the tree, and preserves any file priority choices already made in the table.

Fixes #24374.

## Validation

- node --check src/webui/www/private/scripts/addtorrent.js
- git diff --check
- cmake --build /private/tmp/qbt-24362-build --target qbittorrent -j4
- Ran the built qBittorrent app with an isolated profile and WebUI enabled on localhost.
- Served a rooted multi-file .torrent locally and opened it through the real WebUI Add Torrent Link flow.
- Waited for metadata in the Add Torrent dialog and confirmed the initial file tree rendered without browser console/page errors.
- Changed Content layout from Original to Don't create subfolder; the visible tree refreshed from Layout Test Rooted -> Rooted Content -> files to Rooted Content -> files.
- Changed Episode 1.txt to Do not download, then switched Content layout to Create subfolder and back to Original; Episode 1.txt stayed Do not download and parent folders showed Mixed priority.