### PR TITLE
Avoid torrent root path collisions

### DIFF
--- a/src/base/bittorrent/filesearcher.cpp
+++ b/src/base/bittorrent/filesearcher.cpp
@@ -28,12 +28,21 @@
 
 #include "filesearcher.h"
 
+#include <algorithm>
+
 #include <QPromise>
 
 #include "base/bittorrent/common.h"
 
 namespace
 {
+    Path makeRootFolderVariant(const Path &rootFolder, const int suffix)
+    {
+        Q_ASSERT(suffix > 0);
+
+        return Path(rootFolder.data() + u" (" + QString::number(suffix) + u")");
+    }
+
     bool findInDir(const Path &dirPath, PathList &fileNames, const bool forceAppendExt)
     {
         bool found = false;
@@ -62,11 +71,43 @@ namespace
     }
 }
 
+Path FileSearcher::makeRootFolderUnique(PathList &fileNames, const Path &baseRootFolder, const QList<Path> &basePaths
+        , const QSet<Path> &occupiedRootPaths)
+{
+    const Path rootFolder = Path::findRootFolder(fileNames);
+    if (rootFolder.isEmpty())
+        return {};
+
+    const Path baseVariantRootFolder = (baseRootFolder.isEmpty() ? rootFolder : baseRootFolder);
+    Path newRootFolder = rootFolder;
+    for (int suffix = 1; ; ++suffix)
+    {
+        const auto iter = std::ranges::find_if(basePaths, [&occupiedRootPaths, &newRootFolder](const Path &basePath)
+        {
+            return !basePath.isEmpty() && occupiedRootPaths.contains(basePath / newRootFolder);
+        });
+        if (iter == basePaths.cend())
+            break;
+
+        newRootFolder = makeRootFolderVariant(baseVariantRootFolder, suffix);
+    }
+
+    if (newRootFolder != rootFolder)
+    {
+        Path::stripRootFolder(fileNames);
+        Path::addRootFolder(fileNames, newRootFolder);
+    }
+
+    return newRootFolder;
+}
+
 void FileSearcher::search(const PathList &originalFileNames, const Path &savePath
-        , const Path &downloadPath, const bool forceAppendExt, QPromise<FileSearchResult> &promise)
+        , const Path &downloadPath, const bool forceAppendExt, const QSet<Path> &occupiedRootPaths
+        , QPromise<FileSearchResult> &promise)
 {
     Path usedPath = savePath;
     PathList adjustedFileNames = originalFileNames;
+    const Path rootFolder = Path::findRootFolder(originalFileNames);
     const bool found = findInDir(usedPath, adjustedFileNames, (forceAppendExt && downloadPath.isEmpty()));
     if (!found && !downloadPath.isEmpty())
     {
@@ -74,5 +115,10 @@ void FileSearcher::search(const PathList &originalFileNames, const Path &savePat
         findInDir(usedPath, adjustedFileNames, forceAppendExt);
     }
 
-    promise.addResult(FileSearchResult {.savePath = usedPath, .fileNames = adjustedFileNames});
+    QList<Path> basePaths {usedPath};
+    if (savePath != usedPath)
+        basePaths.append(savePath);
+    makeRootFolderUnique(adjustedFileNames, rootFolder, basePaths, occupiedRootPaths);
+
+    promise.addResult(FileSearchResult {.savePath = usedPath, .fileNames = adjustedFileNames, .rootFolder = rootFolder});
 }

--- a/src/base/bittorrent/filesearcher.h
+++ b/src/base/bittorrent/filesearcher.h
@@ -28,7 +28,9 @@
 
 #pragma once
 
+#include <QList>
 #include <QObject>
+#include <QSet>
 
 #include "base/path.h"
 
@@ -38,6 +40,7 @@ struct FileSearchResult
 {
     Path savePath;
     PathList fileNames;
+    Path rootFolder;
 };
 
 class FileSearcher final : public QObject
@@ -48,6 +51,10 @@ class FileSearcher final : public QObject
 public:
     using QObject::QObject;
 
+    static Path makeRootFolderUnique(PathList &fileNames, const Path &baseRootFolder, const QList<Path> &basePaths
+            , const QSet<Path> &occupiedRootPaths);
+
     void search(const PathList &originalFileNames, const Path &savePath
-            , const Path &downloadPath, bool forceAppendExt, QPromise<FileSearchResult> &promise);
+            , const Path &downloadPath, bool forceAppendExt, const QSet<Path> &occupiedRootPaths
+            , QPromise<FileSearchResult> &promise);
 };

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2663,6 +2663,54 @@ qsizetype SessionImpl::torrentsCount() const
     return m_torrents.size();
 }
 
