### PR TITLE
WebUI: Add shared dialog for adding multiple torrents

### DIFF
--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -42,28 +42,26 @@
 
             document.getElementById("urls").value = source;
 
+            const sharedMode = searchParams.get("shared") === "true";
+            // preserve positional alignment with urls
+            const enginesParam = searchParams.get("engines");
+            const engines = enginesParam ? enginesParam.split("\n") : [];
+            if (sharedMode) {
+                for (const elementId of ["renameRow", "torrentInfoSection", "filesColumn", "saveTorrent", "metadataStatus", "loadingSpinner"])
+                    document.getElementById(elementId).style.display = "none";
+                // the Torrent Information section is hidden in shared mode, so surface free space here instead
+                document.getElementById("freeSpaceRow").style.display = "";
+            }
+
             // fetch unless explicitly told not to
             const fetchMetadata = searchParams.get("fetch") !== "false";
-            let submitted = false;
 
             const windowId = searchParams.get("windowId");
             window.qBittorrent.AddTorrent.setWindowId(windowId);
 
-            const downloader = searchParams.get("downloader");
-            if (downloader?.length > 0) {
-                const downloaderInput = document.getElementById("downloader");
-                downloaderInput.value = downloader;
-                downloaderInput.disabled = false;
-            }
-
             document.getElementById("uploadForm").addEventListener("submit", (event) => {
-                submitted = true;
+                event.preventDefault();
                 window.qBittorrent.AddTorrent.submitForm();
-            });
-
-            document.getElementById("upload_frame").addEventListener("load", (event) => {
-                if (submitted)
-                    window.parent.qBittorrent.Client.closeFrameWindow(window);
             });
 
             document.getElementById("saveTorrent").addEventListener("click", (event) => {
@@ -90,7 +88,7 @@
             });
 
             window.qBittorrent.pathAutofill.attachPathAutofill();
-            window.qBittorrent.AddTorrent.init(source, downloader, fetchMetadata);
+            window.qBittorrent.AddTorrent.init(source, fetchMetadata, sharedMode, engines);
         });
     </script>
 
@@ -158,11 +156,9 @@
         </li>
     </ul>
 
-    <iframe id="upload_frame" name="upload_frame" class="invisible" title="" src="about:blank"></iframe>
-    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center; padding: 10px 12px;" target="upload_frame" autocorrect="off" autocapitalize="none">
+    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center; padding: 10px 12px;" autocorrect="off" autocapitalize="none">
         <input type="hidden" id="urls" name="urls">
         <input type="hidden" id="filePriorities" name="filePriorities">
-        <input type="hidden" id="downloader" name="downloader" disabled>
         <div class="container">
             <div class="column">
                 <fieldset class="settings" style="text-align: left;">
@@ -188,6 +184,14 @@
                                     <input type="text" id="savepath" name="savepath" class="pathDirectory" style="width: 100%;">
                                 </td>
                             </tr>
+                            <tr id="freeSpaceRow" style="display: none;">
+                                <td class="noWrap">
+                                    <label>QBT_TR(Free space:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                                </td>
+                                <td class="fullWidth">
+                                    <span id="freeSpace">QBT_TR(Not available)QBT_TR[CONTEXT=AddNewTorrentDialog]</span>
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
                     <fieldset class="settings">
@@ -206,7 +210,7 @@
                     <legend>QBT_TR(Torrent settings)QBT_TR[CONTEXT=AddNewTorrentDialog]</legend>
                     <table style="width: 100%">
                         <tbody>
-                            <tr>
+                            <tr id="renameRow">
                                 <td class="noWrap">
                                     <label for="rename">QBT_TR(Rename torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                                 </td>
@@ -332,7 +336,7 @@
                     </table>
                 </fieldset>
 
-                <fieldset class="settings" style="text-align: left;">
+                <fieldset id="torrentInfoSection" class="settings" style="text-align: left;">
                     <legend>QBT_TR(Torrent information)QBT_TR[CONTEXT=AddNewTorrentDialog]</legend>
                     <table style="width: 100%">
                         <tbody>
@@ -380,7 +384,7 @@
                     </table>
                 </fieldset>
             </div>
-            <div class="column" style="max-height: 750px; overflow-y: auto;">
+            <div id="filesColumn" class="column" style="max-height: 750px; overflow-y: auto;">
                 <fieldset class="settings" style="text-align: left; display: flex; flex-direction: column; height: 100%; box-sizing: border-box;">
                     <legend style="width: fit-content;">QBT_TR(Files)QBT_TR[CONTEXT=AddNewTorrentDialog]</legend>
                     <div style="text-align: right; padding-bottom: 10px;">
@@ -411,7 +415,7 @@
             <!-- maintains button's relative position after metadataStatus element is deleted -->
             <span>&nbsp;</span>
             <div style="position: absolute; left: 50%; transform: translateX(-50%);">
-                <button type="submit" style="font-size: 1em;">QBT_TR(Add Torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</button>
+                <button type="submit" style="font-size: 1em;">QBT_TR(Download)QBT_TR[CONTEXT=AddNewTorrentDialog]</button>
             </div>
         </div>
     </form>

--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -49,8 +49,6 @@
             if (sharedMode) {
                 for (const elementId of ["renameRow", "torrentInfoSection", "filesColumn", "saveTorrent", "metadataStatus", "loadingSpinner"])
                     document.getElementById(elementId).style.display = "none";
-                // the Torrent Information section is hidden in shared mode, so surface free space here instead
-                document.getElementById("freeSpaceRow").style.display = "";
             }
 
             // fetch unless explicitly told not to
@@ -88,7 +86,7 @@
             });
 
             window.qBittorrent.pathAutofill.attachPathAutofill();
-            window.qBittorrent.AddTorrent.init(source, fetchMetadata, sharedMode, engines);
+            window.qBittorrent.AddTorrent.init(source, fetchMetadata, sharedMode, engines, searchParams.get("size"));
         });
     </script>
 
