### PR TITLE
WebUI: Use correct row id when updating Rss Downloader feed selection

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -3354,7 +3354,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     checkbox.dataset.id = row.rowId;
                     checkbox.addEventListener("click", (e) => {
                         const targetId = e.target.dataset.id;
-                        const row = window.qBittorrent.RssDownloader.rssDownloaderRulesTable.getRow(targetId);
+                        const row = window.qBittorrent.RssDownloader.rssDownloaderFeedSelectionTable.getRow(targetId);
                         window.qBittorrent.RssDownloader.rssDownloaderFeedSelectionTable.updateRowData({
                             rowId: row.rowId,
                             checked: checkbox.checked


### PR DESCRIPTION
Currently in `RssDownloaderFeedSelectionTable` "click" event listener, the `row` value is retrieved from the `rssDownloaderRulesTable` when it should be from `rssDownloaderFeedSelectionTable`. This value is used in `rssDownloaderFeedSelectionTable.updateRowData()` and it makes no sense to update an item in a table using another tables item id.

You can reproduce the bug by having more feeds than rules, and trying to change the selection of feeds at the end of the list. You can circumvent this bug by creating a corresponding number of Rules for each Feed, so that an Id is found by `rssDownloaderRulesTable.getRow()`.

This bug was driving me crazy so I'm opening a PR to fix it 😄 