### PR TITLE
Fix array copy

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -33,6 +33,8 @@
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/entry.hpp>
 
+#include <QtAssert>
+#include <QByteArrayView>
 #include <QHostAddress>
 
 #include "base/exceptions.h"
@@ -97,9 +99,10 @@ namespace
         {
         case QAbstractSocket::IPv4Protocol:
         case QAbstractSocket::AnyIPProtocol:
-        {
+            {
                 const quint32 ipv4 = addr.toIPv4Address();
                 QByteArray ret;
+                ret.reserve(sizeof(quint32));
                 ret.append(static_cast<char>((ipv4 >> 24) & 0xFF))
                    .append(static_cast<char>((ipv4 >> 16) & 0xFF))
                    .append(static_cast<char>((ipv4 >> 8) & 0xFF))
@@ -108,18 +111,26 @@ namespace
             }
 
         case QAbstractSocket::IPv6Protocol:
-        {
+            {
                 const Q_IPV6ADDR ipv6 = addr.toIPv6Address();
                 QByteArray ret;
+                ret.reserve(sizeof(Q_IPV6ADDR));
                 for (const quint8 i : ipv6.c)
                     ret.append(i);
                 return ret;
             }
 
         case QAbstractSocket::UnknownNetworkLayerProtocol:
-        default:
             return {};
-        };
+        }
+
+        Q_UNREACHABLE_RETURN({});
+    }
+
+    lt::entry::string_type toEntryString(const QByteArrayView array)
+    {
+        using SizeType = lt::entry::string_type::size_type;
+        return {array.constData(), static_cast<SizeType>(array.size())};
     }
 }
 
@@ -341,15 +352,15 @@ void Tracker::processAnnounceRequest()
 
     // 8. cache `peers` field so we don't recompute when sending response
     const QHostAddress claimedIPAddress {QString::fromLatin1(announceReq.claimedAddress)};
-    announceReq.peer.endpoint = toBigEndianByteArray(!claimedIPAddress.isNull() ? claimedIPAddress : announceReq.socketAddress)
+    announceReq.peer.endpoint = toEntryString(
+        toBigEndianByteArray(!claimedIPAddress.isNull() ? claimedIPAddress : announceReq.socketAddress)
         .append(static_cast<char>((announceReq.peer.port >> 8) & 0xFF))
-        .append(static_cast<char>(announceReq.peer.port & 0xFF))
-        .toStdString();
+        .append(static_cast<char>(announceReq.peer.port)));
 
     // 9. cache `address` field so we don't recompute when sending response
-    announceReq.peer.address = !announceReq.claimedAddress.isEmpty()
-        ? announceReq.claimedAddress.constData()
-        : announceReq.socketAddress.toString().toLatin1().constData(),
+    announceReq.peer.address = toEntryString(!announceReq.claimedAddress.isEmpty()
+        ? announceReq.claimedAddress
+        : announceReq.socketAddress.toString().toLatin1());
 
     // 10. event
     announceReq.event = QString::fromLatin1(queryParams.value(ANNOUNCE_REQUEST_EVENT));
@@ -359,7 +370,7 @@ void Tracker::processAnnounceRequest()
         || (announceReq.event == ANNOUNCE_REQUEST_EVENT_COMPLETED)
         || (announceReq.event == ANNOUNCE_REQUEST_EVENT_STARTED)
         || (announceReq.event == ANNOUNCE_REQUEST_EVENT_PAUSED))
-        {
+    {
         // [BEP-21] Extension for partial seeds
         // (partial support - we don't support BEP-48 so the part that concerns that is not supported)
         registerPeer(announceReq);
@@ -460,7 +471,7 @@ void Tracker::prepareAnnounceResponse(const TrackerAnnounceRequest &announceReq)
                 };
 
                 if (!announceReq.noPeerId)
-                    peerDict[ANNOUNCE_RESPONSE_PEERS_PEER_ID] = lt::entry::string_type(peer.peerId.constData(), peer.peerId.size());
+                    peerDict[ANNOUNCE_RESPONSE_PEERS_PEER_ID] = toEntryString(peer.peerId);
 
                 peerList.emplace_back(peerDict);
             }


### PR DESCRIPTION
Previously it was assigning a char pointer to `lt::entry::string_type` which might be null-terminated in the middle. Now this is handled correctly.
Also clean up code formatting and add `reserve()` calls.
