### PR TITLE
WebUI: Bring back properties panel expand/collapse button

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1713,7 +1713,9 @@ window.addEventListener("DOMContentLoaded", async (event) => {
         tabsURL: "views/propertiesToolbar.html?v=${CACHEID}",
         tabsOnload: () => {}, // must be included, otherwise panel won't load properly
         onContentLoaded: function() {
-            this.panelHeaderCollapseBoxEl.classList.add("invisible");
+            this.panelHeaderCollapseBoxEl.addEvent("click", () => {
+                localPreferences.set("properties_panel_collapsed", this.isCollapsed.toString());
+            });
 
             const togglePropertiesPanel = () => {
                 this.collapseToggleEl.click();

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1713,7 +1713,7 @@ window.addEventListener("DOMContentLoaded", async (event) => {
         tabsURL: "views/propertiesToolbar.html?v=${CACHEID}",
         tabsOnload: () => {}, // must be included, otherwise panel won't load properly
         onContentLoaded: function() {
-            this.panelHeaderCollapseBoxEl.addEvent("click", () => {
+            this.panelHeaderCollapseBoxEl.addEvent("click", (event) => {
                 localPreferences.set("properties_panel_collapsed", this.isCollapsed.toString());
             });
 


### PR DESCRIPTION
Closes #24429.

This bring back the expand/collapse button in the WebUI properties panel which was made hidden in this PR: 

https://github.com/qbittorrent/qBittorrent/pull/21209

<img width="1237" height="231" alt="Screenshot 2026-05-31 at 3 19 01 PM" src="https://github.com/user-attachments/assets/7c1c7622-99b0-4058-b991-d29769b7833c" />


This make the button also save the expand/collapse state of the panel. 