### PR TITLE
WebUI: Use SameSite=Lax for session cookie to fix cross-site login

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -752,7 +752,7 @@ void WebApplication::setSessionCookie(Http::HeaderMap &headers)
         cookie.setSecure(m_isSecureCookieEnabled && isOriginTrustworthy());  // [rfc6265] 4.1.2.5. The Secure Attribute
         cookie.setPath(u"/"_s);
         if (m_isCSRFProtectionEnabled)
-            cookie.setSameSitePolicy(QNetworkCookie::SameSite::Strict);
+            cookie.setSameSitePolicy(QNetworkCookie::SameSite::Lax);
         else if (cookie.isSecure())
             cookie.setSameSitePolicy(QNetworkCookie::SameSite::None);
         headers.insert(Http::HEADER_SET_COOKIE, QString::fromLatin1(cookie.toRawForm()));


### PR DESCRIPTION
The session cookie was previously set with SameSite=Strict when CSRF protection is enabled. Strict withholds the cookie on cross-site top-level navigations, so when the WebUI is reached via a link from another origin (dashboards like Portainer or a reverse-proxied subdomain), the browser does not send the cookie on the post-login reload. The server then serves the login page again, producing the long-standing "login just refreshes" loop that users work around by editing the URL in the address bar.

Lax sends the cookie on top-level GET navigations while still withholding it on cross-site POST and cross-site subresource requests, so CSRF defense for state-changing requests is preserved. All mutating endpoints are already POST-only and additionally validated by the Origin/Referer check.

SameSite=Strict was introduced in #9884 and shipped in v4.1.5. This correlates perfectly with the reports in #10405.

Closes #10405.
