### PR TITLE
WebUI: Add support for binding to a Unix domain socket

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1018,11 +1018,20 @@ int Application::exec()
         }
         else if (m_webui->isEnabled())
         {
-            const QHostAddress address = m_webui->hostAddress();
-            const QString url = u"%1://%2:%3"_s.arg((m_webui->isHttps() ? u"https"_s : u"http"_s)
-                    , (address.isEqual(QHostAddress::Any, QHostAddress::ConvertUnspecifiedAddress) ? u"localhost"_s : address.toString())
-                    , QString::number(m_webui->port()));
-            printf("%s\n", qUtf8Printable(tr("To control qBittorrent, access the WebUI at: %1").arg(url)));
+            const QString socketPath = m_webui->unixSocketPath();
+            if (!socketPath.isEmpty())
+            {
+                const QString msg = tr("To control qBittorrent, access the WebUI via Unix socket: %1").arg(socketPath);
+                printf("%s\n", qUtf8Printable(msg));
+            }
+            else
+            {
+                const QHostAddress address = m_webui->hostAddress();
+                const QString url = u"%1://%2:%3"_s.arg((m_webui->isHttps() ? u"https"_s : u"http"_s)
+                        , (address.isEqual(QHostAddress::Any, QHostAddress::ConvertUnspecifiedAddress) ? u"localhost"_s : address.toString())
+                        , QString::number(m_webui->port()));
+                printf("%s\n", qUtf8Printable(tr("To control qBittorrent, access the WebUI at: %1").arg(url)));
+            }
 
             if (!tempPassword.isEmpty())
             {

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -37,12 +37,24 @@
 
 #include <QtLogging>
 #include <QNetworkProxy>
+#include <QSocketNotifier>
 #include <QSslCertificate>
 #include <QSslCipher>
 #include <QSslKey>
 #include <QSslSocket>
 #include <QStringList>
 #include <QTimer>
+#include <QTcpSocket>
+
+#if defined(Q_OS_UNIX)
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+#endif
 
 #include "base/global.h"
 #include "base/utils/net.h"
@@ -111,6 +123,11 @@ Server::Server(IRequestHandler *requestHandler, QObject *parent)
     auto *dropConnectionTimer = new QTimer(this);
     connect(dropConnectionTimer, &QTimer::timeout, this, &Server::dropTimedOutConnection);
     dropConnectionTimer->start(CONNECTIONS_SCAN_INTERVAL);
+}
+
+Server::~Server()
+{
+    closeUnixSocket();
 }
 
 void Server::incomingConnection(const qintptr socketDescriptor)
@@ -192,3 +209,228 @@ bool Server::isHttps() const
 {
     return m_https;
 }
+
+#if defined(Q_OS_UNIX)
+
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 0
+#endif
+
+#ifndef SOCK_NONBLOCK
+#define SOCK_NONBLOCK 0
+#endif
+
+namespace
+{
+    int portableAccept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+    {
+#if defined(__linux__)
+        return ::accept4(sockfd, addr, addrlen, SOCK_CLOEXEC | SOCK_NONBLOCK);
+#else
+        const int fd = ::accept(sockfd, addr, addrlen);
+        if (fd < 0)
+            return fd;
+
+        if (::fcntl(fd, F_SETFD, ::fcntl(fd, F_GETFD) | FD_CLOEXEC) < 0)
+            qWarning("WebUI: Failed to set FD_CLOEXEC on accepted Unix socket: %s", ::strerror(errno));
+        if (::fcntl(fd, F_SETFL, ::fcntl(fd, F_GETFL) | O_NONBLOCK) < 0)
+            qWarning("WebUI: Failed to set O_NONBLOCK on accepted Unix socket: %s", ::strerror(errno));
+        return fd;
+#endif
+    }
+
+    bool setSocketFlags(const int fd)
+    {
+#if !defined(SOCK_CLOEXEC) || (SOCK_CLOEXEC == 0)
+        if (::fcntl(fd, F_SETFD, ::fcntl(fd, F_GETFD) | FD_CLOEXEC) < 0)
+            return false;
+#endif
+#if !defined(SOCK_NONBLOCK) || (SOCK_NONBLOCK == 0)
+        if (::fcntl(fd, F_SETFL, ::fcntl(fd, F_GETFL) | O_NONBLOCK) < 0)
+            return false;
+#endif
+        return true;
+    }
+}
+
+bool Server::listenUnixSocket(const QString &path, const int permissions)
+{
+    Q_ASSERT(!path.isEmpty());
+
+    // Close previous Unix socket if any
+    closeUnixSocket();
+
+    const QByteArray pathBytes = path.toUtf8();
+    const bool isAbstract = path.startsWith(u'@');
+
+    m_unixListenFd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+    if (m_unixListenFd < 0)
+    {
+        m_unixErrorString = QString::fromUtf8(::strerror(errno));
+        qWarning() << "WebUI: Failed to create Unix socket:" << m_unixErrorString;
+        return false;
+    }
+
+    if (!setSocketFlags(m_unixListenFd))
+    {
+        m_unixErrorString = QString::fromUtf8(::strerror(errno));
+        qWarning() << "WebUI: Failed to set socket flags:" << m_unixErrorString;
+        ::close(m_unixListenFd);
+        m_unixListenFd = -1;
+        return false;
+    }
+
+    struct sockaddr_un addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+
+    int nameLen = 0;
+
+    if (isAbstract)
+    {
+        // Abstract socket: first byte of sun_path is null
+        const QByteArray name = pathBytes.mid(1);  // skip '@'
+        const auto maxLen = static_cast<qsizetype>(sizeof(addr.sun_path)) - 1;
+        nameLen = static_cast<int>(std::min(name.size(), maxLen));
+        if (nameLen > 0)
+            std::memcpy(addr.sun_path + 1, name.constData(), nameLen);
+    }
+    else
+    {
+        // Filesystem socket
+        const auto maxLen = static_cast<qsizetype>(sizeof(addr.sun_path)) - 1;
+        nameLen = static_cast<int>(std::min(pathBytes.size(), maxLen));
+        if (nameLen > 0)
+            std::memcpy(addr.sun_path, pathBytes.constData(), nameLen);
+
+        // Remove existing socket file
+        ::unlink(pathBytes.constData());
+    }
+
+    const int addrLen = (isAbstract
+        ? offsetof(struct sockaddr_un, sun_path) + 1 + nameLen
+        : sizeof(addr));
+
+    if (::bind(m_unixListenFd, reinterpret_cast<struct sockaddr *>(&addr), addrLen) < 0)
+    {
+        m_unixErrorString = QString::fromUtf8(::strerror(errno));
+        qWarning() << "WebUI: Failed to bind Unix socket:" << m_unixErrorString;
+        ::close(m_unixListenFd);
+        m_unixListenFd = -1;
+        return false;
+    }
+
+    // Set permissions for non-abstract sockets
+    if (!isAbstract)
+    {
+        if (::chmod(pathBytes.constData(), permissions) < 0)
+        {
+            qWarning() << "WebUI: Failed to set Unix socket permissions:" << ::strerror(errno);
+        }
+    }
+
+    if (::listen(m_unixListenFd, SOMAXCONN) < 0)
+    {
+        m_unixErrorString = QString::fromUtf8(::strerror(errno));
+        qWarning() << "WebUI: Failed to listen on Unix socket:" << m_unixErrorString;
+        ::close(m_unixListenFd);
+        m_unixListenFd = -1;
+        if (!isAbstract)
+            ::unlink(pathBytes.constData());
+        return false;
+    }
+
+    m_unixSocketNotifier = new QSocketNotifier(m_unixListenFd, QSocketNotifier::Read, this);
+    connect(m_unixSocketNotifier, &QSocketNotifier::activated, this, &Server::acceptUnixConnection);
+
+    m_unixErrorString.clear();
+    m_isUnixSocket = true;
+    m_unixSocketPath = path;
+    m_unixSocketPermissions = permissions;
+
+    return true;
+}
+
+void Server::closeUnixSocket()
+{
+    if (m_unixListenFd < 0)
+        return;
+
+    delete m_unixSocketNotifier;
+    m_unixSocketNotifier = nullptr;
+
+    ::close(m_unixListenFd);
+    m_unixListenFd = -1;
+
+    // Remove socket file for non-abstract sockets
+    if (!m_unixSocketPath.startsWith(u'@'))
+        ::unlink(m_unixSocketPath.toUtf8().constData());
+
+    m_isUnixSocket = false;
+    m_unixSocketPath.clear();
+}
+
+void Server::acceptUnixConnection()
+{
+    if (m_unixListenFd < 0)
+        return;
+
+    struct sockaddr_un peerAddr;
+    socklen_t peerAddrLen = sizeof(peerAddr);
+
+    const int clientFd = portableAccept4(m_unixListenFd, reinterpret_cast<struct sockaddr *>(&peerAddr)
+                                         , &peerAddrLen);
+    if (clientFd < 0)
+    {
+        if ((errno != EAGAIN) && (errno != EWOULDBLOCK))
+            qWarning() << "WebUI: Failed to accept Unix socket connection:" << ::strerror(errno);
+        return;
+    }
+
+    if (m_connections.size() >= CONNECTIONS_LIMIT)
+    {
+        qWarning("Too many connections on Unix socket. Exceeded CONNECTIONS_LIMIT (%d). Connection closed.", CONNECTIONS_LIMIT);
+        ::close(clientFd);
+        return;
+    }
+
+    // Wrap the Unix domain socket fd in a QTcpSocket to reuse the existing
+    // HTTP connection pipeline (Connection, ResponseWriterImpl) which operates
+    // on QAbstractSocket. QAbstractSocket methods that query TCP-specific info
+    // (peerAddress, localPort, etc.) will return invalid data for Unix sockets,
+    // but those are only used in log messages where empty/zero is acceptable.
+    std::unique_ptr<QTcpSocket> socket = std::make_unique<QTcpSocket>(this);
+    if (!socket->setSocketDescriptor(clientFd))
+    {
+        qWarning() << "WebUI: Failed to set socket descriptor for Unix connection";
+        ::close(clientFd);
+        return;
+    }
+
+    try
+    {
+        auto *connection = new Connection(socket.release(), m_requestHandler, this);
+        m_connections.insert(connection);
+        connect(connection, &Connection::closed, this, [this, connection] { removeConnection(connection); });
+    }
+    catch (const std::bad_alloc &)
+    {
+        qWarning("Failed to allocate memory for HTTP connection on Unix socket. Connection closed.");
+    }
+}
+#else
+bool Server::listenUnixSocket(const QString &path, int permissions)
+{
+    Q_UNUSED(path)
+    Q_UNUSED(permissions)
+    return false;
+}
+
+void Server::closeUnixSocket()
+{
+}
+
+void Server::acceptUnixConnection()
+{
+}
+#endif

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -34,6 +34,8 @@
 #include <QSslConfiguration>
 #include <QTcpServer>
 
+class QSocketNotifier;
+
 namespace Http
 {
     class IRequestHandler;
@@ -46,10 +48,18 @@ namespace Http
 
     public:
         explicit Server(IRequestHandler *requestHandler, QObject *parent = nullptr);
+        ~Server() override;
 
         bool setupHttps(const QByteArray &certificates, const QByteArray &privateKey);
         void disableHttps();
         bool isHttps() const;
+
+        bool listenUnixSocket(const QString &path, int permissions = 0666);
+        void closeUnixSocket();
+        bool isUnixSocket() const { return m_isUnixSocket; }
+        QString unixSocketPath() const { return m_unixSocketPath; }
+        int unixSocketPermissions() const { return m_unixSocketPermissions; }
+        QString unixErrorString() const { return m_unixErrorString; }
 
     private slots:
         void dropTimedOutConnection();
@@ -57,11 +67,19 @@ namespace Http
     private:
         void incomingConnection(qintptr socketDescriptor) override;
         void removeConnection(Connection *connection);
+        void acceptUnixConnection();
 
         IRequestHandler *m_requestHandler = nullptr;
         QSet<Connection *> m_connections;  // for tracking persistent connections
 
         bool m_https = false;
         QSslConfiguration m_sslConfig;
+
+        bool m_isUnixSocket = false;
+        QString m_unixSocketPath;
+        QString m_unixErrorString;
+        int m_unixSocketPermissions = 0666;
+        int m_unixListenFd = -1;
+        QSocketNotifier *m_unixSocketNotifier = nullptr;
     };
 }

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -877,6 +877,53 @@ void Preferences::setUPnPForWebUIPort(const bool enabled)
     setValue(u"Preferences/WebUI/UseUPnP"_s, enabled);
 }
 
