### PR TITLE
Revise container usage

### DIFF
--- a/src/base/bittorrent/torrentcreationmanager.cpp
+++ b/src/base/bittorrent/torrentcreationmanager.cpp
@@ -32,9 +32,8 @@
 #include <utility>
 
 #include <boost/multi_index_container.hpp>
-#include <boost/multi_index/composite_key.hpp>
 #include <boost/multi_index/indexed_by.hpp>
-#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/key.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 
 #include <QUuid>
@@ -45,14 +44,12 @@ namespace BitTorrent
 {
     using namespace boost::multi_index;
 
-    class TorrentCreationManager::TaskSet final : public boost::multi_index_container<
-            std::shared_ptr<TorrentCreationTask>,
-            indexed_by<
-                    ordered_unique<tag<struct ByID>, const_mem_fun<TorrentCreationTask, QString, &TorrentCreationTask::id>>,
-                    ordered_non_unique<tag<struct ByCompletion>, composite_key<
-                            TorrentCreationTask,
-                            const_mem_fun<TorrentCreationTask, bool, &TorrentCreationTask::isFinished>,
-                            const_mem_fun<TorrentCreationTask, QDateTime, &TorrentCreationTask::timeAdded>>>>>
+    class TorrentCreationManager::TaskSet final : public multi_index_container<
+        std::shared_ptr<TorrentCreationTask>,
+        indexed_by<
+            ordered_unique<tag<struct ByID>, key<&TorrentCreationTask::id>>,
+            ordered_non_unique<tag<struct ByCompletion>,
+                key<&TorrentCreationTask::isFinished, &TorrentCreationTask::timeAdded>>>>
     {
     };
 }
