### PR TITLE
Fix "Torrent is already present" dialog position when main window is minimized

### DIFF
--- a/src/gui/raisedmessagebox.cpp
+++ b/src/gui/raisedmessagebox.cpp
@@ -28,6 +28,8 @@
 
 #include "raisedmessagebox.h"
 
+#include "utils.h"
+
 RaisedMessageBox::RaisedMessageBox(QMessageBox::Icon icon, const QString &title, const QString &text,
                                    QMessageBox::StandardButtons buttons, QWidget *parent, Qt::WindowFlags f)
   : QMessageBox(icon, title, text, buttons, parent, f)
@@ -64,6 +66,10 @@ QMessageBox::StandardButton RaisedMessageBox::warning(QWidget *parent, const QSt
 void RaisedMessageBox::showEvent(QShowEvent *event)
 {
     QMessageBox::showEvent(event);
+
+    if (parentWidget() && parentWidget()->isMinimized())
+        move(Utils::Gui::screenCenter(this));
+
     activateWindow();
     raise();
 }


### PR DESCRIPTION
When the qBittorrent main window is minimized and a duplicate torrent
is added, the `RaisedMessageBox` dialog (e.g. "Torrent is already present")
appears at the top-left corner of the screen instead of being centered.

**Root cause:** Qt's automatic parent-relative centering fails when the
parent widget is minimized, because the minimized window has invalid/zero
geometry. The dialog defaults to position (0,0).

**Fix:** In `RaisedMessageBox::showEvent()`, detect when the parent widget
is minimized (`isMinimized()`) and manually reposition the dialog to the
center of the parent's screen using the existing
`Utils::Gui::screenCenter()` utility. This finds the correct screen via the
parent window's `windowHandle() → screen()` and computes the center point
from `availableGeometry()`.

Since `showEvent()` fires during `QDialog::exec()` before the dialog is
rendered to the user, the `move()` takes effect before any visual frame,
so there is no visible repositioning.

Closes #24375.