### PR TITLE
Allow binding to multiple network interfaces (Multi-WAN)

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -279,6 +279,8 @@ namespace BitTorrent
         virtual void setNetworkInterfaceName(const QString &name) = 0;
         virtual QString networkInterfaceAddress() const = 0;
         virtual void setNetworkInterfaceAddress(const QString &address) = 0;
+        virtual QStringList additionalNetworkInterfaces() const = 0;
+        virtual void setAdditionalNetworkInterfaces(const QStringList &ifaces) = 0;
         virtual int encryption() const = 0;
         virtual void setEncryption(int state) = 0;
         virtual int maxActiveCheckingTorrents() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -549,6 +549,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_networkInterface(BITTORRENT_SESSION_KEY(u"Interface"_s))
     , m_networkInterfaceName(BITTORRENT_SESSION_KEY(u"InterfaceName"_s))
     , m_networkInterfaceAddress(BITTORRENT_SESSION_KEY(u"InterfaceAddress"_s))
+    , m_additionalNetworkInterfaces(BITTORRENT_SESSION_KEY(u"AdditionalInterfaces"_s))
     , m_encryption(BITTORRENT_SESSION_KEY(u"Encryption"_s), 0)
     , m_maxActiveCheckingTorrents(BITTORRENT_SESSION_KEY(u"MaxActiveCheckingTorrents"_s), 1)
     , m_isProxyPeerConnectionsEnabled(BITTORRENT_SESSION_KEY(u"ProxyPeerConnections"_s), false)
@@ -3385,6 +3386,29 @@ void SessionImpl::setDownloadPath(const Path &path)
 
 QStringList SessionImpl::getListeningIPs() const
 {
+    // The primary interface (plus its optional bound address) keeps its original
+    // single-interface semantics. Any additional Multi-WAN interfaces are appended
+    // as device NAMES so that applyNetworkInterfacesSettings() binds them via
+    // SO_BINDTODEVICE (the path validated by RFC-0001 Milestone 1).
+    QStringList IPs = getPrimaryListeningIPs();
+
+    // Skip blanks, exact duplicates, and the primary interface itself. The primary may
+    // already be present as an IP address rather than a name (when an address is bound),
+    // so a plain contains() check is not enough to catch it -- binding the same interface
+    // twice would collide on the listen port.
+    const QString primaryIface = networkInterface();
+    for (const QString &iface : asConst(additionalNetworkInterfaces()))
+    {
+        if (iface.isEmpty() || (iface == primaryIface) || IPs.contains(iface))
+            continue;
+        IPs.append(iface);
+    }
+
+    return IPs;
+}
+
+QStringList SessionImpl::getPrimaryListeningIPs() const
+{
     QStringList IPs;
 
     const QString ifaceName = networkInterface();
@@ -3791,6 +3815,20 @@ void SessionImpl::setNetworkInterfaceAddress(const QString &address)
     if (address != networkInterfaceAddress())
     {
         m_networkInterfaceAddress = address;
+        configureListeningInterface();
+    }
+}
+
+QStringList SessionImpl::additionalNetworkInterfaces() const
+{
+    return m_additionalNetworkInterfaces;
+}
+
+void SessionImpl::setAdditionalNetworkInterfaces(const QStringList &ifaces)
+{
+    if (ifaces != additionalNetworkInterfaces())
+    {
+        m_additionalNetworkInterfaces = ifaces;
         configureListeningInterface();
     }
 }

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -254,6 +254,8 @@ namespace BitTorrent
         void setNetworkInterfaceName(const QString &name) override;
         QString networkInterfaceAddress() const override;
         void setNetworkInterfaceAddress(const QString &address) override;
+        QStringList additionalNetworkInterfaces() const override;
+        void setAdditionalNetworkInterfaces(const QStringList &ifaces) override;
         int encryption() const override;
         void setEncryption(int state) override;
         int maxActiveCheckingTorrents() const override;
@@ -556,6 +558,7 @@ namespace BitTorrent
         void applyBandwidthLimits();
         void processBannedIPs(lt::ip_filter &filter);
         QStringList getListeningIPs() const;
+        QStringList getPrimaryListeningIPs() const;
         void configureListeningInterface();
         void enableTracker(bool enable);
         void enableBandwidthScheduler();
@@ -743,6 +746,7 @@ namespace BitTorrent
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;
+        CachedSettingValue<QStringList> m_additionalNetworkInterfaces;
         CachedSettingValue<int> m_encryption;
         CachedSettingValue<int> m_maxActiveCheckingTorrents;
         CachedSettingValue<bool> m_isProxyPeerConnectionsEnabled;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -76,6 +76,8 @@ namespace
         NETWORK_IFACE,
         //Optional network address
         NETWORK_IFACE_ADDRESS,
+        // additional interfaces (Multi-WAN)
+        NETWORK_ADDITIONAL_IFACES,
         // behavior
         SAVE_RESUME_DATA_INTERVAL,
         SAVE_STATISTICS_INTERVAL,
@@ -314,6 +316,15 @@ void AdvancedSettings::saveAdvancedSettings() const
     // Construct a QHostAddress to filter malformed strings
     const QHostAddress ifaceAddr {m_comboBoxInterfaceAddress.currentData().toString()};
     session->setNetworkInterfaceAddress(ifaceAddr.toString());
+    // Additional network interfaces (Multi-WAN)
+    QStringList additionalIfaces;
+    for (int i = 0; i < m_listWidgetAdditionalInterfaces.count(); ++i)
+    {
+        const QListWidgetItem *item = m_listWidgetAdditionalInterfaces.item(i);
+        if (item->checkState() == Qt::Checked)
+            additionalIfaces.append(item->data(Qt::UserRole).toString());
+    }
+    session->setAdditionalNetworkInterfaces(additionalIfaces);
     // Announce IP
     // Construct a QHostAddress to filter malformed strings
     const QHostAddress addr(m_lineEditAnnounceIP.text().trimmed());
