### PR TITLE
WebUI: Implement skip "Add new torrent" dialog

### DIFF
--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -37,18 +37,32 @@
                 if (urls.length === 0)
                     return;
 
-                for (const url of urls)
-                    window.parent.qBittorrent.Client.createAddTorrentWindow("QBT_TR(Magnet link)QBT_TR[CONTEXT=DownloadFromURLDialog]", url);
+                const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData;
+                const addTorrentWindowEnabled = clientData.get("add_new_torrent_dialog_enabled") ?? true;
 
-                window.parent.qBittorrent.Client.closeFrameWindow(window);
-            });
+                if (addTorrentWindowEnabled) {
+                    for (const url of urls)
+                        window.parent.qBittorrent.Client.createAddTorrentWindow("QBT_TR(Magnet link)QBT_TR[CONTEXT=DownloadFromURLDialog]", url);
 
-            window.addEventListener("keydown", (event) => {
-                switch (event.key) {
-                    case "Escape":
-                        event.preventDefault();
-                        window.parent.qBittorrent.Client.closeFrameWindow(window);
-                        break;
+                    window.parent.qBittorrent.Client.closeFrameWindow(window);
+                }
+                else {
+                    fetch("api/v2/torrents/add", {
+                            method: "POST",
+                            body: new URLSearchParams({
+                                urls: urls.join("\n")
+                            })
+                        })
+                        .then((response) => {
+                            if (!response.ok)
+                                alert("QBT_TR(Unable to add torrents.)QBT_TR[CONTEXT=HttpServer]");
+                        })
+                        .catch((error) => {
+                            alert("QBT_TR(Unable to add torrents.)QBT_TR[CONTEXT=HttpServer]");
+                        })
+                        .finally(() => {
+                            window.parent.qBittorrent.Client.closeFrameWindow(window);
+                        });
                 }
             });
         });

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -62,6 +62,7 @@ window.qBittorrent.Client ??= (() => {
         // fetch various data and store it in memory
         clientDataPromise = window.qBittorrent.ClientData.fetch([
             "add_torrent_default_category",
+            "add_new_torrent_dialog_enabled",
             "color_scheme",
             "date_format",
             "dblclick_complete",
@@ -233,11 +234,34 @@ window.qBittorrent.Client ??= (() => {
                     return;
                 }
 
+                const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData;
+                const addTorrentWindowEnabled = clientData.get("add_new_torrent_dialog_enabled") ?? true;
+
                 const json = await response.json();
+                const hashes = [];
                 for (const [i, metadata] of json.entries()) {
                     const title = metadata.name || fileNames[i];
                     const hash = metadata.infohash_v2 || metadata.infohash_v1;
-                    createAddTorrentWindow(title, hash, metadata);
+                    if (addTorrentWindowEnabled)
+                        createAddTorrentWindow(title, hash, metadata);
+                    else
+                        hashes.push(hash);
+                }
+
+                if ((hashes.length > 0) && !addTorrentWindowEnabled) {
+                    fetch("api/v2/torrents/add", {
+                            method: "POST",
+                            body: new URLSearchParams({
+                                urls: hashes.join("\n")
+                            })
+                        })
+                        .then((response) => {
+                            if (!response.ok)
+                                alert("QBT_TR(Unable to add torrents.)QBT_TR[CONTEXT=HttpServer]");
+                        })
+                        .catch((error) => {
+                            alert("QBT_TR(Unable to add torrents.)QBT_TR[CONTEXT=HttpServer]");
+                        });
                 }
             })
             .catch((error) => {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -140,6 +140,10 @@
     <fieldset class="settings">
         <legend title="QBT_TR(Following settings are WebUI only)QBT_TR[CONTEXT=OptionsDialog]">QBT_TR(Custom WebUI settings)QBT_TR[CONTEXT=OptionsDialog]</legend>
         <div class="formRow" style="margin-bottom: 3px;">
+            <input type="checkbox" id="addTorrentWindowEnabled">
+            <label for="addTorrentWindowEnabled">QBT_TR(Display torrent content and some options)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow" style="margin-bottom: 3px;">
             <input type="checkbox" id="displayFullURLTrackerColumn">
             <label for="displayFullURLTrackerColumn">QBT_TR(Display full announce URL in the Tracker column)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
@@ -153,6 +157,10 @@
 <div id="DownloadsTab" class="PrefTab invisible">
     <fieldset class="settings">
         <legend>QBT_TR(When adding a torrent)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <div class="formRow">
+            <input type="checkbox" id="addNewTorrentDialogEnabledCheckbox">
+            <label for="addNewTorrentDialogEnabledCheckbox">QBT_TR(Display torrent content and some options)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
         <div class="formRow">
             <label for="contentlayout_select">QBT_TR(Torrent content layout:)QBT_TR[CONTEXT=OptionsDialog]</label>
             <select id="contentlayout_select">
@@ -2342,6 +2350,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     const dblclickComplete = clientData.get("dblclick_complete") ?? "1";
                     const dblclickFilter = clientData.get("dblclick_filter") ?? "1";
                     const useAltRowColors = clientData.get("use_alt_row_colors");
+                    const addTorrentWindowEnabled = clientData.get("add_new_torrent_dialog_enabled") ?? true;
 
                     // Behavior tab
                     // Localization
@@ -2359,7 +2368,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     // Interface
                     updateColoSchemeSelect(colorScheme);
                     document.getElementById("displayDensitySelect").value = displayDensity;
-
+                    document.getElementById("addTorrentWindowEnabled").checked = addTorrentWindowEnabled === true;
                     document.getElementById("statusBarExternalIP").checked = pref.status_bar_external_ip;
                     document.getElementById("performanceWarning").checked = pref.performance_warning;
                     document.getElementById("displayFullURLTrackerColumn").checked = fullUrlTrackerColumn === true;
@@ -2814,6 +2823,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["performance_warning"] = document.getElementById("performanceWarning").checked;
             clientData.full_url_tracker_column = document.getElementById("displayFullURLTrackerColumn").checked;
             clientData.use_virtual_list = document.getElementById("useVirtualList").checked;
+            clientData.add_new_torrent_dialog_enabled = document.getElementById("addTorrentWindowEnabled").checked;
             clientData.hide_zero_status_filters = document.getElementById("hideZeroFiltersCheckbox").checked;
             clientData.dblclick_download = document.getElementById("dblclickDownloadSelect").value;
             clientData.dblclick_complete = document.getElementById("dblclickCompleteSelect").value;

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -158,10 +158,6 @@
     <fieldset class="settings">
         <legend>QBT_TR(When adding a torrent)QBT_TR[CONTEXT=OptionsDialog]</legend>
         <div class="formRow">
-            <input type="checkbox" id="addNewTorrentDialogEnabledCheckbox">
-            <label for="addNewTorrentDialogEnabledCheckbox">QBT_TR(Display torrent content and some options)QBT_TR[CONTEXT=OptionsDialog]</label>
-        </div>
-        <div class="formRow">
             <label for="contentlayout_select">QBT_TR(Torrent content layout:)QBT_TR[CONTEXT=OptionsDialog]</label>
             <select id="contentlayout_select">
                 <option value="Original">QBT_TR(Original)QBT_TR[CONTEXT=OptionsDialog]</option>


### PR DESCRIPTION
This implements `Display torrent content and some options` in WebUI.

Currently, the WebUI **always** opens a the `AddNewTorrentDialog` when adding a new torrent.

Settings is stored in `web_clientdata.json`

<img width="558" height="159" alt="Screenshot from 2026-06-01 09-25-31" src="https://github.com/user-attachments/assets/e8a07760-bde7-410a-8aaf-99b47860d7ac" />

