### PR TITLE
Preserve tracker tier gaps in resume data

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -44,6 +44,9 @@
 #include <QRegularExpression>
 #include <QThread>
 
+#include <string>
+#include <vector>
+
 #include "base/exceptions.h"
 #include "base/global.h"
 #include "base/logger.h"
@@ -104,6 +107,45 @@ namespace
         for (const Tag &setValue : input)
             entryList.emplace_back(setValue.toString().toStdString());
         return entryList;
+    }
+
+    void preserveSparseTrackerTiers(lt::add_torrent_params &params, const lt::bdecode_node &resumeDataRoot)
+    {
+        const lt::bdecode_node trackersNode = resumeDataRoot.dict_find_list("trackers");
+        if (trackersNode.type() != lt::bdecode_node::list_t)
+            return;
+
+        std::vector<std::string> trackers;
+        std::vector<int> trackerTiers;
+
+        for (int tier = 0; tier < trackersNode.list_size(); ++tier)
+        {
+            const lt::bdecode_node tierNode = trackersNode.list_at(tier);
+            if (tierNode.type() == lt::bdecode_node::string_t)
+            {
+                const lt::string_view tracker = tierNode.string_value();
+                if (!tracker.empty())
+                {
+                    trackers.emplace_back(tracker);
+                    trackerTiers.push_back(tier);
+                }
+            }
+            else if (tierNode.type() == lt::bdecode_node::list_t)
+            {
+                for (int i = 0; i < tierNode.list_size(); ++i)
+                {
+                    const lt::string_view tracker = tierNode.list_string_value_at(i);
+                    if (!tracker.empty())
+                    {
+                        trackers.emplace_back(tracker);
+                        trackerTiers.push_back(tier);
+                    }
+                }
+            }
+        }
+
+        if (trackers == params.trackers)
+            params.tracker_tiers = std::move(trackerTiers);
     }
 }
 
@@ -309,6 +351,7 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
     p = lt::read_resume_data(resumeDataRoot, ec);
     if (ec)
         return nonstd::make_unexpected(tr("Cannot parse resume data: %1").arg(QString::fromStdString(ec.message())));
+    preserveSparseTrackerTiers(p, resumeDataRoot);
 
     if (!metadata.isEmpty())
     {

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -97,6 +97,44 @@ namespace
         return entry;
     }
 
+    QList<TrackerEntryStatus> makeTrackerEntryStatuses(const lt::add_torrent_params &params
+            , const std::vector<lt::announce_entry> &fallbackTrackers)
+    {
+        QList<TrackerEntryStatus> statuses;
+
+        if (!params.trackers.empty())
+        {
+            statuses.reserve(static_cast<decltype(statuses)::size_type>(params.trackers.size()));
+            for (std::size_t i = 0; i < params.trackers.size(); ++i)
+            {
+                const int tier = (i < params.tracker_tiers.size()) ? params.tracker_tiers[i] : 0;
+                statuses.append({QString::fromStdString(params.trackers[i]), tier});
+            }
+
+            return statuses;
+        }
+
+        statuses.reserve(static_cast<decltype(statuses)::size_type>(fallbackTrackers.size()));
+        for (const lt::announce_entry &announceEntry : fallbackTrackers)
+            statuses.append({QString::fromStdString(announceEntry.url), announceEntry.tier});
+
+        return statuses;
+    }
+
+    void applyTrackerEntryStatuses(lt::add_torrent_params &params, const QList<TrackerEntryStatus> &statuses)
+    {
+        params.trackers.clear();
+        params.tracker_tiers.clear();
+        params.trackers.reserve(static_cast<std::size_t>(statuses.size()));
+        params.tracker_tiers.reserve(static_cast<std::size_t>(statuses.size()));
+
+        for (const TrackerEntryStatus &status : statuses)
+        {
+            params.trackers.emplace_back(status.url.toStdString());
+            params.tracker_tiers.emplace_back(status.tier);
+        }
+    }
+
     QString toString(const lt::tcp::endpoint &ltTCPEndpoint)
     {
         static QCache<lt::tcp::endpoint, QString> cache;
@@ -113,8 +151,7 @@ namespace
             , const QSet<int> &btProtocols, const QHash<lt::tcp::endpoint, QMap<int, int>> &updateInfo)
     {
         Q_ASSERT(trackerEntryStatus.url == QString::fromStdString(nativeEntry.url));
-
-        trackerEntryStatus.tier = nativeEntry.tier;
+        // Keep qBittorrent's own tier value to preserve intentionally empty tiers.
 
         const auto numEndpoints = static_cast<qsizetype>(nativeEntry.endpoints.size()) * btProtocols.size();
 
@@ -378,9 +415,7 @@ TorrentImpl::TorrentImpl(SessionImpl *session, const lt::torrent_handle &nativeH
     setStopCondition(params.stopCondition);
 
     const auto *extensionData = static_cast<ExtensionData *>(m_ltAddTorrentParams.userdata);
-    m_trackerEntryStatuses.reserve(static_cast<decltype(m_trackerEntryStatuses)::size_type>(extensionData->trackers.size()));
-    for (const lt::announce_entry &announceEntry : extensionData->trackers)
-        m_trackerEntryStatuses.append({QString::fromStdString(announceEntry.url), announceEntry.tier});
+    m_trackerEntryStatuses = makeTrackerEntryStatuses(m_ltAddTorrentParams, extensionData->trackers);
     m_urlSeeds.reserve(static_cast<decltype(m_urlSeeds)::size_type>(extensionData->urlSeeds.size()));
     for (const std::string &urlSeed : extensionData->urlSeeds)
         m_urlSeeds.append(QString::fromStdString(urlSeed));
@@ -2288,6 +2323,8 @@ void TorrentImpl::prepareResumeData(lt::add_torrent_params params)
         if (preserveSeedMode)
             m_ltAddTorrentParams.flags |= lt::torrent_flags::seed_mode;
     }
+
+    applyTrackerEntryStatuses(m_ltAddTorrentParams, m_trackerEntryStatuses);
 
     // We shouldn't save upload_mode flag to allow torrent operate normally on next run
     m_ltAddTorrentParams.flags &= ~lt::torrent_flags::upload_mode;


### PR DESCRIPTION
## Summary
- restore sparse tracker tier numbers from legacy resume data before libtorrent compacts them
- keep qBittorrent's own tracker tier values during tracker status refreshes
- write qBittorrent tracker tiers back into resume data on save

Reworks closed #24364 after the #24360 upgrade-path test was corrected.

Fixes #24360.

## Validation
- Isolated `qbittorrent-nox` relaunch validation with a generated v1 torrent and legacy `.fastresume` whose raw `trackers` list had non-empty tiers `[0, 1, 8, 9, 10]` and empty tiers `2..7`. The test launched the built nox binary with `--profile=/private/tmp/qbt-24364-relaunch-validation-forced-save-v4/profile --configuration=tiergap`, changed the torrent category through the WebAPI, shut down through the WebAPI, and decoded the saved `.fastresume`. The file digest changed and `qBt-category` persisted as `tier-gap-validation`, while the raw non-empty tracker tiers remained `[0, 1, 8, 9, 10]`.
