### PR TITLE
Fix "RSS Smart Episode Filter" RegEx

### DIFF
--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -100,7 +100,7 @@ QPointer<AutoDownloader> AutoDownloader::m_instance = nullptr;
 
 QString computeSmartFilterRegex(const QStringList &filters)
 {
-    return u"(?:_|\\b)(?:(?:%1))(?:_|\\b)"_s.arg(filters.join(u")|(?:"));
+    return u"(?:_|\\b)(?:%1)(?:_|\\b)"_s.arg(filters.join(u"|"));
 }
 
 AutoDownloader::AutoDownloader(IApplication *app)

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -100,7 +100,7 @@ QPointer<AutoDownloader> AutoDownloader::m_instance = nullptr;
 
 QString computeSmartFilterRegex(const QStringList &filters)
 {
-    return u"(?:_|\\b)(?:%1)(?:_|\\b)"_s.arg(filters.join(u")|(?:"));
+    return u"(?:_|\\b)(?:(?:%1))(?:_|\\b)"_s.arg(filters.join(u")|(?:"));
 }
 
 AutoDownloader::AutoDownloader(IApplication *app)


### PR DESCRIPTION
## Description

The current "RSS Smart Episode Filter" RegEx is not as intended. Currently, the RegEx compiles to

`(?:_|\b)(?:filter1)|(?:filter2)|(?:filter3)(?:_|\b)`;

which only put boundary before the first filter and after the last filter, but it should have been either

`(?:_|\b)(?:(?:filter1)|(?:filter2)|(?:filter3))(?:_|\b)`, <- (Current commit change)

which put all filter within the boundary, or

`(?:filter1)|(?:filter2)|(?:filter3)`,

which doesn't force any boundary.

I actually prefer the latter; I think the intention of forcing `_|\b` is to prevent accidental matching (like in hashes), but those could be added to the default filters themselves.