### PR TITLE
Fix torrent creator crash when calculating number of pieces

### DIFF
--- a/src/base/bittorrent/torrentcreator.cpp
+++ b/src/base/bittorrent/torrentcreator.cpp
@@ -324,9 +324,13 @@ int TorrentCreator::calculateTotalPieces(const Path &inputPath, const int pieceS
     const auto &filter = ignoreDotfiles ? fileFilter : noopFilter;
 #if LIBTORRENT_VERSION_NUM >= 20100
     const std::vector<lt::create_file_entry> files = lt::list_files(inputPath.toString().toStdString(), filter);
+    if (files.empty())
+        return 0;
 #else
     lt::file_storage files;
     lt::add_files(files, inputPath.toString().toStdString(), filter);
+    if (files.num_files() == 0)
+        return 0;
 #endif
 
 #ifdef QBT_USES_LIBTORRENT2


### PR DESCRIPTION
`lt::create_torrent()` will throw exception when the files are empty. Crash only occurs with libtorrent 2.1.x and not 2.0.x.

