### PR TITLE
Schedule Pause bittorrent session with bandwidth scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .vscode/
+.zed/
+.idea/
 
 src/gui/geoip/GeoIP.dat
 src/gui/geoip/GeoIP.dat.gz
@@ -41,3 +43,10 @@ src/icons/skin/build-icons/icons/*.png
 
 # CMake build directory
 build/
+
+
+# clang cache
+.cache/
+
+# Node.js dependencies
+node_modules/

--- a/src/base/bittorrent/bandwidthscheduler.cpp
+++ b/src/base/bittorrent/bandwidthscheduler.cpp
@@ -49,6 +49,7 @@ void BandwidthScheduler::start()
 {
     m_lastAlternative = isTimeForAlternative();
     emit bandwidthLimitRequested(m_lastAlternative);
+    emit sessionStateChangeRequested(Preferences::instance()->getSchedulerSessionState());
 
     // Timeout regularly to accommodate for external system clock changes
     // eg from the user or from a timesync utility
@@ -119,4 +120,8 @@ void BandwidthScheduler::onTimeout()
         m_lastAlternative = alternative;
         emit bandwidthLimitRequested(alternative);
     }
+
+    // Always emit pause state when schedule is active
+    if (alternative)
+        emit sessionStateChangeRequested(Preferences::instance()->getSchedulerSessionState());
 }

--- a/src/base/bittorrent/bandwidthscheduler.h
+++ b/src/base/bittorrent/bandwidthscheduler.h
@@ -31,6 +31,7 @@
 
 #include <QObject>
 #include <QTimer>
+#include "base/preferences.h"
 
 class BandwidthScheduler : public QObject
 {
@@ -43,6 +44,7 @@ public:
 
 signals:
     void bandwidthLimitRequested(bool alternative);
+    void sessionStateChangeRequested(Scheduler::AlternativeSessionState requestedState);
 
 private:
     bool isTimeForAlternative() const;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -36,6 +36,7 @@
 
 #include "base/pathfwd.h"
 #include "base/tagset.h"
+#include "base/preferences.h"
 #include "addtorrentparams.h"
 #include "categoryoptions.h"
 #include "sharelimits.h"
@@ -255,6 +256,7 @@ namespace BitTorrent
         virtual void setUploadSpeedLimit(int limit) = 0;
         virtual bool isAltGlobalSpeedLimitEnabled() const = 0;
         virtual void setAltGlobalSpeedLimitEnabled(bool enabled) = 0;
+        virtual void setAlternativeSessionState(Scheduler::AlternativeSessionState requestedState) = 0;
         virtual bool isBandwidthSchedulerEnabled() const = 0;
         virtual void setBandwidthSchedulerEnabled(bool enabled) = 0;
 
@@ -498,6 +500,7 @@ namespace BitTorrent
         void paused();
         void resumed();
         void speedLimitModeChanged(bool alternative);
+        void sessionStateChanged(Scheduler::AlternativeSessionState requestedState);
         void statsUpdated();
         void subcategoriesSupportChanged();
         void tagAdded(const Tag &tag);

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2370,6 +2370,8 @@ void SessionImpl::enableBandwidthScheduler()
         m_bwScheduler = new BandwidthScheduler(this);
         connect(m_bwScheduler.data(), &BandwidthScheduler::bandwidthLimitRequested
                 , this, &SessionImpl::setAltGlobalSpeedLimitEnabled);
+        connect(m_bwScheduler.data(), &BandwidthScheduler::sessionStateChangeRequested
+                , this, &SessionImpl::setAlternativeSessionState);
     }
     m_bwScheduler->start();
 }
@@ -3666,8 +3668,25 @@ void SessionImpl::setAltGlobalSpeedLimitEnabled(const bool enabled)
     // Save new state to remember it on startup
     m_isAltGlobalSpeedLimitEnabled = enabled;
     applyBandwidthLimits();
+
     // Notify
     emit speedLimitModeChanged(m_isAltGlobalSpeedLimitEnabled);
+}
+
+void SessionImpl::setAlternativeSessionState(Scheduler::AlternativeSessionState requestedState)
+{
+    auto *pref = Preferences::instance();
+    pref->setSchedulerSessionState(requestedState);
+
+    // Apply session pause/resume based on state and alt speed limit state
+    // This might be expanded with new states in the future, but for now we only have Paused and Limited
+    if (isAltGlobalSpeedLimitEnabled() && (requestedState == Scheduler::AlternativeSessionState::Paused))
+        pause();
+    else
+        resume();
+
+    // Notify
+    emit sessionStateChanged(requestedState);
 }
 
 bool SessionImpl::isBandwidthSchedulerEnabled() const

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -231,6 +231,7 @@ namespace BitTorrent
         void setUploadSpeedLimit(int limit) override;
         bool isAltGlobalSpeedLimitEnabled() const override;
         void setAltGlobalSpeedLimitEnabled(bool enabled) override;
+        void setAlternativeSessionState(Scheduler::AlternativeSessionState requestedState) override;
         bool isBandwidthSchedulerEnabled() const override;
         void setBandwidthSchedulerEnabled(bool enabled) override;
 
@@ -239,7 +240,7 @@ namespace BitTorrent
         int saveResumeDataInterval() const override;
         void setSaveResumeDataInterval(int value) override;
         std::chrono::minutes saveStatisticsInterval() const override;
-        void setSaveStatisticsInterval(std::chrono::minutes value) override;
+        void setSaveStatisticsInterval(std::chrono::minutes timeInMinutes) override;
         int shutdownTimeout() const override;
         void setShutdownTimeout(int value) override;
         int port() const override;

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -698,6 +698,20 @@ void Preferences::setSchedulerDays(const Scheduler::Days days)
     setValue(u"Preferences/Scheduler/days"_s, days);
 }
 
+Scheduler::AlternativeSessionState Preferences::getSchedulerSessionState() const
+{
+    return value(u"Preferences/Scheduler/alt_session_state"_s, Scheduler::AlternativeSessionState::Limited);
+}
+
+void Preferences::setSchedulerSessionState(const Scheduler::AlternativeSessionState state)
+{
+    if (state == getSchedulerSessionState())
+        return;
+
+    setValue(u"Preferences/Scheduler/alt_session_state"_s, state);
+}
+
+
 // Search
 bool Preferences::isSearchEnabled() const
 {

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -59,6 +59,15 @@ namespace Scheduler
         Sunday = 9
     };
     Q_ENUM_NS(Days)
+
+    enum class AlternativeSessionState : int
+    {
+        Limited = 0,
+        Paused = 1
+    };
+    Q_ENUM_NS(AlternativeSessionState)
+
+
 }
 
 namespace DNS
@@ -163,6 +172,8 @@ public:
     void setSchedulerEndTime(const QTime &time);
     Scheduler::Days getSchedulerDays() const;
     void setSchedulerDays(Scheduler::Days days);
+    void setSchedulerSessionState(Scheduler::AlternativeSessionState state);
+    Scheduler::AlternativeSessionState getSchedulerSessionState() const;
 
     // Search
     bool isSearchEnabled() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1096,6 +1096,7 @@ void OptionsDialog::loadSpeedTabOptions()
     m_ui->timeEditScheduleFrom->setTime(pref->getSchedulerStartTime());
     m_ui->timeEditScheduleTo->setTime(pref->getSchedulerEndTime());
     m_ui->comboBoxScheduleDays->setCurrentIndex(static_cast<int>(pref->getSchedulerDays()));
+    m_ui->comboBoxScheduleActions->setCurrentIndex(static_cast<int>(pref->getSchedulerSessionState()));
 
     m_ui->checkLimituTPConnections->setChecked(session->isUTPRateLimited());
     m_ui->checkLimitTransportOverhead->setChecked(session->includeOverheadInLimits());
@@ -1119,6 +1120,7 @@ void OptionsDialog::loadSpeedTabOptions()
     connect(m_ui->timeEditScheduleFrom, &QDateTimeEdit::timeChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->timeEditScheduleTo, &QDateTimeEdit::timeChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->comboBoxScheduleDays, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->comboBoxScheduleActions, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkLimituTPConnections, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkLimitTransportOverhead, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -1145,6 +1147,7 @@ void OptionsDialog::saveSpeedTabOptions() const
     pref->setSchedulerStartTime(m_ui->timeEditScheduleFrom->time());
     pref->setSchedulerEndTime(m_ui->timeEditScheduleTo->time());
     pref->setSchedulerDays(static_cast<Scheduler::Days>(m_ui->comboBoxScheduleDays->currentIndex()));
+    pref->setSchedulerSessionState(static_cast<Scheduler::AlternativeSessionState>(m_ui->comboBoxScheduleActions->currentIndex()));
 
     session->setUTPRateLimited(m_ui->checkLimituTPConnections->isChecked());
     session->setIncludeOverheadInLimits(m_ui->checkLimitTransportOverhead->isChecked());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2579,7 +2579,7 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                <item row="2" column="0" colspan="4">
                 <widget class="QGroupBox" name="groupBoxSchedule">
                  <property name="title">
-                  <string>Schedule &amp;the use of alternative rate limits</string>
+                  <string>Scheduler</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -2686,6 +2686,27 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                     <item>
                      <property name="text">
                       <string>Weekends</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_9">
+                    <property name="text">
+                     <string>Do:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QComboBox" name="comboBoxScheduleActions">
+                    <item>
+                     <property name="text">
+                      <string>Use alternative limits</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Pause bittorrent session</string>
                      </property>
                     </item>
                    </widget>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -293,6 +293,8 @@ void AppController::preferencesAction()
     data[u"schedule_to_hour"_s] = end_time.hour();
     data[u"schedule_to_min"_s] = end_time.minute();
     data[u"scheduler_days"_s] = static_cast<int>(pref->getSchedulerDays());
+    data[u"scheduler_alt_session_state"_s] = static_cast<int>(pref->getSchedulerSessionState());
+
 
     // Bittorrent
     // Privacy
@@ -807,6 +809,8 @@ void AppController::setPreferencesAction()
         pref->setSchedulerEndTime({hourIter.value().toInt(), minIter.value().toInt()});
     if (hasKey(u"scheduler_days"_s))
         pref->setSchedulerDays(static_cast<Scheduler::Days>(it.value().toInt()));
+    if (hasKey(u"scheduler_alt_session_state"_s))
+        pref->setSchedulerSessionState(static_cast<Scheduler::AlternativeSessionState>(it.value().toInt()));
 
     // Bittorrent
     // Privacy

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -700,7 +700,7 @@ QBT_TR((best choice if supported))QBT_TR[CONTEXT=OptionsDialog] QBT_TR(Default p
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="limitSchedulingCheckbox" onclick="qBittorrent.Preferences.updateSchedulingEnabled();">
-                <label for="limitSchedulingCheckbox">QBT_TR(Schedule the use of alternative rate limits)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="limitSchedulingCheckbox">QBT_TR(Scheduler)QBT_TR[CONTEXT=OptionsDialog]</label>
             </legend>
             <div class="formRow">
                 <label id="scheduleFromHourLabel">QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -721,6 +721,13 @@ QBT_TR((best choice if supported))QBT_TR[CONTEXT=OptionsDialog] QBT_TR(Default p
                     <option value="7">QBT_TR(Friday)QBT_TR[CONTEXT=HttpServer]</option>
                     <option value="8">QBT_TR(Saturday)QBT_TR[CONTEXT=HttpServer]</option>
                     <option value="9">QBT_TR(Sunday)QBT_TR[CONTEXT=HttpServer]</option>
+                </select>
+            </div>
+            <div class="formRow">
+                <label for="schedule_alt_session_state_select">QBT_TR(Do:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <select id="schedule_alt_session_state_select">
+                    <option value="0">QBT_TR(Use alternative limits)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    <option value="1">QBT_TR(Pause bittorrent session)QBT_TR[CONTEXT=OptionsDialog]</option>
                 </select>
             </div>
         </fieldset>
@@ -2174,6 +2181,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             document.getElementById("schedule_to_hour").disabled = !isLimitSchedulingEnabled;
             document.getElementById("schedule_to_min").disabled = !isLimitSchedulingEnabled;
             document.getElementById("schedule_freq_select").disabled = !isLimitSchedulingEnabled;
+            document.getElementById("schedule_alt_session_state_select").disabled = !isLimitSchedulingEnabled;
         };
 
         // Bittorrent tab
@@ -2618,6 +2626,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("schedule_to_hour").value = time_padding(pref.schedule_to_hour);
                     document.getElementById("schedule_to_min").value = time_padding(pref.schedule_to_min);
                     document.getElementById("schedule_freq_select").value = pref.scheduler_days;
+                    document.getElementById("schedule_alt_session_state_select").value = pref.scheduler_alt_session_state;
                     updateSchedulingEnabled();
 
                     // Bittorrent tab
@@ -3041,6 +3050,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 settings["schedule_to_hour"] = Number(document.getElementById("schedule_to_hour").value);
                 settings["schedule_to_min"] = Number(document.getElementById("schedule_to_min").value);
                 settings["scheduler_days"] = Number(document.getElementById("schedule_freq_select").value);
+                settings["scheduler_alt_session_state"] = Number(document.getElementById("schedule_alt_session_state_select").value);
             }
 
             // Bittorrent tab


### PR DESCRIPTION
<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->

Draft of PR, which adds pause/resume session to current scheduler. Since #9203 was abandoned, I coded this because I need to pause all activities during a day, but I want to add torrents to qbt and maybe resume session for some time. Since this can be controlled via AltGlobalSpeedLimit feature, then I reused this feature.

Scope:
- GUI checkbox for user to decide if wants to pause session during alternative time
- WebUI controls to mirror GUI
- workaround to apply session state during start up of qbt. Without this, qbt would start with session resumed, despite selecting to schedule pause and being in selected hours. If there is a better solution, feel free to share it.

This should satisfy anyone, who wants to pause activity during day/night or anyone who wants 0KB transfer limit for scheduler. Just don't expect it to grow into another #9203 

I guess this would close following:

Closes  #18451.

<details><summary>Screenshot</summary>
<img width="1446" height="703" alt="Zrzut ekranu 2026-06-04 134355" src="https://github.com/user-attachments/assets/d988723b-56bf-4d6f-9169-d709a910d803" />