@@ -182,14 +180,7 @@
                                 </td>
                                 <td class="fullWidth">
                                     <input type="text" id="savepath" name="savepath" class="pathDirectory" style="width: 100%;">
-                                </td>
-                            </tr>
-                            <tr id="freeSpaceRow" style="display: none;">
-                                <td class="noWrap">
-                                    <label>QBT_TR(Free space:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                                </td>
-                                <td class="fullWidth">
-                                    <span id="freeSpace">QBT_TR(Not available)QBT_TR[CONTEXT=AddNewTorrentDialog]</span>
+                                    <div id="diskInfo" style="margin-top: 4px; margin-left: 3px;"></div>
                                 </td>
                             </tr>
                         </tbody>
@@ -340,14 +331,6 @@
                     <legend>QBT_TR(Torrent information)QBT_TR[CONTEXT=AddNewTorrentDialog]</legend>
                     <table style="width: 100%">
                         <tbody>
-                            <tr>
-                                <td class="noWrap">
-                                    <label>QBT_TR(Size:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                                </td>
-                                <td class="fullWidth">
-                                    <span id="size">QBT_TR(Not available)QBT_TR[CONTEXT=AddNewTorrentDialog]</span>
-                                </td>
-                            </tr>
                             <tr>
                                 <td class="noWrap">
                                     <label>QBT_TR(Date:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>

--- a/src/webui/www/private/confirmaddtorrents.html
+++ b/src/webui/www/private/confirmaddtorrents.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="${LANG}" class="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <title>QBT_TR(Add Torrents)QBT_TR[CONTEXT=DownloadFromURLDialog]</title>
+    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
+    <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css">
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script>
+        "use strict";
+
+        window.addEventListener("DOMContentLoaded", (event) => {
+            window.addEventListener("keydown", (event) => {
+                if (event.key === "Escape") {
+                    event.preventDefault();
+                    window.parent.qBittorrent.Client.closeFrameWindow(window);
+                }
+            });
+
+            const count = new URLSearchParams(window.location.search).get("count");
+            const heading = document.getElementById("heading");
+            heading.textContent = heading.textContent.replace("%1", count);
+
+            const clientData = window.parent.qBittorrent.ClientData;
+            const separateDialogCheckbox = document.getElementById("separateDialogPerTorrent");
+            separateDialogCheckbox.checked = clientData.get("add_torrent_separate_dialog_per_torrent") ?? false;
+            separateDialogCheckbox.addEventListener("change", (e) => {
+                clientData.set({ add_torrent_separate_dialog_per_torrent: e.target.checked }).catch(console.error);
+            });
+
+            document.getElementById("addButton").addEventListener("click", (e) => {
+                e.preventDefault();
+                window.parent.qBittorrent.Client.confirmAddTorrents(separateDialogCheckbox.checked);
+                window.parent.qBittorrent.Client.closeFrameWindow(window);
+            });
+        });
+    </script>
+</head>
+
+<body>
+    <div style="text-align: center; padding: 10px;">
+        <h2 class="vcenter" id="heading">QBT_TR(Add %1 torrents)QBT_TR[CONTEXT=DownloadFromURLDialog]</h2>
+        <p><i>QBT_TR(All torrents will use a single options dialog. Check below to configure each one separately.)QBT_TR[CONTEXT=DownloadFromURLDialog]</i></p>
+        <div style="margin-top: 8px;">
+            <input type="checkbox" id="separateDialogPerTorrent">
+            <label for="separateDialogPerTorrent">QBT_TR(Open separate dialog for each torrent)QBT_TR[CONTEXT=DownloadFromURLDialog]</label>
+        </div>
+        <div style="margin-top: 12px;">
+            <button type="button" id="addButton">QBT_TR(Continue)QBT_TR[CONTEXT=DownloadFromURLDialog]</button>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -30,6 +30,13 @@
                     document.getElementById("urls").value = urls.join("\n");
             }
 
+            const clientData = window.parent.qBittorrent.ClientData;
+            const separateDialogCheckbox = document.getElementById("separateDialogPerTorrent");
+            separateDialogCheckbox.checked = clientData.get("add_torrent_separate_dialog_per_torrent") ?? false;
+            separateDialogCheckbox.addEventListener("change", (e) => {
+                clientData.set({ add_torrent_separate_dialog_per_torrent: e.target.checked }).catch(console.error);
+            });
+
             document.getElementById("submitButton").addEventListener("click", (e) => {
                 e.preventDefault();
 
@@ -37,16 +44,8 @@
                 if (urls.length === 0)
                     return;
 
-                const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData;
                 const addTorrentWindowEnabled = clientData.get("add_new_torrent_dialog_enabled") ?? true;
-
-                if (addTorrentWindowEnabled) {
-                    for (const url of urls)
-                        window.parent.qBittorrent.Client.createAddTorrentWindow("QBT_TR(Magnet link)QBT_TR[CONTEXT=DownloadFromURLDialog]", url);
-
-                    window.parent.qBittorrent.Client.closeFrameWindow(window);
-                }
-                else {
+                if (!addTorrentWindowEnabled) {
                     fetch("api/v2/torrents/add", {
                             method: "POST",
                             body: new URLSearchParams({
@@ -63,7 +62,20 @@
                         .finally(() => {
                             window.parent.qBittorrent.Client.closeFrameWindow(window);
                         });
+                    return;
                 }
+
+                const useSeparateDialogs = separateDialogCheckbox.checked || (urls.length === 1);
+                if (useSeparateDialogs) {
+                    for (const url of urls)
+                        window.parent.qBittorrent.Client.createAddTorrentWindow("QBT_TR(Magnet link)QBT_TR[CONTEXT=DownloadFromURLDialog]", url);
+                }
+                else {
+                    const title = "QBT_TR(Add %1 torrents)QBT_TR[CONTEXT=DownloadFromURLDialog]".replace("%1", urls.length);
+                    window.parent.qBittorrent.Client.createAddTorrentWindow(title, urls.join("\n"), undefined, { shared: true });
+                }
+
+                window.parent.qBittorrent.Client.closeFrameWindow(window);
             });
         });
     </script>
@@ -76,8 +88,12 @@
         <h2 class="vcenter">QBT_TR(Add torrent links)QBT_TR[CONTEXT=DownloadFromURLDialog]</h2>
         <textarea id="urls" name="urls" rows="10" required style="width: 80%;" aria-label="QBT_TR(URLs)QBT_TR[CONTEXT=DownloadFromURLDialog]"></textarea>
         <p><i>QBT_TR(One link per line (HTTP links, Magnet links and info-hashes are supported))QBT_TR[CONTEXT=DownloadFromURLDialog]</i></p>
+        <div style="margin-top: 8px;">
+            <input type="checkbox" id="separateDialogPerTorrent">
+            <label for="separateDialogPerTorrent">QBT_TR(Open separate dialog for each torrent)QBT_TR[CONTEXT=DownloadFromURLDialog]</label>
+        </div>
         <div id="submitbutton" style="margin-top: 12px; text-align: center;">
-            <button type="submit" id="submitButton">QBT_TR(Download)QBT_TR[CONTEXT=DownloadFromURLDialog]</button>
+            <button type="submit" id="submitButton">QBT_TR(Continue)QBT_TR[CONTEXT=DownloadFromURLDialog]</button>
         </div>
     </div>
 </body>

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -38,7 +38,8 @@ window.qBittorrent.AddTorrent ??= (() => {
     };
 
     let table = null;
-    let torrentSize = "";
+    let torrentSizeBytes = null;
+    let freeSpaceBytes = null;
     let defaultSavePath = "";
     let defaultTempPath = "";
     let defaultTempPathEnabled = false;
@@ -222,6 +223,24 @@ window.qBittorrent.AddTorrent ??= (() => {
         }
     };
 
+    const updateDiskInfo = () => {
+        const el = document.getElementById("diskInfo");
+        if (freeSpaceBytes === null)
+            return;
+        const free = window.qBittorrent.Misc.friendlyUnit(freeSpaceBytes, false);
+        if (torrentSizeBytes === null) {
+            el.textContent = "QBT_TR(%1 free)QBT_TR[CONTEXT=AddNewTorrentDialog]".replace("%1", free);
+            el.classList.remove("red");
+        }
+        else {
+            const size = window.qBittorrent.Misc.friendlyUnit(torrentSizeBytes, false);
+            const fits = torrentSizeBytes <= freeSpaceBytes;
+            el.textContent = "QBT_TR(%1 needed · %2 free)QBT_TR[CONTEXT=AddNewTorrentDialog]"
+                .replace("%1", size).replace("%2", free);
+            el.classList.toggle("red", !fits);
+        }
+    };
+
     const showFreeSpace = (path) => {
         if (path === "")
             return;
@@ -236,15 +255,8 @@ window.qBittorrent.AddTorrent ??= (() => {
                 cache: "no-store"
             })
             .then(async (response) => {
-                const freeSpace = window.qBittorrent.Misc.friendlyUnit(await response.text(), false);
-                if (sharedMode) {
-                    document.getElementById("freeSpace").textContent = freeSpace;
-                }
-                else {
-                    document.getElementById("size").textContent = "QBT_TR(%1 (Free space on disk: %2))QBT_TR[CONTEXT=AddNewTorrentDialog]"
-                        .replace("%1", torrentSize)
-                        .replace("%2", freeSpace);
-                }
+                freeSpaceBytes = Number(await response.text());
+                updateDiskInfo();
             })
             .catch(error => {});
     };
@@ -314,9 +326,9 @@ window.qBittorrent.AddTorrent ??= (() => {
         document.getElementById("infoHashV1").textContent = (metadata.infohash_v1 === undefined) ? notAvailable : (metadata.infohash_v1 || notApplicable);
         document.getElementById("infoHashV2").textContent = (metadata.infohash_v2 === undefined) ? notAvailable : (metadata.infohash_v2 || notApplicable);
 
-        if (metadata.info?.length !== undefined) {
-            torrentSize = window.qBittorrent.Misc.friendlyUnit(metadata.info.length, false);
-            showFreeSpace(document.getElementById("savepath").value);
+        if (metadata.info !== undefined) {
+            torrentSizeBytes = metadata.info.length ?? (metadata.info.files ?? []).reduce((sum, file) => sum + file.length, 0);
+            updateDiskInfo();
         }
         if ((metadata.creation_date !== undefined) && (metadata.creation_date > 1))
             document.getElementById("createdDate").textContent = window.qBittorrent.Misc.formatDate(new Date(metadata.creation_date * 1000));
@@ -389,11 +401,17 @@ window.qBittorrent.AddTorrent ??= (() => {
         });
     };
 
-    const init = (source, fetchMetadata, sharedModeParam = false, enginesParam = []) => {
+    const init = (source, fetchMetadata, sharedModeParam = false, enginesParam = [], totalSizeBytes = null) => {
         sharedMode = sharedModeParam;
 
         // pair each URL with its (optional) engine
         urlEntries = source ? source.split("\n").map((url, i) => ({ url: url, engine: enginesParam[i] || "" })) : [];
+
+        // shared multi-file uploads pass a precomputed total; single/per-torrent adds get size from metadata instead
+        if (totalSizeBytes !== null) {
+            torrentSizeBytes = Number(totalSizeBytes);
+            updateDiskInfo();
+        }
 
         if (!sharedMode) {
             table = window.qBittorrent.TorrentContent.init("addTorrentFilesTableDiv", window.qBittorrent.DynamicTable.AddTorrentFilesTable);

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -45,6 +45,8 @@ window.qBittorrent.AddTorrent ??= (() => {
     let windowId = "";
     let source = "";
     let downloader = "";
+    let sharedMode = false;
+    let urlEntries = [];
 
     const clientData = window.parent.qBittorrent.ClientData;
 
@@ -234,10 +236,15 @@ window.qBittorrent.AddTorrent ??= (() => {
                 cache: "no-store"
             })
             .then(async (response) => {
-                const freeSpace = await response.text();
-                document.getElementById("size").textContent = "QBT_TR(%1 (Free space on disk: %2))QBT_TR[CONTEXT=AddNewTorrentDialog]"
-                    .replace("%1", torrentSize)
-                    .replace("%2", window.qBittorrent.Misc.friendlyUnit(freeSpace, false));
+                const freeSpace = window.qBittorrent.Misc.friendlyUnit(await response.text(), false);
+                if (sharedMode) {
+                    document.getElementById("freeSpace").textContent = freeSpace;
+                }
+                else {
+                    document.getElementById("size").textContent = "QBT_TR(%1 (Free space on disk: %2))QBT_TR[CONTEXT=AddNewTorrentDialog]"
+                        .replace("%1", torrentSize)
+                        .replace("%2", freeSpace);
+                }
             })
             .catch(error => {});
     };
@@ -337,10 +344,12 @@ window.qBittorrent.AddTorrent ??= (() => {
         document.getElementById("dlLimitHidden").value = Number(document.getElementById("dlLimitText").value) * 1024;
         document.getElementById("upLimitHidden").value = Number(document.getElementById("upLimitText").value) * 1024;
 
-        document.getElementById("filePriorities").value = table.getFileTreeArray()
-            .filter((node) => !node.isFolder)
-            .sort((node1, node2) => (node1.fileId - node2.fileId))
-            .map((node) => node.priority);
+        if (table !== null) {
+            document.getElementById("filePriorities").value = table.getFileTreeArray()
+                .filter((node) => !node.isFolder)
+                .sort((node1, node2) => (node1.fileId - node2.fileId))
+                .map((node) => node.priority);
+        }
 
         if (!isAutoTMMEnabled())
             document.getElementById("useDownloadPathHidden").value = document.getElementById("useDownloadPath").checked;
@@ -351,12 +360,46 @@ window.qBittorrent.AddTorrent ??= (() => {
             const category = document.getElementById("category").value.trim();
             clientData.set({ add_torrent_default_category: (category.length > 0) ? category : null }).catch(console.error);
         }
+
+        const form = document.getElementById("uploadForm");
+        form.querySelector("button[type=submit]").disabled = true;
+        const baseFormData = new FormData(form);
+
+        // group URLs by engine
+        const groupedByEngine = new Map();
+        for (const { url, engine } of urlEntries) {
+            if (!groupedByEngine.has(engine))
+                groupedByEngine.set(engine, []);
+            groupedByEngine.get(engine).push(url);
+        }
+
+        const requests = [];
+        for (const [engine, groupUrls] of groupedByEngine) {
+            const groupFormData = new FormData();
+            for (const [key, value] of baseFormData)
+                groupFormData.append(key, value);
+            groupFormData.set("urls", groupUrls.join("\n"));
+            if (engine)
+                groupFormData.set("downloader", engine);
+            requests.push(fetch("api/v2/torrents/add", { method: "POST", body: groupFormData }));
+        }
+
+        Promise.allSettled(requests).then(() => {
+            window.parent.qBittorrent.Client.closeFrameWindow(window);
+        });
     };
 
-    const init = (source, downloader, fetchMetadata) => {
-        table = window.qBittorrent.TorrentContent.init("addTorrentFilesTableDiv", window.qBittorrent.DynamicTable.AddTorrentFilesTable);
-        if (fetchMetadata)
-            loadMetadata(source, downloader);
+    const init = (source, fetchMetadata, sharedModeParam = false, enginesParam = []) => {
+        sharedMode = sharedModeParam;
+
+        // pair each URL with its (optional) engine
+        urlEntries = source ? source.split("\n").map((url, i) => ({ url: url, engine: enginesParam[i] || "" })) : [];
+
+        if (!sharedMode) {
+            table = window.qBittorrent.TorrentContent.init("addTorrentFilesTableDiv", window.qBittorrent.DynamicTable.AddTorrentFilesTable);
+            if (fetchMetadata)
+                loadMetadata(source, enginesParam[0]);
+        }
     };
 
     window.addEventListener("load", async (event) => {

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -61,8 +61,9 @@ window.qBittorrent.Client ??= (() => {
     const setup = () => {
         // fetch various data and store it in memory
         clientDataPromise = window.qBittorrent.ClientData.fetch([
-            "add_torrent_default_category",
             "add_new_torrent_dialog_enabled",
+            "add_torrent_default_category",
+            "add_torrent_separate_dialog_per_torrent",
             "color_scheme",
             "date_format",
             "dblclick_complete",
@@ -167,26 +168,32 @@ window.qBittorrent.Client ??= (() => {
         return showingLogViewer;
     };
 
-    const createAddTorrentWindow = (title, source, metadata = undefined, downloader = undefined) => {
+    const createAddTorrentWindow = (title, source, metadata = undefined, options = {}) => {
+        const { shared = false, engines } = options;
         const isFirefox = navigator.userAgent.includes("Firefox");
         const isSafari = navigator.userAgent.includes("AppleWebKit") && !navigator.userAgent.includes("Chrome");
-        let height = 855;
+        let height = shared ? 625 : 855;
         if (isSafari)
             height -= 40;
         else if (isFirefox)
             height -= 10;
 
-        const staticId = "uploadPage";
+        const staticId = shared ? "uploadPageShared" : "uploadPage";
         const id = `${staticId}-${encodeURIComponent(source)}`;
 
-        const contentURL = new URL("addtorrent.html", window.location);
-        contentURL.search = new URLSearchParams({
+        const shouldFetchMetadata = !shared && (metadata === undefined);
+
+        const params = {
             v: "${CACHEID}",
             source: source,
-            fetch: metadata === undefined,
+            fetch: shouldFetchMetadata,
             windowId: id,
-            downloader: downloader ?? ""
-        });
+            shared: shared
+        };
+        if (engines?.length > 0)
+            params.engines = engines.join("\n");
+        const contentURL = new URL("addtorrent.html", window.location);
+        contentURL.search = new URLSearchParams(params);
 
         new MochaUI.Window({
             id: id,
@@ -198,13 +205,14 @@ window.qBittorrent.Client ??= (() => {
             maximizable: false,
             paddingVertical: 0,
             paddingHorizontal: 0,
-            width: loadWindowWidth(staticId, 980),
+            width: loadWindowWidth(staticId, shared ? 600 : 980),
             height: loadWindowHeight(staticId, height),
             onResize: window.qBittorrent.Misc.createDebounceHandler(500, (e) => {
                 saveWindowSize(staticId, id);
             }),
             onContentLoaded: () => {
-                if (metadata !== undefined) {
+                const shouldPostMetadata = !shared && (metadata !== undefined);
+                if (shouldPostMetadata) {
                     const type = "addtorrent_metadata";
                     document.getElementById(`${id}_iframe`).contentWindow.postMessage({
                         type,

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -46,6 +46,7 @@ window.qBittorrent.Client ??= (() => {
             isShowLogViewer: isShowLogViewer,
             createAddTorrentWindow: createAddTorrentWindow,
             uploadTorrentFiles: uploadTorrentFiles,
+            confirmAddTorrents: confirmAddTorrents,
             categoryMap: categoryMap,
             tagMap: tagMap
         };
@@ -169,7 +170,7 @@ window.qBittorrent.Client ??= (() => {
     };
 
     const createAddTorrentWindow = (title, source, metadata = undefined, options = {}) => {
-        const { shared = false, engines } = options;
+        const { shared = false, engines, totalSize } = options;
         const isFirefox = navigator.userAgent.includes("Firefox");
         const isSafari = navigator.userAgent.includes("AppleWebKit") && !navigator.userAgent.includes("Chrome");
         let height = shared ? 625 : 855;
@@ -192,6 +193,8 @@ window.qBittorrent.Client ??= (() => {
         };
         if (engines?.length > 0)
             params.engines = engines.join("\n");
+        if (totalSize !== undefined)
+            params.size = totalSize;
         const contentURL = new URL("addtorrent.html", window.location);
         contentURL.search = new URLSearchParams(params);
 
@@ -223,7 +226,59 @@ window.qBittorrent.Client ??= (() => {
         });
     };
 
-    const uploadTorrentFiles = (files) => {
+    let resolveAddTorrentsPrompt = null;
+
+    const showAddTorrentsPrompt = (count) => {
+        return new Promise((resolve) => {
+            resolveAddTorrentsPrompt = resolve;
+
+            const id = "confirmAddTorrentsPage";
+            const contentURL = new URL("confirmaddtorrents.html", window.location);
+            contentURL.search = new URLSearchParams({
+                v: "${CACHEID}",
+                count: count
+            });
+
+            new MochaUI.Window({
+                id: id,
+                icon: "images/qbittorrent-tray.svg",
+                title: "QBT_TR(Add Torrents)QBT_TR[CONTEXT=DownloadFromURLDialog]",
+                loadMethod: "iframe",
+                contentURL: contentURL.toString(),
+                scrollbars: false,
+                maximizable: false,
+                closable: true,
+                paddingVertical: 0,
+                paddingHorizontal: 0,
+                width: 440,
+                height: 170,
+                onClose: () => {
+                    // closing dialog without confirming counts as cancel
+                    if (resolveAddTorrentsPrompt) {
+                        resolveAddTorrentsPrompt({ cancelled: true });
+                        resolveAddTorrentsPrompt = null;
+                    }
+                }
+            });
+        });
+    };
+
+    const confirmAddTorrents = (useSeparateDialogs) => {
+        if (resolveAddTorrentsPrompt) {
+            resolveAddTorrentsPrompt({ cancelled: false, useSeparateDialogs: useSeparateDialogs });
+            resolveAddTorrentsPrompt = null;
+        }
+    };
+
+    const uploadTorrentFiles = async (files) => {
+        let useSeparateDialogs = true;
+        if (files.length > 1) {
+            const result = await showAddTorrentsPrompt(files.length);
+            if (result.cancelled)
+                return;
+            useSeparateDialogs = result.useSeparateDialogs;
+        }
+
         const fileNames = [];
         const formData = new FormData();
         for (const [i, file] of Array.prototype.entries.call(files)) {
@@ -246,30 +301,38 @@ window.qBittorrent.Client ??= (() => {
                 const addTorrentWindowEnabled = clientData.get("add_new_torrent_dialog_enabled") ?? true;
 
                 const json = await response.json();
-                const hashes = [];
-                for (const [i, metadata] of json.entries()) {
-                    const title = metadata.name || fileNames[i];
-                    const hash = metadata.infohash_v2 || metadata.infohash_v1;
-                    if (addTorrentWindowEnabled)
-                        createAddTorrentWindow(title, hash, metadata);
-                    else
-                        hashes.push(hash);
-                }
 
-                if ((hashes.length > 0) && !addTorrentWindowEnabled) {
-                    fetch("api/v2/torrents/add", {
-                            method: "POST",
-                            body: new URLSearchParams({
-                                urls: hashes.join("\n")
+                if (!addTorrentWindowEnabled) {
+                    const hashes = json.map((metadata) => metadata.infohash_v2 || metadata.infohash_v1);
+                    if (hashes.length > 0) {
+                        fetch("api/v2/torrents/add", {
+                                method: "POST",
+                                body: new URLSearchParams({
+                                    urls: hashes.join("\n")
+                                })
                             })
-                        })
-                        .then((response) => {
-                            if (!response.ok)
+                            .then((response) => {
+                                if (!response.ok)
+                                    alert("QBT_TR(Unable to add torrents.)QBT_TR[CONTEXT=HttpServer]");
+                            })
+                            .catch((error) => {
                                 alert("QBT_TR(Unable to add torrents.)QBT_TR[CONTEXT=HttpServer]");
-                        })
-                        .catch((error) => {
-                            alert("QBT_TR(Unable to add torrents.)QBT_TR[CONTEXT=HttpServer]");
-                        });
+                            });
+                    }
+                }
+                else if (useSeparateDialogs) {
+                    for (const [i, metadata] of json.entries()) {
+                        const title = metadata.name || fileNames[i];
+                        const hash = metadata.infohash_v2 || metadata.infohash_v1;
+                        createAddTorrentWindow(title, hash, metadata);
+                    }
+                }
+                else {
+                    const sizeOf = (info) => (info?.length ?? (info?.files ?? []).reduce((sum, file) => sum + file.length, 0));
+                    const hashes = json.map((metadata) => metadata.infohash_v2 || metadata.infohash_v1);
+                    const totalSize = json.reduce((sum, metadata) => sum + sizeOf(metadata.info), 0);
+                    const title = "QBT_TR(Add %1 torrents)QBT_TR[CONTEXT=DownloadFromURLDialog]".replace("%1", hashes.length);
+                    createAddTorrentWindow(title, hashes.join("\n"), undefined, { shared: true, totalSize: totalSize });
                 }
             })
             .catch((error) => {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -215,7 +215,7 @@ const initializeWindows = () => {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: loadWindowWidth(id, 500),
-            height: loadWindowHeight(id, 300),
+            height: loadWindowHeight(id, 350),
             onResize: window.qBittorrent.Misc.createDebounceHandler(500, (e) => {
                 saveWindowSize(id);
             })

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -133,12 +133,28 @@ window.qBittorrent.Search ??= (() => {
             menu: "searchResultsTableMenu",
             actions: {
                 OpenDownloadWindow: openDownloadWindow,
+                OpenSharedDownloadWindow: openSharedDownloadWindow,
                 Download: downloadSearchTorrent,
                 OpenDescriptionUrl: openSearchTorrentDescriptionUrl
             },
             offsets: {
                 x: 0,
                 y: -60
+            },
+            onShow: function() {
+                const multiSelect = searchResultsTable.selectedRowsIds().length > 1;
+
+                const openDownloadAnchor = this.menu.querySelector("a[href=\"#OpenDownloadWindow\"]");
+                const label = multiSelect
+                    ? "QBT_TR(Open separate download windows)QBT_TR[CONTEXT=SearchJobWidget]"
+                    : "QBT_TR(Open download window)QBT_TR[CONTEXT=SearchJobWidget]";
+                openDownloadAnchor.querySelector("img").alt = label;
+                openDownloadAnchor.lastChild.nodeValue = ` ${label}`;
+
+                if (multiSelect)
+                    this.showItem("OpenSharedDownloadWindow");
+                else
+                    this.hideItem("OpenSharedDownloadWindow");
             }
         });
         searchResultsTable = new window.qBittorrent.DynamicTable.SearchResultsTable();
@@ -608,8 +624,23 @@ window.qBittorrent.Search ??= (() => {
     const openDownloadWindow = () => {
         for (const rowID of searchResultsTable.selectedRowsIds()) {
             const { engineName, fileName, fileUrl } = searchResultsTable.getRow(rowID).full_data;
-            qBittorrent.Client.createAddTorrentWindow(fileName, fileUrl, undefined, engineName);
+            qBittorrent.Client.createAddTorrentWindow(fileName, fileUrl, undefined, { engines: [engineName] });
         }
+    };
+
+    const openSharedDownloadWindow = () => {
+        const rowIds = searchResultsTable.selectedRowsIds();
+        if (rowIds.length === 0)
+            return;
+        const urls = [];
+        const engines = [];
+        for (const rowID of rowIds) {
+            const row = searchResultsTable.getRow(rowID).full_data;
+            urls.push(row.fileUrl);
+            engines.push(row.engineName);
+        }
+        const title = "QBT_TR(Add %1 torrents)QBT_TR[CONTEXT=SearchJobWidget]".replace("%1", urls.length);
+        qBittorrent.Client.createAddTorrentWindow(title, urls.join("\n"), undefined, { shared: true, engines: engines });
     };
 
     const downloadSearchTorrent = () => {

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -224,6 +224,7 @@
 
 <ul id="searchResultsTableMenu" class="contextMenu">
     <li><a href="#OpenDownloadWindow"><img src="images/download.svg" alt="QBT_TR(Open download window)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Open download window)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+    <li><a href="#OpenSharedDownloadWindow"><img src="images/download.svg" alt="QBT_TR(Open shared download window)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Open shared download window)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
     <li><a href="#Download"><img src="images/downloading.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
     <li class="separator"><a href="#OpenDescriptionUrl"><img src="images/application-url.svg" alt="QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
     <li>

--- a/src/webui/www/webui.qrc
+++ b/src/webui/www/webui.qrc
@@ -4,6 +4,7 @@
         <file>private/addtorrent.html</file>
         <file>private/addtrackers.html</file>
         <file>private/addwebseeds.html</file>
+        <file>private/confirmaddtorrents.html</file>
         <file>private/confirmfeeddeletion.html</file>
         <file>private/confirmruleclear.html</file>
         <file>private/confirmruledeletion.html</file>


### PR DESCRIPTION
This change adds a new Add Torrent dialog that can be used to download multiple torrents at once. The category, tags, save path, and other options apply to all of the torrents at once.

The new dialog is accessible via a new "Open separate dialog for each torrent" option when specifying multiple URLs to download, or via a new "Open shared download window" context menu option when selecting multiple search results. The state of the "Open separate dialog for each torrent" checkbox is persisted across uses.

The original per-torrent dialog is retained and always used when downloading a single torrent.

Closes #24181.

---

## Add multiple torrent URLs

<img src="https://github.com/user-attachments/assets/bc3d2dd1-a959-4305-9136-c8b89b944305" width=513 height=415>

<img src="https://github.com/user-attachments/assets/3ef5bea1-abf8-403b-8aad-3f05d37da411" width=621 height=658>

<img src="https://github.com/user-attachments/assets/a9bc2be8-ebac-43d7-8ae9-5b36e2f2b3f4" width=244 height=154>

## Add multiple torrent files

<img src="https://github.com/user-attachments/assets/6b1e839c-e3c1-4fd9-9f83-1004da259b1d" width=454 height=237>