@@ -72,7 +69,7 @@ BitTorrent::TorrentCreationManager::TorrentCreationManager(IApplication *app, QO
 
 BitTorrent::TorrentCreationManager::~TorrentCreationManager() = default;
 
-std::shared_ptr<BitTorrent::TorrentCreationTask> BitTorrent::TorrentCreationManager::createTask(const TorrentCreatorParams &params, bool startSeeding)
+std::shared_ptr<BitTorrent::TorrentCreationTask> BitTorrent::TorrentCreationManager::createTask(const TorrentCreatorParams &params, const bool startSeeding)
 {
     if (std::cmp_greater_equal(m_tasks->size(), m_maxTasks.get()))
     {

--- a/src/gui/trackerlist/trackerlistmodel.cpp
+++ b/src/gui/trackerlist/trackerlistmodel.cpp
@@ -33,10 +33,9 @@
 #include <chrono>
 
 #include <boost/multi_index_container.hpp>
-#include <boost/multi_index/composite_key.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/indexed_by.hpp>
-#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/key.hpp>
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index/tag.hpp>
 
@@ -135,14 +134,10 @@ struct TrackerListModel::Item final
 
     std::weak_ptr<Item> parentItem {};
 
-    multi_index_container<std::shared_ptr<Item>, indexed_by<
-            random_access<>,
-            hashed_unique<tag<struct ByID>, composite_key<
-                    Item,
-                    member<Item, QString, &Item::name>,
-                    member<Item, int, &Item::btVersion>
-            >>
-    >> childItems {};
+    using ChildItems = multi_index_container<std::shared_ptr<Item>, indexed_by<
+        random_access<tag<struct ByIndex>>,
+        hashed_unique<tag<struct ByID>, key<&Item::name, &Item::btVersion>>>>;
+    ChildItems childItems {};
 
     Item(QStringView name, QStringView message);
     explicit Item(const BitTorrent::TrackerEntryStatus &trackerEntryStatus);
@@ -155,10 +150,10 @@ struct TrackerListModel::Item final
 };
 
 class TrackerListModel::Items final : public multi_index_container<
-        std::shared_ptr<Item>,
-        indexed_by<
-                random_access<>,
-                hashed_unique<tag<struct ByName>, member<Item, QString, &Item::name>>>>
+    std::shared_ptr<Item>,
+    indexed_by<
+        random_access<tag<struct ByIndex>>,
+        hashed_unique<tag<struct ByName>, key<&Item::name>>>>
 {
 };
 
@@ -308,15 +303,18 @@ void TrackerListModel::populate()
 {
     Q_ASSERT(m_torrent);
 
+    auto &itemsByPos = m_items->get<ByIndex>();
+
     const QList<BitTorrent::TrackerEntryStatus> trackers = m_torrent->trackers();
-    m_items->reserve(trackers.size() + STICKY_ROW_COUNT);
+    m_items->get<ByIndex>().reserve(trackers.size() + STICKY_ROW_COUNT);
+    m_items->get<ByName>().reserve(trackers.size() + STICKY_ROW_COUNT);
 
     const QString &privateTorrentMessage = m_torrent->isPrivate() ? tr(STR_PRIVATE_MSG) : u""_s;
-    m_items->emplace_back(std::make_shared<Item>(u"** [DHT] **", privateTorrentMessage));
-    m_items->emplace_back(std::make_shared<Item>(u"** [PeX] **", privateTorrentMessage));
-    m_items->emplace_back(std::make_shared<Item>(u"** [LSD] **", privateTorrentMessage));
+    itemsByPos.emplace_back(std::make_shared<Item>(u"** [DHT] **", privateTorrentMessage));
+    itemsByPos.emplace_back(std::make_shared<Item>(u"** [PeX] **", privateTorrentMessage));
+    itemsByPos.emplace_back(std::make_shared<Item>(u"** [LSD] **", privateTorrentMessage));
 
-    m_torrent->fetchPeerInfo().then(this, [this, torrent = QPointer(m_torrent)](const QList<BitTorrent::PeerInfo> &peers)
+    m_torrent->fetchPeerInfo().then(this, [this, &itemsByPos, torrent = QPointer(m_torrent)](const QList<BitTorrent::PeerInfo> &peers)
     {
         if (!m_torrent || (m_torrent != torrent))
            return;
@@ -353,7 +351,6 @@ void TrackerListModel::populate()
             }
         }
 
-        auto &itemsByPos = m_items->get<0>();
         itemsByPos.modify((itemsByPos.begin() + ROW_DHT), [&seedsDHT, &peersDHT](std::shared_ptr<Item> &item)
         {
             item->numSeeds = seedsDHT;
@@ -386,15 +383,17 @@ void TrackerListModel::populate()
 std::shared_ptr<TrackerListModel::Item> TrackerListModel::createTrackerItem(const BitTorrent::TrackerEntryStatus &trackerEntryStatus)
 {
     const auto item = std::make_shared<Item>(trackerEntryStatus);
+    item->childItems.get<ByIndex>().reserve(trackerEntryStatus.endpoints.size());
+    item->childItems.get<ByID>().reserve(trackerEntryStatus.endpoints.size());
     for (const auto &[id, endpointStatus] : trackerEntryStatus.endpoints.asKeyValueRange())
-        item->childItems.emplace_back(std::make_shared<Item>(item, endpointStatus));
+        item->childItems.get<ByIndex>().emplace_back(std::make_shared<Item>(item, endpointStatus));
 
     return item;
 }
 
 void TrackerListModel::addTrackerItem(const BitTorrent::TrackerEntryStatus &trackerEntryStatus)
 {
-    [[maybe_unused]] const auto &[iter, res] = m_items->emplace_back(createTrackerItem(trackerEntryStatus));
+    [[maybe_unused]] const auto &[iter, res] = m_items->get<ByIndex>().emplace_back(createTrackerItem(trackerEntryStatus));
     Q_ASSERT(res);
 }
 
@@ -407,7 +406,7 @@ void TrackerListModel::updateTrackerItem(const std::shared_ptr<Item> &item, cons
         endpointItemIDs.insert(id);
 
         auto &itemsByID = item->childItems.get<ByID>();
-        if (const auto &iter = itemsByID.find(std::make_tuple(id.first, id.second)); iter != itemsByID.end())
+        if (const auto iter = itemsByID.find(std::make_tuple(id.first, id.second)); iter != itemsByID.end())
         {
             (*iter)->fillFrom(endpointStatus);
         }
@@ -417,12 +416,12 @@ void TrackerListModel::updateTrackerItem(const std::shared_ptr<Item> &item, cons
         }
     }
 
-    const auto &itemsByPos = m_items->get<0>();
-    const auto trackerRow = std::distance(itemsByPos.begin(), itemsByPos.iterator_to(item));
+    const auto trackerRow = std::distance(m_items->get<ByIndex>().begin(), m_items->get<ByIndex>().iterator_to(item));
     const auto trackerIndex = index(trackerRow, 0);
 
-    auto it = item->childItems.begin();
-    while (it != item->childItems.end())
+    auto &childItemsByPos = item->childItems.get<ByIndex>();
+    auto it = childItemsByPos.begin();
+    while (it != childItemsByPos.end())
     {
         if (const auto endpointItemID = std::make_pair((*it)->name, (*it)->btVersion)
                 ; endpointItemIDs.contains(endpointItemID))
@@ -431,9 +430,9 @@ void TrackerListModel::updateTrackerItem(const std::shared_ptr<Item> &item, cons
         }
         else
         {
-            const auto row = std::distance(item->childItems.begin(), it);
+            const auto row = std::distance(childItemsByPos.begin(), it);
             beginRemoveRows(trackerIndex, row, row);
-            it = item->childItems.erase(it);
+            it = childItemsByPos.erase(it);
             endRemoveRows();
         }
     }
@@ -444,8 +443,10 @@ void TrackerListModel::updateTrackerItem(const std::shared_ptr<Item> &item, cons
     if (!newEndpointItems.isEmpty())
     {
         beginInsertRows(trackerIndex, numRows, (numRows + newEndpointItems.size() - 1));
+        item->childItems.get<ByIndex>().reserve(newEndpointItems.size());
+        item->childItems.get<ByID>().reserve(newEndpointItems.size());
         for (const auto &newEndpointItem : asConst(newEndpointItems))
-            item->childItems.get<0>().push_back(newEndpointItem);
+            childItemsByPos.push_back(newEndpointItem);
         endInsertRows();
     }
 
@@ -673,8 +674,8 @@ QModelIndex TrackerListModel::index(const int row, const int column, const QMode
         return {};
 
     const std::shared_ptr<Item> item = parent.isValid()
-            ? m_items->at(static_cast<std::size_t>(parent.row()))->childItems.at(row)
-            : m_items->at(static_cast<std::size_t>(row));
+            ? m_items->get<ByIndex>().at(static_cast<std::size_t>(parent.row()))->childItems.at(row)
+            : m_items->get<ByIndex>().at(static_cast<std::size_t>(row));
     return createIndex(row, column, item.get());
 }
 
@@ -698,8 +699,8 @@ QModelIndex TrackerListModel::parent(const QModelIndex &index) const
     if (itemsByNameIter == itemsByName.end()) [[unlikely]]
         return {};
 
-    const auto &itemsByPosIter = m_items->project<0>(itemsByNameIter);
-    const auto row = std::distance(m_items->get<0>().begin(), itemsByPosIter);
+    const auto &itemsByPosIter = m_items->project<ByIndex>(itemsByNameIter);
+    const auto row = std::distance(m_items->get<ByIndex>().begin(), itemsByPosIter);
 
     // From https://doc.qt.io/qt-6/qabstractitemmodel.html#parent:
     // A common convention used in models that expose tree data structures is that only items
@@ -722,10 +723,10 @@ void TrackerListModel::onTrackersRemoved(const QStringList &deletedTrackers)
     for (const QString &trackerURL : deletedTrackers)
     {
         auto &itemsByName = m_items->get<ByName>();
-        if (auto iter = itemsByName.find(trackerURL); iter != itemsByName.end())
+        if (const auto iter = itemsByName.find(trackerURL); iter != itemsByName.end())
         {
-            const auto &iterByPos = m_items->project<0>(iter);
-            const auto row = std::distance(m_items->get<0>().begin(), iterByPos);
+            const auto &iterByPos = m_items->project<ByIndex>(iter);
+            const auto row = std::distance(m_items->get<ByIndex>().begin(), iterByPos);
             beginRemoveRows({}, row, row);
             itemsByName.erase(iter);
             endRemoveRows();
@@ -737,7 +738,7 @@ void TrackerListModel::onTrackersChanged()
 {
     QSet<QString> trackerItemIDs;
     for (int i = 0; i < STICKY_ROW_COUNT; ++i)
-        trackerItemIDs.insert(m_items->at(i)->name);
+        trackerItemIDs.insert(m_items->get<ByIndex>().at(i)->name);
 
     QList<std::shared_ptr<Item>> newTrackerItems;
     for (const BitTorrent::TrackerEntryStatus &trackerEntryStatus : asConst(m_torrent->trackers()))
@@ -745,7 +746,7 @@ void TrackerListModel::onTrackersChanged()
         trackerItemIDs.insert(trackerEntryStatus.url);
 
         auto &itemsByName = m_items->get<ByName>();
-        if (const auto &iter = itemsByName.find(trackerEntryStatus.url); iter != itemsByName.end())
+        if (const auto iter = itemsByName.find(trackerEntryStatus.url); iter != itemsByName.end())
         {
             updateTrackerItem(*iter, trackerEntryStatus);
         }
@@ -755,8 +756,8 @@ void TrackerListModel::onTrackersChanged()
         }
     }
 
-    auto it = m_items->begin();
-    while (it != m_items->end())
+    auto it = m_items->get<ByIndex>().begin();
+    while (it != m_items->get<ByIndex>().end())
     {
         if (trackerItemIDs.contains((*it)->name))
         {
@@ -764,19 +765,23 @@ void TrackerListModel::onTrackersChanged()
         }
         else
         {
-            const auto row = std::distance(m_items->begin(), it);
+            const auto row = std::distance(m_items->get<ByIndex>().begin(), it);
             beginRemoveRows({}, row, row);
-            it = m_items->erase(it);
+            it = m_items->get<ByIndex>().erase(it);
             endRemoveRows();
         }
     }
 
     if (!newTrackerItems.isEmpty())
     {
-        const int numRows = rowCount();
-        beginInsertRows({}, numRows, (numRows + newTrackerItems.size() - 1));
+        const int row = rowCount();
+        const int total = row + newTrackerItems.size();
+
+        beginInsertRows({}, row, (total - 1));
+        m_items->get<ByIndex>().reserve(total);
+        m_items->get<ByName>().reserve(total);
         for (const auto &newTrackerItem : asConst(newTrackerItems))
-            m_items->get<0>().push_back(newTrackerItem);
+            m_items->get<ByIndex>().push_back(newTrackerItem);
         endInsertRows();
     }
 }
@@ -786,7 +791,7 @@ void TrackerListModel::onTrackersUpdated(const QHash<QString, BitTorrent::Tracke
     for (const auto &[url, tracker] : updatedTrackers.asKeyValueRange())
     {
         auto &itemsByName = m_items->get<ByName>();
-        if (const auto &iter = itemsByName.find(tracker.url); iter != itemsByName.end()) [[likely]]
+        if (const auto iter = itemsByName.find(tracker.url); iter != itemsByName.end()) [[likely]]
         {
             updateTrackerItem(*iter, tracker);
         }


### PR DESCRIPTION
* Add `reserve()` calls. Each index needs to call independently.
* Use `key` template helper. This can simplify code.
* Add `ByIndex` tag. This improves readability and avoid ambiguity.

There should be no user visible changes.