+QSet<Path> SessionImpl::occupiedTorrentRootPaths() const
+{
+    QSet<Path> result = m_pendingTorrentRootPaths;
+    for (const TorrentImpl *torrent : asConst(m_torrents))
+    {
+        const Path rootFolder = Path::findRootFolder(torrent->filePaths());
+        if (rootFolder.isEmpty())
+            continue;
+
+        const auto addRootPath = [&result, &rootFolder](const Path &basePath)
+        {
+            if (!basePath.isEmpty())
+                result.insert(basePath / rootFolder);
+        };
+        addRootPath(torrent->actualStorageLocation());
+        addRootPath(torrent->savePath());
+    }
+
+    return result;
+}
+
+QSet<Path> SessionImpl::reservePendingTorrentRootPaths(FileSearchResult &result, const Path &savePath)
+{
+    QList<Path> basePaths {result.savePath};
+    if (savePath != result.savePath)
+        basePaths.append(savePath);
+
+    const Path rootFolder = FileSearcher::makeRootFolderUnique(result.fileNames, result.rootFolder, basePaths, occupiedTorrentRootPaths());
+    if (rootFolder.isEmpty())
+        return {};
+
+    QSet<Path> rootPaths;
+    for (const Path &basePath : asConst(basePaths))
+    {
+        if (!basePath.isEmpty())
+            rootPaths.insert(basePath / rootFolder);
+    }
+
+    m_pendingTorrentRootPaths.unite(rootPaths);
+    return rootPaths;
+}
+
+void SessionImpl::releasePendingTorrentRootPaths(const QSet<Path> &rootPaths)
+{
+    for (const Path &rootPath : rootPaths)
+        m_pendingTorrentRootPaths.remove(rootPath);
+}
+
 bool SessionImpl::addTorrent(const TorrentDescriptor &torrentDescr, const AddTorrentParams &params)
 {
     if (!isRestored())
@@ -2958,16 +3006,22 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
     const auto resolveFileNames = [&, this]
     {
         if (!needFindIncompleteFiles)
-            return QtFuture::makeReadyValueFuture(FileSearchResult {.savePath = actualSavePath, .fileNames = filePaths});
+            return QtFuture::makeReadyValueFuture(FileSearchResult {
+                    .savePath = actualSavePath
+                    , .fileNames = filePaths
+                    , .rootFolder = Path::findRootFolder(filePaths)});
 
         const Path actualDownloadPath = loadTorrentParams.useAutoTMM
                 ? categoryDownloadPath(loadTorrentParams.category) : loadTorrentParams.downloadPath;
         return findIncompleteFiles(actualSavePath, actualDownloadPath, filePaths);
     };
 
-    resolveFileNames().then(this, [this, id, loadTorrentParams = std::move(loadTorrentParams)](const FileSearchResult &result) mutable
+    resolveFileNames().then(this, [this, id, actualSavePath, needFindIncompleteFiles
+            , loadTorrentParams = std::move(loadTorrentParams)](FileSearchResult result) mutable
     {
         lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;
+        const QSet<Path> pendingRootPaths = (needFindIncompleteFiles
+                ? reservePendingTorrentRootPaths(result, actualSavePath) : QSet<Path>());
 
         p.save_path = result.savePath.toString().toStdString();
         if (p.ti)
@@ -2979,8 +3033,10 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         }
 
         m_nativeSession->async_add_torrent(p);
-        m_addTorrentAlertHandlers.append([this, loadTorrentParams = std::move(loadTorrentParams)](const lt::add_torrent_alert *alert) mutable
+        m_addTorrentAlertHandlers.append([this, pendingRootPaths, loadTorrentParams = std::move(loadTorrentParams)](const lt::add_torrent_alert *alert) mutable
         {
+            releasePendingTorrentRootPaths(pendingRootPaths);
+
             if (alert->error)
             {
                 const QString msg = QString::fromStdString(alert->message());
@@ -3022,9 +3078,10 @@ QFuture<FileSearchResult> SessionImpl::findIncompleteFiles(const Path &savePath,
     QPromise<FileSearchResult> promise;
     QFuture<FileSearchResult> future = promise.future();
     promise.start();
+    const QSet<Path> occupiedRootPaths = occupiedTorrentRootPaths();
     QMetaObject::invokeMethod(m_fileSearcher, [=, this, promise = std::move(promise)]() mutable
     {
-        m_fileSearcher->search(filePaths, savePath, downloadPath, isAppendExtensionEnabled(), promise);
+        m_fileSearcher->search(filePaths, savePath, downloadPath, isAppendExtensionEnabled(), occupiedRootPaths, promise);
         promise.finish();
     });
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -486,6 +486,9 @@ namespace BitTorrent
 
         lt::torrent_handle reloadTorrent(const lt::torrent_handle &currentHandle, lt::add_torrent_params params);
 
+        QSet<Path> occupiedTorrentRootPaths() const;
+        QSet<Path> reservePendingTorrentRootPaths(FileSearchResult &result, const Path &savePath);
+        void releasePendingTorrentRootPaths(const QSet<Path> &rootPaths);
         QFuture<FileSearchResult> findIncompleteFiles(const Path &savePath, const Path &downloadPath, const PathList &filePaths = {}) const;
 
         void enablePortMapping();
@@ -835,6 +838,7 @@ namespace BitTorrent
         QHash<TorrentID, TorrentImpl *> m_hybridTorrentsByAltID;
         QHash<TorrentID, RemovingTorrentData> m_removingTorrents;
         QHash<TorrentID, TorrentID> m_changedTorrentIDs;
+        QSet<Path> m_pendingTorrentRootPaths;
         QMap<QString, CategoryOptions> m_categories;
         TagSet m_tags;
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2215,11 +2215,16 @@ void TorrentImpl::handleSaveResumeData(lt::add_torrent_params params)
                 filePaths[i] = Path(it->second);
         }
 
-        m_session->findIncompleteFiles(savePath(), downloadPath(), filePaths).then(this
-                , [this](const FileSearchResult &result)
+        const Path finalSavePath = savePath();
+        m_session->findIncompleteFiles(finalSavePath, downloadPath(), filePaths).then(this
+                , [this, finalSavePath](FileSearchResult result)
         {
             if (m_maintenanceJob == MaintenanceJob::HandleMetadata)
+            {
+                const QSet<Path> pendingRootPaths = m_session->reservePendingTorrentRootPaths(result, finalSavePath);
                 endReceivedMetadataHandling(result.savePath, result.fileNames);
+                m_session->releasePendingTorrentRootPaths(pendingRootPaths);
+            }
         });
     }
     else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories("../src")
 
 set(testFiles
     testalgorithm.cpp
+    testbittorrentfilesearcher.cpp
     testbittorrentpeeraddress.cpp
     testbittorrenttrackerentry.cpp
     testconceptsexplicitlyconvertibleto.cpp

--- a/test/testbittorrentfilesearcher.cpp
+++ b/test/testbittorrentfilesearcher.cpp
@@ -1,0 +1,185 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  qBittorrent project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QFile>
+#include <QFuture>
+#include <QObject>
+#include <QPromise>
+#include <QSet>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include "base/bittorrent/filesearcher.h"
+#include "base/global.h"
+#include "base/path.h"
+#include "base/utils/fs.h"
+
+class TestBitTorrentFileSearcher final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestBitTorrentFileSearcher)
+
+public:
+    TestBitTorrentFileSearcher() = default;
+
+private:
+    FileSearchResult search(const PathList &fileNames, const Path &savePath
+            , const Path &downloadPath = {}, const bool forceAppendExt = false
+            , const QSet<Path> &occupiedRootPaths = {}) const
+    {
+        QPromise<FileSearchResult> promise;
+        QFuture<FileSearchResult> future = promise.future();
+        promise.start();
+
+        FileSearcher fileSearcher;
+        fileSearcher.search(fileNames, savePath, downloadPath, forceAppendExt, occupiedRootPaths, promise);
+        promise.finish();
+
+        future.waitForFinished();
+        return future.result();
+    }
+
+private slots:
+    void testPreserveExistingRootWhenItIsNotOccupied() const
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        const Path savePath {tempDir.path()};
+        QVERIFY(Utils::Fs::mkpath(savePath / Path(u"Torrent"_s)));
+        QVERIFY(QFile((savePath / Path(u"Torrent/file.txt"_s)).data()).open(QIODevice::WriteOnly));
+
+        const FileSearchResult result = search({Path(u"Torrent/file.txt"_s)}, savePath);
+
+        QCOMPARE_EQ(result.savePath, savePath);
+        QCOMPARE_EQ(result.fileNames, PathList({Path(u"Torrent/file.txt"_s)}));
+    }
+
+    void testAvoidOccupiedRoot() const
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        const Path savePath {tempDir.path()};
+        const QSet<Path> occupiedRootPaths {savePath / Path(u"Torrent"_s)};
+
+        const FileSearchResult result = search({Path(u"Torrent/file.txt"_s)}, savePath, {}, false, occupiedRootPaths);
+
+        QCOMPARE_EQ(result.savePath, savePath);
+        QCOMPARE_EQ(result.fileNames, PathList({Path(u"Torrent (1)/file.txt"_s)}));
+    }
+
+    void testAvoidMultipleOccupiedRoots() const
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        const Path savePath {tempDir.path()};
+        const QSet<Path> occupiedRootPaths
+        {
+            savePath / Path(u"Torrent"_s),
+            savePath / Path(u"Torrent (1)"_s)
+        };
+
+        const FileSearchResult result = search({Path(u"Torrent/file.txt"_s)}, savePath, {}, false, occupiedRootPaths);
+
+        QCOMPARE_EQ(result.savePath, savePath);
+        QCOMPARE_EQ(result.fileNames, PathList({Path(u"Torrent (2)/file.txt"_s)}));
+    }
+
+    void testAvoidOccupiedRootInDownloadPath() const
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        const Path basePath {tempDir.path()};
+        const Path savePath = basePath / Path(u"save"_s);
+        const Path downloadPath = basePath / Path(u"incomplete"_s);
+        const QSet<Path> occupiedRootPaths {downloadPath / Path(u"Torrent"_s)};
+
+        const FileSearchResult result = search({Path(u"Torrent/file.txt"_s)}, savePath, downloadPath, false, occupiedRootPaths);
+
+        QCOMPARE_EQ(result.savePath, downloadPath);
+        QCOMPARE_EQ(result.fileNames, PathList({Path(u"Torrent (1)/file.txt"_s)}));
+    }
+
+    void testAvoidOccupiedRootInFinalSavePath() const
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        const Path basePath {tempDir.path()};
+        const Path savePath = basePath / Path(u"save"_s);
+        const Path downloadPath = basePath / Path(u"incomplete"_s);
+        const QSet<Path> occupiedRootPaths {savePath / Path(u"Torrent"_s)};
+
+        const FileSearchResult result = search({Path(u"Torrent/file.txt"_s)}, savePath, downloadPath, false, occupiedRootPaths);
+
+        QCOMPARE_EQ(result.savePath, downloadPath);
+        QCOMPARE_EQ(result.fileNames, PathList({Path(u"Torrent (1)/file.txt"_s)}));
+    }
+
+    void testAvoidOccupiedRootsAcrossStoragePaths() const
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        const Path basePath {tempDir.path()};
+        const Path savePath = basePath / Path(u"save"_s);
+        const Path downloadPath = basePath / Path(u"incomplete"_s);
+        const QSet<Path> occupiedRootPaths
+        {
+            downloadPath / Path(u"Torrent"_s),
+            savePath / Path(u"Torrent (1)"_s)
+        };
+
+        const FileSearchResult result = search({Path(u"Torrent/file.txt"_s)}, savePath, downloadPath, false, occupiedRootPaths);
+
+        QCOMPARE_EQ(result.savePath, downloadPath);
+        QCOMPARE_EQ(result.fileNames, PathList({Path(u"Torrent (2)/file.txt"_s)}));
+    }
+
+    void testKeepOriginalRootForSecondCollisionPass() const
+    {
+        PathList fileNames {Path(u"Torrent (1)/file.txt"_s)};
+        const QSet<Path> occupiedRootPaths
+        {
+            Path(u"/downloads/Torrent"_s),
+            Path(u"/downloads/Torrent (1)"_s)
+        };
+
+        const Path rootFolder = FileSearcher::makeRootFolderUnique(
+                fileNames, Path(u"Torrent"_s), {Path(u"/downloads"_s)}, occupiedRootPaths);
+
+        QCOMPARE_EQ(rootFolder, Path(u"Torrent (2)"_s));
+        QCOMPARE_EQ(fileNames, PathList({Path(u"Torrent (2)/file.txt"_s)}));
+    }
+};
+
+QTEST_APPLESS_MAIN(TestBitTorrentFileSearcher)
+#include "testbittorrentfilesearcher.moc"


### PR DESCRIPTION
Closes #12842.

## Summary
- avoid assigning a torrent root folder that is already owned by another loaded or pending torrent
- reserve selected root folders while add-torrent and magnet metadata completion paths finish, so concurrent adds do not choose the same destination
- check both the active storage path and final save path when incomplete downloads are stored separately
- keep existing on-disk files reusable when no active or pending torrent owns that root, preserving resume/cross-seed behavior

## Tests
- `cmake -S . -B build -G Ninja -DTESTING=ON -DGUI=OFF`
- `cmake --build build --target testbittorrentfilesearcher -j 4`
- `./build/test/testbittorrentfilesearcher`
- `ctest --test-dir build/test --output-on-failure -R testbittorrentfilesearcher`
- `cmake --build build --target check -j 4`
- `git diff --check`

## Notes
- This intentionally does not rename skip-check/seed-mode adds, since those flows expect existing complete files to be reused at the requested location.
