### PR TITLE
WebUI: Add hover and active styles on main toolbar

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -464,7 +464,7 @@ a.propButton img {
 }
 
 .mochaToolButton:active {
-    background-color: hsl(from var(--color-background-hover) h s l / 0.5);
+    background-color: hsl(from var(--color-background-hover) h s l / 50%);
 }
 
 /* Mocha Customization */

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -459,6 +459,14 @@ a.propButton img {
     margin-right: 10px;
 }
 
+.mochaToolButton:hover {
+    background-color: var(--color-background-hover);
+}
+
+.mochaToolButton:active {
+    background-color: hsl(from var(--color-background-hover) h s l / 0.5);
+}
+
 /* Mocha Customization */
 
 #mochaToolbar {


### PR DESCRIPTION
This PR adds a `background-color` on the `active` and `hover` main toolbar in the WebUI.

This gives the user more UI feedback when moving the mouse between the buttons on the toolbar


<img width="724" height="93" alt="Screenshot from 2026-05-30 17-57-11" src="https://github.com/user-attachments/assets/c3775e0b-adc6-4e78-ad5c-ebb680d314c4" />
<img width="724" height="93" alt="Screenshot from 2026-05-30 17-57-33" src="https://github.com/user-attachments/assets/ada0b54e-88ff-4af5-a6c5-2229b47a8755" />


Only problem is the `Stop` button color is very similar to `--color-background-hover` but it still give some feedback that the `Stop` button is hovered.