### PR TITLE
Fix clearing RSS downloaded episode history

### DIFF
--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -158,6 +158,7 @@ namespace RSS
                     && (left.ignoreDays == right.ignoreDays)
                     && (left.lastMatch == right.lastMatch)
                     && (left.smartFilter == right.smartFilter)
+                    && (left.previouslyMatchedEpisodes == right.previouslyMatchedEpisodes)
                     && (left.addTorrentParams == right.addTorrentParams);
         }
     };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(testFiles
     testglobal.cpp
     testorderedset.cpp
     testpath.cpp
+    testrssautodownloadrule.cpp
     testutilsbytearray.cpp
     testutilscompare.cpp
     testutilsdatetime.cpp

--- a/test/testrssautodownloadrule.cpp
+++ b/test/testrssautodownloadrule.cpp
@@ -1,0 +1,57 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QObject>
+#include <QTest>
+
+#include "base/global.h"
+#include "base/rss/rss_autodownloadrule.h"
+
+class TestRSSAutoDownloadRule final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestRSSAutoDownloadRule)
+
+public:
+    TestRSSAutoDownloadRule() = default;
+
+private slots:
+    void testDownloadedEpisodesAffectEquality() const
+    {
+        RSS::AutoDownloadRule rule {u"rule"_s};
+        rule.setPreviouslyMatchedEpisodes({u"S01E01"_s});
+
+        RSS::AutoDownloadRule clearedRule {rule};
+        clearedRule.setPreviouslyMatchedEpisodes({});
+
+        QVERIFY(rule != clearedRule);
+    }
+};
+
+QTEST_APPLESS_MAIN(TestRSSAutoDownloadRule)
+#include "testrssautodownloadrule.moc"


### PR DESCRIPTION
Closes #24010.

## Summary
- include RSS downloaded episode history in auto-download rule equality checks
- add a regression test for clearing `previouslyMatchedEpisodes`

## Testing
```bash
git diff --check
cmake -S . -B /tmp/qbt-24010-build -DGUI=OFF -DWEBUI=ON -DTESTING=ON -DSTACKTRACE=OFF
cmake --build /tmp/qbt-24010-build --target testrssautodownloadrule -j4
/tmp/qbt-24010-build/test/testrssautodownloadrule
cmake --build /tmp/qbt-24010-build --target check -j4
```

The targeted RSS auto-download rule test passed, and the full `check` target passed 18/18 locally.