### PR TITLE
Don't store redundant pointer in cookies model

### DIFF
--- a/src/gui/cookiesdialog.cpp
+++ b/src/gui/cookiesdialog.cpp
@@ -63,9 +63,10 @@ CookiesDialog::CookiesDialog(QWidget *parent)
 
     m_ui->treeView->setModel(m_cookiesModel);
     if (m_cookiesModel->rowCount() > 0)
-        m_ui->treeView->selectionModel()->setCurrentIndex(
-                    m_cookiesModel->index(0, 0),
-                    QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    {
+        m_ui->treeView->selectionModel()->setCurrentIndex(m_cookiesModel->index(0, 0)
+            , (QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
+    }
 
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
         resize(dialogSize);
@@ -92,7 +93,7 @@ void CookiesDialog::onButtonAddClicked()
 
     m_cookiesModel->insertRow(row);
     m_ui->treeView->selectionModel()->setCurrentIndex(
-                m_cookiesModel->index(row, 0), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+        m_cookiesModel->index(row, 0), (QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
 }
 
 void CookiesDialog::onButtonDeleteClicked()

--- a/src/gui/cookiesmodel.cpp
+++ b/src/gui/cookiesmodel.cpp
@@ -63,14 +63,14 @@ QVariant CookiesModel::headerData(int section, Qt::Orientation orientation, int 
     return {};
 }
 
-QModelIndex CookiesModel::index(int row, int column, const QModelIndex &parent) const
+QModelIndex CookiesModel::index(const int row, const int column, const QModelIndex &parent) const
 {
     if (parent.isValid() // no items with valid parent
         || (row < 0) || (row >= m_cookies.size())
         || (column < 0) || (column >= NB_COLUMNS))
         return {};
 
-    return createIndex(row, column, &m_cookies[row]);
+    return createIndex(row, column);
 }
 
 QModelIndex CookiesModel::parent([[maybe_unused]] const QModelIndex &index) const
@@ -149,7 +149,7 @@ bool CookiesModel::insertRows(int row, int count, const QModelIndex &parent)
     QNetworkCookie newCookie;
     newCookie.setExpirationDate(QDateTime::currentDateTime().addYears(2));
 
-    beginInsertRows(parent, row, row + count - 1);
+    beginInsertRows(parent, row, (row + count - 1));
     while (count-- > 0)
         m_cookies.insert(row, newCookie);
     endInsertRows();
@@ -164,7 +164,7 @@ bool CookiesModel::removeRows(int row, int count, const QModelIndex &parent)
         || ((row + count) > m_cookies.size()))
         return false;
 
-    beginRemoveRows(parent, row, row + count - 1);
+    beginRemoveRows(parent, row, (row + count - 1));
     while (count-- > 0)
         m_cookies.removeAt(row);
     endRemoveRows();


### PR DESCRIPTION
The pointer is not in use so storing it is unnecessary.
The pointer might become dangling when the container is modified and this will trigger warnings from code analyzers.
