### PR TITLE
Detect and diagnose silent torrent add failure after extended uptime

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2966,9 +2966,8 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         return findIncompleteFiles(actualSavePath, actualDownloadPath, filePaths);
     };
 
-    // Start a watchdog timer to detect IO thread blockage during file search
+    // Start a watchdog timer to detect if the continuation never fires
     QPointer<QTimer> watchdogTimer;
-    if (needFindIncompleteFiles)
     {
         auto *timer = new QTimer(this);
         timer->setSingleShot(true);
@@ -2977,9 +2976,8 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
             m_addTorrentWatchdogTimers.remove(timer);
             timer->deleteLater();
 
-            LogMsg(tr("Warning: Torrent add file search is taking longer than expected. "
-                "The IO thread may be blocked. Torrent: %1. "
-                "Async calls: %2, Alerts received: %3.")
+            LogMsg(tr("Warning: Torrent add continuation did not execute within timeout. "
+                "Torrent: %1. Async calls: %2, Alerts received: %3.")
                 .arg(id.toString()
                     , QString::number(m_addTorrentCallCount)
                     , QString::number(m_addTorrentAlertReceivedCount))
@@ -2990,10 +2988,12 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         watchdogTimer = timer;
     }
 
-    resolveFileNames().then(this, [this, id, loadTorrentParams = std::move(loadTorrentParams),
+    QFuture<FileSearchResult> fileNamesFuture = resolveFileNames();
+
+    fileNamesFuture.then(this, [this, id, loadTorrentParams = std::move(loadTorrentParams),
             watchdogTimer = std::move(watchdogTimer)](const FileSearchResult &result) mutable
     {
-        // Cancel the watchdog timer since file search completed
+        // Cancel the watchdog timer since continuation is running
         if (watchdogTimer)
         {
             if (m_addTorrentWatchdogTimers.contains(watchdogTimer.data()))

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1609,6 +1609,7 @@ void SessionImpl::processNextResumeData(ResumeSessionContext *context)
 
     qDebug() << "Starting up torrent" << torrentID.toString() << "...";
     m_nativeSession->async_add_torrent(resumeData.ltAddTorrentParams);
+    ++m_addTorrentCallCount;
     m_addTorrentAlertHandlers.append([this, resumeData = std::move(resumeData)](const lt::add_torrent_alert *alert) mutable
     {
         if (alert->error)
@@ -2965,8 +2966,44 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         return findIncompleteFiles(actualSavePath, actualDownloadPath, filePaths);
     };
 
-    resolveFileNames().then(this, [this, id, loadTorrentParams = std::move(loadTorrentParams)](const FileSearchResult &result) mutable
+    // Start a watchdog timer to detect IO thread blockage during file search
+    QPointer<QTimer> watchdogTimer;
+    if (needFindIncompleteFiles)
     {
+        auto *timer = new QTimer(this);
+        timer->setSingleShot(true);
+        connect(timer, &QTimer::timeout, this, [this, id, timer]()
+        {
+            m_addTorrentWatchdogTimers.remove(timer);
+            timer->deleteLater();
+
+            LogMsg(tr("Warning: Torrent add file search is taking longer than expected. "
+                "The IO thread may be blocked. Torrent: %1. "
+                "Async calls: %2, Alerts received: %3.")
+                .arg(id.toString()
+                    , QString::number(m_addTorrentCallCount)
+                    , QString::number(m_addTorrentAlertReceivedCount))
+                , Log::WARNING);
+        });
+        m_addTorrentWatchdogTimers.insert(timer);
+        timer->start(30s);
+        watchdogTimer = timer;
+    }
+
+    resolveFileNames().then(this, [this, id, loadTorrentParams = std::move(loadTorrentParams),
+            watchdogTimer = std::move(watchdogTimer)](const FileSearchResult &result) mutable
+    {
+        // Cancel the watchdog timer since file search completed
+        if (watchdogTimer)
+        {
+            if (m_addTorrentWatchdogTimers.contains(watchdogTimer.data()))
+            {
+                m_addTorrentWatchdogTimers.remove(watchdogTimer.data());
+                watchdogTimer->stop();
+                watchdogTimer->deleteLater();
+            }
+        }
+
         lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;
 
         p.save_path = result.savePath.toString().toStdString();
@@ -2979,6 +3016,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         }
 
         m_nativeSession->async_add_torrent(p);
+        ++m_addTorrentCallCount;
         m_addTorrentAlertHandlers.append([this, loadTorrentParams = std::move(loadTorrentParams)](const lt::add_torrent_alert *alert) mutable
         {
             if (alert->error)
@@ -3165,6 +3203,7 @@ bool SessionImpl::downloadMetadata(const TorrentDescriptor &torrentDescr)
 
     // Adding torrent to libtorrent session
     m_nativeSession->async_add_torrent(p);
+    ++m_addTorrentCallCount;
     m_downloadedMetadata.insert(id, {});
     m_addTorrentAlertHandlers.append([this](const lt::add_torrent_alert *alert)
     {
@@ -5480,7 +5519,9 @@ lt::torrent_handle SessionImpl::reloadTorrent(const lt::torrent_handle &currentH
 
     // libtorrent will post an add_torrent_alert anyway, so we have to add an empty handler to ignore it.
     m_addTorrentAlertHandlers.emplaceBack();
-    return m_nativeSession->add_torrent(std::move(params));
+    const lt::torrent_handle handle = m_nativeSession->add_torrent(std::move(params));
+    ++m_addTorrentCallCount;
+    return handle;
 }
 
 void SessionImpl::moveTorrentStorage(const MoveStorageJob &job) const
@@ -5798,9 +5839,32 @@ void SessionImpl::readAlerts()
 
 void SessionImpl::handleAddTorrentAlert(const lt::add_torrent_alert *alert)
 {
-    Q_ASSERT(!m_addTorrentAlertHandlers.isEmpty());
-    if (m_addTorrentAlertHandlers.isEmpty()) [[unlikely]]
+    ++m_addTorrentAlertReceivedCount;
+
+    if (m_addTorrentAlertHandlers.isEmpty())
+    {
+        LogMsg(tr("Warning: Received add_torrent_alert but handler queue is empty. "
+            "This indicates alert handler desynchronization. Torrent: \"%1\". "
+            "Async calls: %2, Alerts received: %3")
+            .arg(QString::fromStdString(alert->params.name)
+                , QString::number(m_addTorrentCallCount)
+                , QString::number(m_addTorrentAlertReceivedCount))
+            , Log::WARNING);
         return;
+    }
+
+    if (m_addTorrentAlertReceivedCount > m_addTorrentCallCount)
+    {
+        if (!m_desyncWarningLogged)
+        {
+            m_desyncWarningLogged = true;
+            LogMsg(tr("Warning: More add_torrent_alerts received (%1) than "
+                "async_add_torrent calls (%2). Alert handler queue may be desynchronized.")
+                .arg(QString::number(m_addTorrentAlertReceivedCount)
+                    , QString::number(m_addTorrentCallCount))
+                , Log::WARNING);
+        }
+    }
 
     if (const AddTorrentAlertHandler handleAlert = m_addTorrentAlertHandlers.takeFirst())
         handleAlert(alert);
@@ -6326,6 +6390,16 @@ void SessionImpl::handleAlertsDroppedAlert(const lt::alerts_dropped_alert *alert
 {
     LogMsg(tr("Error: Internal alert queue is full and alerts are dropped, you might see degraded performance. Dropped alert type: \"%1\". Message: \"%2\"")
         .arg(QString::fromStdString(alert->dropped_alerts.to_string()), QString::fromStdString(alert->message())), Log::CRITICAL);
+
+    if (alert->dropped_alerts.test(lt::add_torrent_alert::alert_type))
+    {
+        LogMsg(tr("Warning: add_torrent_alert was among dropped alerts. "
+            "This may cause alert handler queue desynchronization. "
+            "Async calls: %1, Alerts received: %2.")
+            .arg(QString::number(m_addTorrentCallCount)
+                , QString::number(m_addTorrentAlertReceivedCount))
+            , Log::WARNING);
+    }
 }
 
 void SessionImpl::handleStorageMovedAlert(const lt::storage_moved_alert *alert)

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -829,6 +829,14 @@ namespace BitTorrent
         using AddTorrentAlertHandler = std::function<void (const lt::add_torrent_alert *alert)>;
         QList<AddTorrentAlertHandler> m_addTorrentAlertHandlers;
 
+        // Diagnostic counters for detecting alert handler queue desynchronization
+        qint64 m_addTorrentCallCount = 0;
+        qint64 m_addTorrentAlertReceivedCount = 0;
+        bool m_desyncWarningLogged = false;
+        // Raw pointers are safe here: timers are parented to `this` and all access
+        // is on the session thread. The set is tracking-only, not owning.
+        QSet<QTimer *> m_addTorrentWatchdogTimers;
+
         QHash<TorrentID, lt::torrent_handle> m_downloadedMetadata;
 
         QHash<TorrentID, TorrentImpl *> m_torrents;
@@ -839,7 +847,6 @@ namespace BitTorrent
         TagSet m_tags;
 
         std::vector<lt::alert *> m_alerts;  // make it a class variable so it can preserve its allocated `capacity`
-        qsizetype m_receivedAddTorrentAlertsCount = 0;
         QList<Torrent *> m_loadedTorrents;
 
         // This field holds amounts of peers reported by trackers in their responses to announces


### PR DESCRIPTION
Fixes #24367

## Problem

After running qBittorrent for several days, `/api/v2/torrents/add` returns
`success_count: 1` but the torrent never appears in the client. No error is
logged. Restarting qBittorrent resolves the issue.

The root cause is an async gap in `addTorrent_impl()`: the method returns
`true` (telling the API the torrent was added) before `async_add_torrent()`
is actually called. The real add happens inside a `.then()` continuation
that runs when file search completes on `m_ioThread`. If that thread is
blocked, or if libtorrent's alert queue drops `add_torrent_alert`s (causing
the `m_addTorrentAlertHandlers` FIFO to desynchronize), the torrent is
never added — but the API already reported success.

## Changes

### Diagnostic counters (`sessionimpl.h`)

- `m_addTorrentCallCount` — incremented at every `async_add_torrent()`
  and synchronous `add_torrent()` call site (4 total)
- `m_addTorrentAlertReceivedCount` — incremented in
  `handleAddTorrentAlert()` for each received alert
- `m_desyncWarningLogged` — ensures the counter mismatch warning is
  logged at most once to prevent log spam

### Watchdog timer for IO thread blockage (`addTorrent_impl()`)

A 30-second `QTimer` is started when `findIncompleteFiles()` dispatches
to `m_ioThread`. If the `.then()` continuation hasn't fired when the
timer elapses, a `WARNING` is logged with diagnostic counters. The timer
is cancelled if the continuation completes normally.

### Diagnostic logging (`handleAddTorrentAlert()`)

- Logs `WARNING` when `add_torrent_alert` arrives but the handler queue
  is empty (desynchronization detected)
- Logs `WARNING` once when received count exceeds call count (queue
  overflow indicator)

### Alert drop detection (`handleAlertsDroppedAlert()`)

When `alerts_dropped_alert` fires and `add_torrent_alert` is among the
dropped types, logs a `WARNING` with diagnostic counters. Handler removal
was intentionally not implemented because libtorrent does not guarantee
ordering of `alerts_dropped_alert` relative to surviving alerts within
the same batch — removing the wrong handler could worsen desynchronization.

### Cleanup

- Removed unused `m_receivedAddTorrentAlertsCount` member
- Renamed `m_asyncAddTorrentCallCount` to `m_addTorrentCallCount`
  (tracks both sync and async calls since both produce alerts)

## Files changed

- `src/base/bittorrent/sessionimpl.h` — new member variables, removed
  dead member
- `src/base/bittorrent/sessionimpl.cpp` — watchdog timer, diagnostic
  logging, counter increments at all call sites