+bool Preferences::isWebUIUnixSocketEnabled() const
+{
+#if defined(Q_OS_UNIX)
+    return value(u"Preferences/WebUI/UnixSocket/Enabled"_s, false);
+#else
+    return false;
+#endif
+}
+
+void Preferences::setWebUIUnixSocketEnabled(const bool enabled)
+{
+#if defined(Q_OS_UNIX)
+    if (enabled == isWebUIUnixSocketEnabled())
+        return;
+
+    setValue(u"Preferences/WebUI/UnixSocket/Enabled"_s, enabled);
+#else
+    Q_UNUSED(enabled)
+#endif
+}
+
+QString Preferences::getWebUIUnixSocketPath() const
+{
+    return value<QString>(u"Preferences/WebUI/UnixSocket/Path"_s);
+}
+
+void Preferences::setWebUIUnixSocketPath(const QString &path)
+{
+    if (path == getWebUIUnixSocketPath())
+        return;
+
+    setValue(u"Preferences/WebUI/UnixSocket/Path"_s, path);
+}
+
+int Preferences::getWebUIUnixSocketPermissions() const
+{
+    return value<int>(u"Preferences/WebUI/UnixSocket/Permissions"_s, 0666);
+}
+
+void Preferences::setWebUIUnixSocketPermissions(const int permissions)
+{
+    if (permissions == getWebUIUnixSocketPermissions())
+        return;
+
+    setValue(u"Preferences/WebUI/UnixSocket/Permissions"_s, permissions);
+}
+
 QString Preferences::getWebUIUsername() const
 {
     return value<QString>(u"Preferences/WebUI/Username"_s, u"admin"_s);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -242,6 +242,14 @@ public:
     QString getWebUITrustedReverseProxiesList() const;
     void setWebUITrustedReverseProxiesList(const QString &addr);
 
+    // Unix socket
+    bool isWebUIUnixSocketEnabled() const;
+    void setWebUIUnixSocketEnabled(bool enabled);
+    QString getWebUIUnixSocketPath() const;
+    void setWebUIUnixSocketPath(const QString &path);
+    int getWebUIUnixSocketPermissions() const;
+    void setWebUIUnixSocketPermissions(int permissions);
+
     // Dynamic DNS
     bool isDynDNSEnabled() const;
     void setDynDNSEnabled(bool enabled);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1404,6 +1404,14 @@ void OptionsDialog::loadWebUITabOptions()
     m_ui->textWebUIAddress->setText(pref->getWebUIAddress());
     m_ui->spinWebUIPort->setValue(pref->getWebUIPort());
     m_ui->checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
+#if defined(Q_OS_UNIX)
+    m_ui->groupWebUIUnixSocket->setChecked(pref->isWebUIUnixSocketEnabled());
+    m_ui->textUnixSocketPath->setText(pref->getWebUIUnixSocketPath());
+    m_ui->spinUnixSocketPermissions->setDisplayIntegerBase(8);
+    m_ui->spinUnixSocketPermissions->setValue(pref->getWebUIUnixSocketPermissions());
+#else
+    m_ui->groupWebUIUnixSocket->hide();
+#endif
     m_ui->checkWebUIHttps->setChecked(pref->isWebUIHttpsEnabled());
     webUIHttpsCertChanged(pref->getWebUIHttpsCertificatePath());
     webUIHttpsKeyChanged(pref->getWebUIHttpsKeyPath());
@@ -1448,6 +1456,9 @@ void OptionsDialog::loadWebUITabOptions()
     connect(m_ui->textWebUIAddress, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinWebUIPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUIUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->groupWebUIUnixSocket, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->textUnixSocketPath, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->spinUnixSocketPermissions, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUIHttps, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIHttpsCert, &FileSystemPathLineEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIHttpsCert, &FileSystemPathLineEdit::selectedPathChanged, this, &OptionsDialog::webUIHttpsCertChanged);
@@ -1499,6 +1510,9 @@ void OptionsDialog::saveWebUITabOptions() const
     pref->setWebUIAddress(m_ui->textWebUIAddress->text());
     pref->setWebUIPort(m_ui->spinWebUIPort->value());
     pref->setUPnPForWebUIPort(m_ui->checkWebUIUPnP->isChecked());
+    pref->setWebUIUnixSocketEnabled(m_ui->groupWebUIUnixSocket->isChecked());
+    pref->setWebUIUnixSocketPath(m_ui->textUnixSocketPath->text());
+    pref->setWebUIUnixSocketPermissions(m_ui->spinUnixSocketPermissions->value());
     pref->setWebUIHttpsEnabled(m_ui->checkWebUIHttps->isChecked());
     pref->setWebUIHttpsCertificatePath(m_ui->textWebUIHttpsCert->selectedPath());
     pref->setWebUIHttpsKeyPath(m_ui->textWebUIHttpsKey->selectedPath());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3769,21 +3769,73 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                  </item>
                 </layout>
                </item>
-               <item>
-                <widget class="QCheckBox" name="checkWebUIUPnP">
-                 <property name="text">
-                  <string>Use UPnP / NAT-PMP to forward the port from my router</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="checkWebUIHttps">
-                 <property name="title">
-                  <string>&amp;Use HTTPS instead of HTTP</string>
-                 </property>
+                <item>
+                 <widget class="QCheckBox" name="checkWebUIUPnP">
+                  <property name="text">
+                   <string>Use UPnP / NAT-PMP to forward the port from my router</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupWebUIUnixSocket">
+                  <property name="title">
+                   <string>Use Unix domain socket</string>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <property name="checked">
+                   <bool>false</bool>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayoutUnixSocket">
+                   <item row="0" column="0">
+                    <widget class="QLabel" name="lblUnixSocketPath">
+                     <property name="text">
+                      <string>Socket path:</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <widget class="QLineEdit" name="textUnixSocketPath">
+                     <property name="toolTip">
+                      <string>Path to the Unix domain socket. Use @socketname for abstract sockets.</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="lblUnixSocketPermissions">
+                     <property name="text">
+                      <string>Socket permissions:</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QSpinBox" name="spinUnixSocketPermissions">
+                     <property name="prefix">
+                      <string>0o</string>
+                     </property>
+                     <property name="minimum">
+                      <number>0</number>
+                     </property>
+                     <property name="maximum">
+                      <number>511</number>
+                     </property>
+                     <property name="value">
+                      <number>438</number>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="checkWebUIHttps">
+                  <property name="title">
+                   <string>&amp;Use HTTPS instead of HTTP</string>
+                  </property>
                  <property name="checkable">
                   <bool>true</bool>
                  </property>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3769,73 +3769,73 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                  </item>
                 </layout>
                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkWebUIUPnP">
-                  <property name="text">
-                   <string>Use UPnP / NAT-PMP to forward the port from my router</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="groupWebUIUnixSocket">
-                  <property name="title">
-                   <string>Use Unix domain socket</string>
-                  </property>
-                  <property name="checkable">
-                   <bool>true</bool>
-                  </property>
-                  <property name="checked">
-                   <bool>false</bool>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayoutUnixSocket">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="lblUnixSocketPath">
-                     <property name="text">
-                      <string>Socket path:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QLineEdit" name="textUnixSocketPath">
-                     <property name="toolTip">
-                      <string>Path to the Unix domain socket. Use @socketname for abstract sockets.</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="lblUnixSocketPermissions">
-                     <property name="text">
-                      <string>Socket permissions:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QSpinBox" name="spinUnixSocketPermissions">
-                     <property name="prefix">
-                      <string>0o</string>
-                     </property>
-                     <property name="minimum">
-                      <number>0</number>
-                     </property>
-                     <property name="maximum">
-                      <number>511</number>
-                     </property>
-                     <property name="value">
-                      <number>438</number>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="checkWebUIHttps">
-                  <property name="title">
-                   <string>&amp;Use HTTPS instead of HTTP</string>
-                  </property>
+               <item>
+                <widget class="QCheckBox" name="checkWebUIUPnP">
+                 <property name="text">
+                  <string>Use UPnP / NAT-PMP to forward the port from my router</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupWebUIUnixSocket">
+                 <property name="title">
+                  <string>Use Unix domain socket</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayoutUnixSocket">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="lblUnixSocketPath">
+                    <property name="text">
+                     <string>Socket path:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="textUnixSocketPath">
+                    <property name="toolTip">
+                     <string>Path to the Unix domain socket. Use @socketname for abstract sockets.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="lblUnixSocketPermissions">
+                    <property name="text">
+                     <string>Socket permissions:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QSpinBox" name="spinUnixSocketPermissions">
+                    <property name="prefix">
+                     <string>0o</string>
+                    </property>
+                    <property name="minimum">
+                     <number>0</number>
+                    </property>
+                    <property name="maximum">
+                     <number>511</number>
+                    </property>
+                    <property name="value">
+                     <number>438</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="checkWebUIHttps">
+                 <property name="title">
+                  <string>&amp;Use HTTPS instead of HTTP</string>
+                 </property>
                  <property name="checkable">
                   <bool>true</bool>
                  </property>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -339,6 +339,9 @@ void AppController::preferencesAction()
     data[u"use_https"_s] = pref->isWebUIHttpsEnabled();
     data[u"web_ui_https_cert_path"_s] = pref->getWebUIHttpsCertificatePath().toString();
     data[u"web_ui_https_key_path"_s] = pref->getWebUIHttpsKeyPath().toString();
+    data[u"web_ui_unix_socket"_s] = pref->isWebUIUnixSocketEnabled();
+    data[u"web_ui_unix_socket_path"_s] = pref->getWebUIUnixSocketPath();
+    data[u"web_ui_unix_socket_permissions"_s] = pref->getWebUIUnixSocketPermissions();
     // Authentication
     data[u"web_ui_username"_s] = pref->getWebUIUsername();
     data[u"bypass_local_auth"_s] = !pref->isWebUILocalAuthEnabled();
@@ -912,6 +915,12 @@ void AppController::setPreferencesAction()
         pref->setWebUIHttpsCertificatePath(Path(it.value().toString()));
     if (hasKey(u"web_ui_https_key_path"_s))
         pref->setWebUIHttpsKeyPath(Path(it.value().toString()));
+    if (hasKey(u"web_ui_unix_socket"_s))
+        pref->setWebUIUnixSocketEnabled(it.value().toBool());
+    if (hasKey(u"web_ui_unix_socket_path"_s))
+        pref->setWebUIUnixSocketPath(it.value().toString());
+    if (hasKey(u"web_ui_unix_socket_permissions"_s))
+        pref->setWebUIUnixSocketPermissions(it.value().toInt());
     // Authentication
     if (hasKey(u"web_ui_username"_s))
     {

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -83,14 +83,14 @@ void WebUI::configure()
         }
         else
         {
+            const QString serverAddressString = pref->getWebUIAddress();
+            const auto serverAddress = ((serverAddressString == u"*") || serverAddressString.isEmpty())
+                ? QHostAddress::Any : QHostAddress(serverAddressString);
+
             const bool needsRestart = useUnixSocket
-                ? (!m_httpServer->isUnixSocket() || (m_httpServer->unixSocketPath() != pref->getWebUIUnixSocketPath().toString()))
+                ? (!m_httpServer->isUnixSocket() || (m_httpServer->unixSocketPath() != pref->getWebUIUnixSocketPath()))
                 : (m_httpServer->isUnixSocket() || (m_httpServer->serverPort() != pref->getWebUIPort())
-                    || (m_httpServer->serverAddress() != [&pref]()
-                    {
-                        const QString addr = pref->getWebUIAddress();
-                        return ((addr == u"*") || addr.isEmpty()) ? QHostAddress::Any : QHostAddress(addr);
-                    }()));
+                    || (m_httpServer->serverAddress() != serverAddress));
 
             if (needsRestart)
             {

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -73,24 +73,9 @@ void WebUI::configure()
 
     if (m_isEnabled && !m_isErrored)
     {
-        const quint16 port = pref->getWebUIPort();
-
-        // Port forwarding
-        auto *portForwarder = Net::PortForwarder::instance();
-        if (pref->useUPnPForWebUIPort())
-        {
-            portForwarder->setPorts(portForwardingProfile, {port});
-        }
-        else
-        {
-            portForwarder->removePorts(portForwardingProfile);
-        }
+        const bool useUnixSocket = pref->isWebUIUnixSocketEnabled();
 
         // http server
-        const QString serverAddressString = pref->getWebUIAddress();
-        const auto serverAddress = ((serverAddressString == u"*") || serverAddressString.isEmpty())
-            ? QHostAddress::Any : QHostAddress(serverAddressString);
-
         if (!m_httpServer)
         {
             m_webapp = new WebApplication(app(), this);
@@ -98,65 +83,129 @@ void WebUI::configure()
         }
         else
         {
-            if ((m_httpServer->serverAddress() != serverAddress) || (m_httpServer->serverPort() != port))
+            const bool needsRestart = useUnixSocket
+                ? (!m_httpServer->isUnixSocket() || (m_httpServer->unixSocketPath() != pref->getWebUIUnixSocketPath().toString()))
+                : (m_httpServer->isUnixSocket() || (m_httpServer->serverPort() != pref->getWebUIPort())
+                    || (m_httpServer->serverAddress() != [&pref]()
+                    {
+                        const QString addr = pref->getWebUIAddress();
+                        return ((addr == u"*") || addr.isEmpty()) ? QHostAddress::Any : QHostAddress(addr);
+                    }()));
+
+            if (needsRestart)
+            {
                 m_httpServer->close();
+                m_httpServer->closeUnixSocket();
+            }
         }
 
         m_webapp->setUsername(username);
         m_webapp->setPasswordHash(passwordHash);
 
-        if (pref->isWebUIHttpsEnabled())
+        if (useUnixSocket)
         {
-            const auto readData = [](const Path &path) -> QByteArray
-            {
-                const auto readResult = Utils::IO::readFile(path, Utils::Net::MAX_SSL_FILE_SIZE);
-                return readResult.value_or(QByteArray());
-            };
-            const QByteArray cert = readData(pref->getWebUIHttpsCertificatePath());
-            const QByteArray key = readData(pref->getWebUIHttpsKeyPath());
-
-            const bool success = m_httpServer->setupHttps(cert, key);
-            if (success)
-                LogMsg(tr("WebUI: HTTPS setup successful"));
-            else
-                LogMsg(tr("WebUI: HTTPS setup failed, fallback to HTTP"), Log::CRITICAL);
-        }
-        else
-        {
+            // UPnP and HTTPS are not applicable for Unix domain sockets
+            Net::PortForwarder::instance()->removePorts(portForwardingProfile);
             m_httpServer->disableHttps();
-        }
 
-        if (!m_httpServer->isListening())
-        {
-            const bool success = m_httpServer->listen(serverAddress, port);
-            if (success)
+            if (!m_httpServer->isListening() && !m_httpServer->isUnixSocket())
             {
-                LogMsg(tr("WebUI: Now listening on IP: %1, port: %2").arg(serverAddressString).arg(port));
+                const QString socketPath = pref->getWebUIUnixSocketPath();
+                if (socketPath.isEmpty())
+                {
+                    setError(tr("Unix socket path is not set"));
+                }
+                else
+                {
+                    const int permissions = pref->getWebUIUnixSocketPermissions();
+                    const bool success = m_httpServer->listenUnixSocket(socketPath, permissions);
+                    if (success)
+                    {
+                        LogMsg(tr("WebUI: Now listening on Unix socket: %1").arg(socketPath));
+                    }
+                    else
+                    {
+                        setError(tr("Unable to bind to Unix socket: %1. Reason: %2")
+                                .arg(socketPath).arg(m_httpServer->unixErrorString()));
+                    }
+                }
             }
-            else
-            {
-                setError(tr("Unable to bind to IP: %1, port: %2. Reason: %3")
-                        .arg(serverAddressString).arg(port).arg(m_httpServer->errorString()));
-            }
-        }
-
-        // DynDNS
-        if (pref->isDynDNSEnabled())
-        {
-            if (!m_dnsUpdater)
-                m_dnsUpdater = new Net::DNSUpdater(this);
-            else
-                m_dnsUpdater->updateCredentials();
         }
         else
         {
-            delete m_dnsUpdater;
+            // Port forwarding
+            const quint16 port = pref->getWebUIPort();
+            auto *portForwarder = Net::PortForwarder::instance();
+            if (pref->useUPnPForWebUIPort())
+            {
+                portForwarder->setPorts(portForwardingProfile, {port});
+            }
+            else
+            {
+                portForwarder->removePorts(portForwardingProfile);
+            }
+
+            // http server address
+            const QString serverAddressString = pref->getWebUIAddress();
+            const auto serverAddress = ((serverAddressString == u"*") || serverAddressString.isEmpty())
+                ? QHostAddress::Any : QHostAddress(serverAddressString);
+
+            // HTTPS
+            if (pref->isWebUIHttpsEnabled())
+            {
+                const auto readData = [](const Path &path) -> QByteArray
+                {
+                    const auto readResult = Utils::IO::readFile(path, Utils::Net::MAX_SSL_FILE_SIZE);
+                    return readResult.value_or(QByteArray());
+                };
+                const QByteArray cert = readData(pref->getWebUIHttpsCertificatePath());
+                const QByteArray key = readData(pref->getWebUIHttpsKeyPath());
+
+                const bool success = m_httpServer->setupHttps(cert, key);
+                if (success)
+                    LogMsg(tr("WebUI: HTTPS setup successful"));
+                else
+                    LogMsg(tr("WebUI: HTTPS setup failed, fallback to HTTP"), Log::CRITICAL);
+            }
+            else
+            {
+                m_httpServer->disableHttps();
+            }
+
+            if (!m_httpServer->isListening() && !m_httpServer->isUnixSocket())
+            {
+                const bool success = m_httpServer->listen(serverAddress, port);
+                if (success)
+                {
+                    LogMsg(tr("WebUI: Now listening on IP: %1, port: %2").arg(serverAddressString).arg(port));
+                }
+                else
+                {
+                    setError(tr("Unable to bind to IP: %1, port: %2. Reason: %3")
+                            .arg(serverAddressString).arg(port).arg(m_httpServer->errorString()));
+                }
+            }
+
+            // DynDNS
+            if (pref->isDynDNSEnabled())
+            {
+                if (!m_dnsUpdater)
+                    m_dnsUpdater = new Net::DNSUpdater(this);
+                else
+                    m_dnsUpdater->updateCredentials();
+            }
+            else
+            {
+                delete m_dnsUpdater;
+            }
         }
     }
     else
     {
         Net::PortForwarder::instance()->removePorts(portForwardingProfile);
 
+        if (m_httpServer)
+            m_httpServer->closeUnixSocket();
         delete m_httpServer;
         delete m_webapp;
         delete m_dnsUpdater;
@@ -206,4 +255,10 @@ quint16 WebUI::port() const
 {
     if (!m_httpServer) return 0;
     return m_httpServer->serverPort();
+}
+
+QString WebUI::unixSocketPath() const
+{
+    if (!m_httpServer) return {};
+    return m_httpServer->unixSocketPath();
 }

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -60,6 +60,7 @@ public:
     bool isHttps() const;
     QHostAddress hostAddress() const;
     quint16 port() const;
+    QString unixSocketPath() const;
 
 signals:
     void error(const QString &message);


### PR DESCRIPTION
This PR adds the ability for the WebUI to bind to a Unix domain socket
(AF_UNIX) instead of (or in addition to) TCP/IP, on Unix platforms.

### Features

- **Abstract and filesystem sockets**: Paths starting with `@` are treated
  as abstract Linux sockets (`sun_path[0] = '\0'`). All other paths are
  treated as filesystem socket files.
- **Configurable permissions**: File permissions for filesystem sockets
  are configurable via a new `web_ui_unix_socket_permissions` setting
  (default: `0666` octal).
- **Full WebUI API integration**: Three new JSON keys exposed in
  `getPreferences`/`setPreferences`:
  - `web_ui_unix_socket` (bool)
  - `web_ui_unix_socket_path` (string)
  - `web_ui_unix_socket_permissions` (int)
- **GUI configuration**: New "Use Unix domain socket" group box in the
  WebUI settings tab (visible on Unix only).
- **CLI integration**: Startup log message shows the socket path when
  Unix socket mode is active.

### Implementation

The Unix socket is managed via native `socket(AF_UNIX, ...)` /
`bind()` / `listen()` / `accept4()` calls wrapped in a
`QSocketNotifier`. Accepted client file descriptors are wrapped in
`QTcpSocket::setSocketDescriptor()` to reuse the existing HTTP
connection pipeline (`Http::Connection`, `ResponseWriterImpl`) without
modification. Since Unix sockets are local, HTTPS is automatically
disabled in this mode.

Portability for macOS/BSD is handled with a `portableAccept4()`
helper that falls back to `accept()` + `fcntl()`.

### Settings (stored in config file)

| Key | Type | Default |
|---|---|---|
| `Preferences/WebUI/UnixSocket/Enabled` | bool | `false` |
| `Preferences/WebUI/UnixSocket/Path` | string | `""` |
| `Preferences/WebUI/UnixSocket/Permissions` | int | `438` (`0666` octal) |

### Use case

Running qBittorrent in a separate network namespace on Linux, where
the WebUI cannot be reached via TCP from the init namespace. A Unix
domain socket in a shared mount namespace provides a clean solution
without ugly workarounds.

Closes #24308 