### PR TITLE
Handle edge case for `splitToViews()`

### DIFF
--- a/src/base/utils/bytearray.cpp
+++ b/src/base/utils/bytearray.cpp
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
  * Copyright (C) 2023-2025  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2018  Mike Tzou (Chocobo1)
+ * Copyright (C) 2018-2026  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -35,24 +35,31 @@
 
 QList<QByteArrayView> Utils::ByteArray::splitToViews(const QByteArrayView in, const QByteArrayView sep, const Qt::SplitBehavior behavior)
 {
-    if (behavior == Qt::SkipEmptyParts)
+    if (sep.isEmpty()) [[unlikely]]
     {
-        if (in.isEmpty())
-            return {};
+        QList<QByteArrayView> ret;
 
-        if (sep.isEmpty())
-            return {in};
-    }
-    else
-    {
-        if (in.isEmpty())
+        if (behavior == Qt::KeepEmptyParts)
         {
-            if (sep.isEmpty())
-                return {{}, {}};
-
-            return {{}};
+            ret.reserve(in.size() + 2);
+            ret.emplace_back();
         }
+        else
+        {
+            ret.reserve(in.size());
+        }
+
+        for (auto iter = in.cbegin(); iter < in.cend(); ++iter)
+            ret.emplace_back(iter, 1);
+
+        if (behavior == Qt::KeepEmptyParts)
+            ret.emplace_back();
+
+        return ret;
     }
+
+    if (in.isEmpty()) [[unlikely]]
+        return (behavior == Qt::SkipEmptyParts) ? QList<QByteArrayView> {} : QList<QByteArrayView> {{}};
 
     const QByteArrayMatcher matcher {sep};
     QList<QByteArrayView> ret;

--- a/src/base/utils/bytearray.h
+++ b/src/base/utils/bytearray.h
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
  * Copyright (C) 2023-2025  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2018  Mike Tzou (Chocobo1)
+ * Copyright (C) 2018-2026  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/test/testutilsbytearray.cpp
+++ b/test/testutilsbytearray.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2025  Mike Tzou (Chocobo1)
+ * Copyright (C) 2025-2026  Mike Tzou (Chocobo1)
  * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
@@ -57,7 +57,7 @@ private slots:
             using Latin1Views = QList<QLatin1StringView>;
 
             const Latin1Views reference = QLatin1StringView(in)
-                    .tokenize(QLatin1StringView(sep), Qt::SkipEmptyParts).toContainer();
+                .tokenize(QLatin1StringView(sep), Qt::SkipEmptyParts).toContainer();
             Latin1Views expectedStrings;
             for (const auto &string : expected)
                 expectedStrings.append(QLatin1StringView(string));
@@ -66,6 +66,8 @@ private slots:
 
         checkSkipEmptyParts({}, {}, {});
         checkSkipEmptyParts({}, "/", {});
+        checkSkipEmptyParts("/", {}, {"/"});
+        checkSkipEmptyParts("/ab", {}, (BAViews {"/", "a", "b"}));
         checkSkipEmptyParts("/", "/", {});
         checkSkipEmptyParts("/a", "/", {"a"});
         checkSkipEmptyParts("/a/", "/", {"a"});
@@ -87,7 +89,7 @@ private slots:
             using Latin1Views = QList<QLatin1StringView>;
 
             const Latin1Views reference = QLatin1StringView(in)
-                    .tokenize(QLatin1StringView(sep), Qt::KeepEmptyParts).toContainer();
+                .tokenize(QLatin1StringView(sep), Qt::KeepEmptyParts).toContainer();
             Latin1Views expectedStrings;
             for (const auto &string : expected)
                 expectedStrings.append(QLatin1StringView(string));
@@ -96,6 +98,8 @@ private slots:
 
         checkKeepEmptyParts({}, {}, {{}, {}});
         checkKeepEmptyParts({}, "/", {{}});
+        checkKeepEmptyParts("/", {}, {"", "/", ""});
+        checkKeepEmptyParts("/ab", {}, (BAViews {"", "/", "a", "b", ""}));
         checkKeepEmptyParts("/", "/", {"", ""});
         checkKeepEmptyParts("/a", "/", {"", "a"});
         checkKeepEmptyParts("/a/", "/", {"", "a", ""});


### PR DESCRIPTION
This avoids potential division by zero when `in` is not empty and `sep` is empty.
Also, now it fully matches `QStringView::split()` behavior.