@@ -822,6 +833,36 @@ void AdvancedSettings::loadAdvancedSettings()
     // Network interface address
     updateInterfaceAddressCombo();
     addRow(NETWORK_IFACE_ADDRESS, tr("Optional IP address to bind to"), &m_comboBoxInterfaceAddress);
+    // Additional network interfaces (Multi-WAN) — peer connections are also bound to these,
+    // letting a single torrent session use more than one active link simultaneously.
+    const QStringList additionalIfaces = session->additionalNetworkInterfaces();
+    const QString primaryIface = session->networkInterface();
+    for (const QNetworkInterface &iface : asConst(QNetworkInterface::allInterfaces()))
+    {
+        const QNetworkInterface::InterfaceFlags flags = iface.flags();
+        const bool alreadySelected = additionalIfaces.contains(iface.name());
+        // Only offer usable WAN links: hide loopback, the interface already chosen as the
+        // primary above (binding it twice would collide), and down interfaces — but keep a
+        // down interface visible if it is already in the saved set, so opening this dialog
+        // does not silently drop a temporarily-disconnected link.
+        if (flags.testFlag(QNetworkInterface::IsLoopBack)
+            || (iface.name() == primaryIface)
+            || (!flags.testFlag(QNetworkInterface::IsUp) && !alreadySelected))
+            continue;
+
+        auto *item = new QListWidgetItem(iface.humanReadableName(), &m_listWidgetAdditionalInterfaces);
+        item->setData(Qt::UserRole, iface.name());
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setCheckState(alreadySelected ? Qt::Checked : Qt::Unchecked);
+    }
+    m_listWidgetAdditionalInterfaces.setMaximumHeight(120);
+    m_listWidgetAdditionalInterfaces.setToolTip(tr("Bind peer connections to these interfaces in addition to the one above,"
+        " so a single session can use multiple links at once."
+        " For best results leave \"Network interface\" set to \"Any interface\" and select every link you want to use here."
+        " On Linux, using a non-default link for outgoing connections may require the CAP_NET_RAW capability."));
+    connect(&m_listWidgetAdditionalInterfaces, &QListWidget::itemChanged, this, &AdvancedSettings::settingsChanged);
+    addRow(NETWORK_ADDITIONAL_IFACES, tr("Additional interfaces (Multi-WAN)"), &m_listWidgetAdditionalInterfaces);
+    setRowHeight(NETWORK_ADDITIONAL_IFACES, 120);
     // Announce IP
     m_lineEditAnnounceIP.setText(session->announceIP());
     addRow(ANNOUNCE_IP, (tr("IP address reported to trackers (requires restart)")

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -34,6 +34,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
+#include <QListWidget>
 #include <QSpinBox>
 #include <QTableWidget>
 
@@ -84,6 +85,7 @@ private:
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxDiskIOReadMode, m_comboBoxDiskIOWriteMode, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage, m_comboBoxTorrentContentRemoveOption;
     QLineEdit m_lineEditAppInstanceName, m_pythonExecutablePath, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes;
+    QListWidget m_listWidgetAdditionalInterfaces;
 
 #ifndef QBT_USES_LIBTORRENT2
     QSpinBox m_spinBoxCache, m_spinBoxCacheTTL;


### PR DESCRIPTION
### What this does

Adds an opt-in way to bind qBittorrent to **multiple network interfaces at once**, instead of the current single-interface limit. A new "Additional interfaces (Multi-WAN)" list in *Options → Advanced* lets the user select extra interfaces; peer connections are then distributed across all of them.

This serves two use cases:
- **Interface selection / VPN whitelisting** (the long-standing request in #12596): bind to several specific interfaces (e.g. multiple VPN tunnels) rather than just one.
- **Multi-WAN aggregation**: use more than one active link (e.g. ethernet + phone hotspot) at the same time to combine bandwidth.

### How it works

qBittorrent already pushes a list into libtorrent's `listen_interfaces`/`outgoing_interfaces` (which bind outgoing sockets round-robin); only the *input* was single-valued. This adds an `additionalNetworkInterfaces` (`QStringList`) setting and appends those interfaces — by device name, so libtorrent uses `SO_BINDTODEVICE` — in `getListeningIPs()`. The existing per-platform endpoint handling, including the Windows adapter-GUID conversion, is reused unchanged.

The primary interface keeps its exact current behaviour; with no additional interfaces selected, nothing changes.

### Validation

Tested with a well-seeded swarm (Ubuntu ISO) over two links:
- **Linux**: ~175 Mbit/s aggregate across ethernet + WiFi-hotspot (~50/50), both NICs near-saturated, vs ~98 Mbit/s for a single link.
- **Windows**: ~164 Mbit/s across Ethernet + WiFi simultaneously (confirmed in Task Manager), no admin required.

### Status — draft, seeking feedback

Opening as a draft to get a steer before finishing:
- [ ] WebUI/WebAPI parity (not yet implemented)
- [ ] Unit test for the interface-merge logic
- [ ] Screenshots (UI is a single checkable list row in Advanced; will attach)
- [ ] **Design question:** this uses an *additive* model (primary interface + an additional list). Would you prefer converting the single "Network interface" setting into a multi-select instead? That decision affects the WebUI shape, so I'd like feedback before building it.

### Known limitations

- Each bound interface announces to trackers separately with the same peer-ID, which may be undesirable on private trackers.
- With the primary set to "Any interface", only the explicitly-selected additional interfaces are used for outgoing connections, so select every link you want to use.

Related to #12596.
