### PR TITLE
Revise container for entry tracking in Transfer List Model

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -142,7 +142,7 @@ TransferListModel::TransferListModel(QObject *parent)
 
 int TransferListModel::rowCount(const QModelIndex &) const
 {
-    return m_torrentList.size();
+    return m_torrents.size();
 }
 
 int TransferListModel::columnCount(const QModelIndex &) const
@@ -542,7 +542,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
     if (!index.isValid())
         return {};
 
-    const BitTorrent::Torrent *torrent = m_torrentList.value(index.row());
+    const BitTorrent::Torrent *torrent = torrentHandle(index);
     if (!torrent)
         return {};
 
@@ -617,7 +617,7 @@ bool TransferListModel::setData(const QModelIndex &index, const QVariant &value,
     if (!index.isValid() || (role != Qt::DisplayRole))
         return false;
 
-    BitTorrent::Torrent *const torrent = m_torrentList.value(index.row());
+    BitTorrent::Torrent *const torrent = torrentHandle(index);
     if (!torrent)
         return false;
 
@@ -642,20 +642,17 @@ void TransferListModel::addTorrents(const QList<BitTorrent::Torrent *> &torrents
     if (torrents.isEmpty())
         return;
 
-    qsizetype row = m_torrentList.size();
+    qsizetype row = m_torrents.size();
     const qsizetype total = row + torrents.size();
 
     beginInsertRows({}, row, (total - 1));
-
-    m_torrentList.reserve(total);
+    m_torrents.get<ByIndex>().reserve(total);
+    m_torrents.get<ByHandle>().reserve(total);
     for (BitTorrent::Torrent *torrent : torrents)
     {
-        Q_ASSERT(!m_torrentMap.contains(torrent));
-
-        m_torrentList.append(torrent);
-        m_torrentMap[torrent] = row++;
+        Q_ASSERT(m_torrents.get<ByHandle>().find(torrent) == m_torrents.get<ByHandle>().end());  // TODO: use `contains()` with boost >= 1.84
+        m_torrents.get<ByIndex>().emplace_back(torrent);
     }
-
     endInsertRows();
 }
 
@@ -669,30 +666,26 @@ Qt::ItemFlags TransferListModel::flags(const QModelIndex &index) const
 
 BitTorrent::Torrent *TransferListModel::torrentHandle(const QModelIndex &index) const
 {
-    if (!index.isValid()) return nullptr;
+    if (!index.isValid() || (index.row() >= static_cast<qsizetype>(m_torrents.size())))
+        return nullptr;
 
-    return m_torrentList.value(index.row());
+    return m_torrents.get<ByIndex>().at(index.row());
 }
 
 void TransferListModel::handleTorrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)
 {
-    const int row = m_torrentMap.value(torrent, -1);
+    const int row = getTorrentRow(torrent);
     Q_ASSERT(row >= 0);
 
+    const auto iter = m_torrents.get<ByIndex>().begin() + row;
     beginRemoveRows({}, row, row);
-    m_torrentList.removeAt(row);
-    m_torrentMap.remove(torrent);
-    for (int &value : m_torrentMap)
-    {
-        if (value > row)
-            --value;
-    }
+    m_torrents.get<ByIndex>().erase(iter);
     endRemoveRows();
 }
 
 void TransferListModel::handleTorrentStatusUpdated(BitTorrent::Torrent *const torrent)
 {
-    const int row = m_torrentMap.value(torrent, -1);
+    const int row = getTorrentRow(torrent);
     Q_ASSERT(row >= 0);
 
     emit dataChanged(index(row, 0), index(row, columnCount() - 1));
@@ -702,11 +695,11 @@ void TransferListModel::handleTorrentsUpdated(const QList<BitTorrent::Torrent *>
 {
     const int columns = (columnCount() - 1);
 
-    if (torrents.size() <= (m_torrentList.size() * 0.5))
+    if (torrents.size() <= (m_torrents.size() * 0.5))
     {
         for (BitTorrent::Torrent *const torrent : torrents)
         {
-            const int row = m_torrentMap.value(torrent, -1);
+            const int row = getTorrentRow(torrent);
             Q_ASSERT(row >= 0);
 
             emit dataChanged(index(row, 0), index(row, columns));
@@ -717,6 +710,14 @@ void TransferListModel::handleTorrentsUpdated(const QList<BitTorrent::Torrent *>
         // save the overhead when more than half of the torrent list needs update
         emit dataChanged(index(0, 0), index((rowCount() - 1), columns));
     }
+}
+
+int TransferListModel::getTorrentRow(BitTorrent::Torrent *const torrent) const
+{
+    const auto iter = m_torrents.get<ByHandle>().find(torrent);
+    const int row = (iter != m_torrents.get<ByHandle>().end())
+        ? std::distance(m_torrents.get<ByIndex>().begin(), m_torrents.project<ByIndex>(iter)) : -1;
+    return row;
 }
 
 void TransferListModel::configure()

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -29,6 +29,11 @@
 
 #pragma once
 
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/random_access_index.hpp>
+#include <boost/multi_index/tag.hpp>
+
 #include <QAbstractListModel>
 #include <QColor>
 #include <QHash>
@@ -116,14 +121,20 @@ private slots:
     void handleTorrentsUpdated(const QList<BitTorrent::Torrent *> &torrents);
 
 private:
+    int getTorrentRow(BitTorrent::Torrent *torrent) const;
+
     void configure();
     void loadUIThemeResources();
     QString displayValue(const BitTorrent::Torrent *torrent, int column) const;
     QVariant internalValue(const BitTorrent::Torrent *torrent, int column, bool alt) const;
     QIcon getIconByState(BitTorrent::TorrentState state) const;
 
-    QList<BitTorrent::Torrent *> m_torrentList;  // maps row number to torrent handle
-    QHash<BitTorrent::Torrent *, int> m_torrentMap;  // maps torrent handle to row number
+    using TorrentList = boost::multi_index_container<
+        BitTorrent::Torrent *,
+        boost::multi_index::indexed_by<
+            boost::multi_index::random_access<boost::multi_index::tag<struct ByIndex>>,
+            boost::multi_index::hashed_unique<boost::multi_index::tag<struct ByHandle>, boost::multi_index::identity<BitTorrent::Torrent *>>>>;
+    TorrentList m_torrents;
     const QHash<BitTorrent::TorrentState, QString> m_statusStrings;
     // row text colors
     QHash<BitTorrent::TorrentState, QColor> m_stateThemeColors;


### PR DESCRIPTION
Instead of maintaining two separate containers, now there is only one.
