### PR TITLE
Batch preview selected media files

### DIFF
--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -44,6 +44,7 @@ namespace MacUtils
     void askForNotificationPermission();
     void displayNotification(const QString &title, const QString &message);
     void openFiles(const PathList &pathList);
+    void openFilesWithDefaultApplication(const PathList &pathList);
 
     bool isMagnetLinkAssocSet();
     void setMagnetLinkAssoc();

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -144,6 +144,37 @@ namespace MacUtils
         }
     }
 
+    void openFilesWithDefaultApplication(const PathList &pathList)
+    {
+        if (pathList.empty())
+            return;
+
+        @autoreleasepool
+        {
+            NSMutableArray *pathURLs = [NSMutableArray arrayWithCapacity:pathList.size()];
+
+            for (const auto &path : pathList)
+                [pathURLs addObject:[NSURL fileURLWithPath:path.toString().toNSString()]];
+
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
+            {
+                NSURL *firstURL = [pathURLs firstObject];
+                if (!firstURL)
+                    return;
+
+                NSURL *applicationURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:firstURL];
+                if (!applicationURL)
+                    return;
+
+                NSWorkspaceOpenConfiguration *configuration = [NSWorkspaceOpenConfiguration configuration];
+                [[NSWorkspace sharedWorkspace] openURLs:pathURLs
+                                   withApplicationAtURL:applicationURL
+                                          configuration:configuration
+                                      completionHandler:nil];
+            });
+        }
+    }
+
     bool isMagnetLinkAssocSet()
     {
         @autoreleasepool

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -62,7 +62,7 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
 {
     m_ui->setupUi(this);
 
-    m_ui->label->setText(tr("The following files from torrent \"%1\" support previewing, please select one of them:")
+    m_ui->label->setText(tr("The following files from torrent \"%1\" support previewing, please select one or more of them:")
         .arg(m_torrent->name()));
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Preview"));
@@ -78,6 +78,7 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
     previewListModel->setHeaderData(PROGRESS, Qt::Horizontal, tr("Progress"));
 
     m_ui->previewList->setAlternatingRowColors(pref->useAlternatingRowColors());
+    m_ui->previewList->setSelectionMode(QAbstractItemView::ExtendedSelection);
     m_ui->previewList->setUniformRowHeights(true);
     m_ui->previewList->setModel(previewListModel);
 
@@ -134,22 +135,28 @@ void PreviewSelectDialog::previewButtonClicked()
     // Flush data
     m_torrent->flushCache();
 
-    // Only one file should be selected
-    const int fileIndex = selectedIndexes.at(0).data().toInt();
-    const Path path = m_torrent->actualStorageLocation() / m_torrent->actualFilePath(fileIndex);
-    // File
-    if (!path.exists())
+    PathList paths;
+    paths.reserve(selectedIndexes.size());
+
+    for (const QModelIndex &selectedIndex : selectedIndexes)
     {
-        const bool isSingleFile = (m_ui->previewList->model()->rowCount() == 1);
-        QWidget *parent = isSingleFile ? this->parentWidget() : this;
-        QMessageBox::critical(parent, tr("Preview impossible")
-            , tr("Sorry, we can't preview this file: \"%1\".").arg(path.toString()));
-        if (isSingleFile)
-            reject();
-        return;
+        const int fileIndex = selectedIndex.data().toInt();
+        const Path path = m_torrent->actualStorageLocation() / m_torrent->actualFilePath(fileIndex);
+        if (!path.exists())
+        {
+            const bool isSingleFile = (m_ui->previewList->model()->rowCount() == 1);
+            QWidget *parent = isSingleFile ? this->parentWidget() : this;
+            QMessageBox::critical(parent, tr("Preview impossible")
+                , tr("Sorry, we can't preview this file: \"%1\".").arg(path.toString()));
+            if (isSingleFile)
+                reject();
+            return;
+        }
+
+        paths.append(path);
     }
 
-    emit readyToPreviewFile(path);
+    emit readyToPreviewFiles(paths);
     accept();
 }
 

--- a/src/gui/previewselectdialog.h
+++ b/src/gui/previewselectdialog.h
@@ -64,7 +64,7 @@ public:
     ~PreviewSelectDialog();
 
 signals:
-    void readyToPreviewFile(const Path &filePath) const;
+    void readyToPreviewFiles(const PathList &filePaths) const;
 
 private slots:
     void previewButtonClicked();

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -105,6 +105,21 @@ namespace
         return false;
     }
 
+    PathList previewableFilePaths(const BitTorrent::Torrent *const torrent)
+    {
+        if (!torrent->hasMetadata())
+            return {};
+
+        PathList paths;
+        for (int i = 0; i < torrent->filesCount(); ++i)
+        {
+            if (Utils::Misc::isPreviewable(torrent->filePath(i)))
+                paths.append(torrent->actualStorageLocation() / torrent->actualFilePath(i));
+        }
+
+        return paths;
+    }
+
     void removeTorrents(const QList<BitTorrent::Torrent *> &torrents, const bool isDeleteFileSelected)
     {
         auto *session = BitTorrent::Session::instance();
@@ -242,9 +257,9 @@ TransferListModel *TransferListWidget::getSourceModel() const
     return m_listModel;
 }
 
-void TransferListWidget::previewFile(const Path &filePath)
+void TransferListWidget::previewFiles(const PathList &filePaths)
 {
-    Utils::Gui::openPath(filePath);
+    Utils::Gui::openPaths(filePaths);
 }
 
 QModelIndex TransferListWidget::mapToSource(const QModelIndex &index) const
@@ -631,18 +646,39 @@ void TransferListWidget::openDestinationFolder(const BitTorrent::Torrent *const 
 
 void TransferListWidget::previewSelectedTorrents()
 {
-    for (const BitTorrent::Torrent *torrent : asConst(getSelectedTorrents()))
+    const QList<BitTorrent::Torrent *> selectedTorrents = getSelectedTorrents();
+    PathList pathsToPreview;
+
+    for (const BitTorrent::Torrent *torrent : asConst(selectedTorrents))
     {
-        if (torrentContainsPreviewableFiles(torrent))
-        {
-            openPreviewSelectDialog(torrent);
-        }
-        else
+        torrent->flushCache();
+
+        const PathList paths = previewableFilePaths(torrent);
+        if (paths.empty())
         {
             QMessageBox::critical(this, tr("Unable to preview"), tr("The selected torrent \"%1\" does not contain previewable files")
                 .arg(torrent->name()));
+            continue;
         }
+
+        if ((selectedTorrents.size() > 1) && (paths.size() == 1))
+        {
+            const Path &path = paths.first();
+            if (!path.exists())
+            {
+                QMessageBox::critical(this, tr("Preview impossible")
+                    , tr("Sorry, we can't preview this file: \"%1\".").arg(path.toString()));
+                continue;
+            }
+
+            pathsToPreview.append(path);
+            continue;
+        }
+
+        openPreviewSelectDialog(torrent);
     }
+
+    previewFiles(pathsToPreview);
 }
 
 void TransferListWidget::setTorrentOptions()
@@ -1506,7 +1542,7 @@ void TransferListWidget::openPreviewSelectDialog(const BitTorrent::Torrent *torr
     auto *dialog = new PreviewSelectDialog(this, torrent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     // Qt::QueuedConnection is required to prevent a bug on wayland compositors where the preview won't open.
-    // It occurs when the window focus shifts immediately after TransferListWidget::previewFile has been called.
-    connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile, Qt::QueuedConnection);
+    // It occurs when the window focus shifts immediately after TransferListWidget::previewFiles has been called.
+    connect(dialog, &PreviewSelectDialog::readyToPreviewFiles, this, &TransferListWidget::previewFiles, Qt::QueuedConnection);
     dialog->show();
 }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -105,6 +105,21 @@ namespace
         return false;
     }
 
+    PathList previewableFilePaths(const BitTorrent::Torrent *const torrent)
+    {
+        if (!torrent->hasMetadata())
+            return {};
+
+        PathList paths;
+        for (int i = 0; i < torrent->filesCount(); ++i)
+        {
+            if (Utils::Misc::isPreviewable(torrent->filePath(i)))
+                paths.append(torrent->actualStorageLocation() / torrent->actualFilePath(i));
+        }
+
+        return paths;
+    }
+
     void removeTorrents(const QList<BitTorrent::Torrent *> &torrents, const bool isDeleteFileSelected)
     {
         auto *session = BitTorrent::Session::instance();
@@ -242,9 +257,9 @@ TransferListModel *TransferListWidget::getSourceModel() const
     return m_listModel;
 }
 
-void TransferListWidget::previewFile(const Path &filePath)
+void TransferListWidget::previewFiles(const PathList &filePaths)
 {
-    Utils::Gui::openPath(filePath);
+    Utils::Gui::openPaths(filePaths);
 }
 
 QModelIndex TransferListWidget::mapToSource(const QModelIndex &index) const
@@ -631,18 +646,38 @@ void TransferListWidget::openDestinationFolder(const BitTorrent::Torrent *const 
 
 void TransferListWidget::previewSelectedTorrents()
 {
-    for (const BitTorrent::Torrent *torrent : asConst(getSelectedTorrents()))
+    const QList<BitTorrent::Torrent *> selectedTorrents = getSelectedTorrents();
+    PathList pathsToPreview;
+
+    for (const BitTorrent::Torrent *torrent : asConst(selectedTorrents))
     {
-        if (torrentContainsPreviewableFiles(torrent))
-        {
-            openPreviewSelectDialog(torrent);
-        }
-        else
+        const PathList paths = previewableFilePaths(torrent);
+        if (paths.empty())
         {
             QMessageBox::critical(this, tr("Unable to preview"), tr("The selected torrent \"%1\" does not contain previewable files")
                 .arg(torrent->name()));
+            continue;
         }
+
+        if ((selectedTorrents.size() > 1) && (paths.size() == 1))
+        {
+            const Path &path = paths.first();
+            if (!path.exists())
+            {
+                QMessageBox::critical(this, tr("Preview impossible")
+                    , tr("Sorry, we can't preview this file: \"%1\".").arg(path.toString()));
+                continue;
+            }
+
+            torrent->flushCache();
+            pathsToPreview.append(path);
+            continue;
+        }
+
+        openPreviewSelectDialog(torrent);
     }
+
+    previewFiles(pathsToPreview);
 }
 
 void TransferListWidget::setTorrentOptions()
@@ -1506,7 +1541,7 @@ void TransferListWidget::openPreviewSelectDialog(const BitTorrent::Torrent *torr
     auto *dialog = new PreviewSelectDialog(this, torrent);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     // Qt::QueuedConnection is required to prevent a bug on wayland compositors where the preview won't open.
-    // It occurs when the window focus shifts immediately after TransferListWidget::previewFile has been called.
-    connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile, Qt::QueuedConnection);
+    // It occurs when the window focus shifts immediately after TransferListWidget::previewFiles has been called.
+    connect(dialog, &PreviewSelectDialog::readyToPreviewFiles, this, &TransferListWidget::previewFiles, Qt::QueuedConnection);
     dialog->show();
 }

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -103,7 +103,7 @@ public slots:
     void applyTagFilter(const std::optional<Tag> &tag);
     void applyTrackerFilter(const std::optional<QString> &trackerHost);
     void applyAnnounceStatusFilter(const std::optional<BitTorrent::TorrentAnnounceStatus> &announceStatus);
-    void previewFile(const Path &filePath);
+    void previewFiles(const PathList &filePaths);
     void renameSelectedTorrent();
 
 signals:

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -52,6 +52,10 @@
 #include <QWidget>
 #include <QWindow>
 
+#ifdef Q_OS_MACOS
+#include "macutilities.h"
+#endif
+
 #ifdef QBT_USES_DBUS
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -219,6 +223,37 @@ void Utils::Gui::openPath(const Path &path)
     thread->start();
 #else
     QDesktopServices::openUrl(url);
+#endif
+}
+
+void Utils::Gui::openPaths(const PathList &paths)
+{
+    if (paths.empty())
+        return;
+
+    if (paths.size() == 1)
+    {
+        openPath(paths.first());
+        return;
+    }
+
+#ifdef Q_OS_MACOS
+    MacUtils::openFilesWithDefaultApplication(paths);
+#elif defined(Q_OS_UNIX)
+    QStringList urls;
+    urls.reserve(paths.size() + 1);
+    urls << u"open"_s;
+    for (const Path &path : paths)
+        urls << toURL(path).toString();
+
+    if (QProcess::startDetached(u"gio"_s, urls))
+        return;
+
+    for (const Path &path : paths)
+        openPath(path);
+#else
+    for (const Path &path : paths)
+        openPath(path);
 #endif
 }
 

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -52,6 +52,7 @@ namespace Utils::Gui
     QPoint screenCenter(const QWidget *w);
 
     void openPath(const Path &path);
+    void openPaths(const PathList &paths);
     void openFolderSelect(const Path &path);
 
     QString tagToWidgetText(const Tag &tag);


### PR DESCRIPTION
## Summary
- allow selecting multiple files in the preview selection dialog
- open selected preview files with one request where the platform supports it
- batch preview multiple selected one-file torrents instead of opening each separately

Closes #24439.