### PR TITLE
Fix off-by-one error

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -639,10 +639,13 @@ bool TransferListModel::setData(const QModelIndex &index, const QVariant &value,
 
 void TransferListModel::addTorrents(const QList<BitTorrent::Torrent *> &torrents)
 {
+    if (torrents.isEmpty())
+        return;
+
     qsizetype row = m_torrentList.size();
     const qsizetype total = row + torrents.size();
 
-    beginInsertRows({}, row, total);
+    beginInsertRows({}, row, (total - 1));
 
     m_torrentList.reserve(total);
     for (BitTorrent::Torrent *torrent : torrents)


### PR DESCRIPTION
The `beginInsertRows()` expects index not total count. Also guard for empty input.


ps. I plan to do a bit more clean ups in `TransferListModel` after this PR.