### PR TITLE
Make Select All/None respect file filter

### DIFF
--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -216,14 +216,40 @@ void TorrentContentWidget::setFilterPattern(const QString &patternText, const Fi
 
 void TorrentContentWidget::checkAll()
 {
-    for (int i = 0; i < model()->rowCount(); ++i)
-        model()->setData(model()->index(i, TorrentContentModelItem::COL_NAME), Qt::Checked, Qt::CheckStateRole);
+    checkItemsIteratively(QModelIndex(), Qt::Checked);
 }
 
 void TorrentContentWidget::checkNone()
 {
-    for (int i = 0; i < model()->rowCount(); ++i)
-        model()->setData(model()->index(i, TorrentContentModelItem::COL_NAME), Qt::Unchecked, Qt::CheckStateRole);
+    checkItemsIteratively(QModelIndex(), Qt::Unchecked);
+}
+
+void TorrentContentWidget::checkItemsIteratively(const QModelIndex &parent, const Qt::CheckState state)
+{
+    QQueue<QModelIndex> pendingParents;
+    pendingParents.enqueue(parent);
+
+    while (!pendingParents.isEmpty())
+    {
+        const QModelIndex currentParent = pendingParents.dequeue();
+        const int childCount = model()->rowCount(currentParent);
+        for (int i = 0; i < childCount; ++i)
+        {
+            const QModelIndex childIndex = model()->index(i, TorrentContentModelItem::COL_NAME, currentParent);
+            if (!childIndex.isValid())
+                continue;
+
+            const TorrentContentModelItem::ItemType itemType = m_filterModel->itemType(childIndex);
+            if (itemType == TorrentContentModelItem::FileType)
+            {
+                model()->setData(childIndex, state, Qt::CheckStateRole);
+            }
+            else if (itemType == TorrentContentModelItem::FolderType)
+            {
+                pendingParents.enqueue(childIndex);
+            }
+        }
+    }
 }
 
 void TorrentContentWidget::setContentDragAllowed(const bool allowed)

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -127,6 +127,7 @@ private:
     // Expand single-item folders recursively.
     // This will trigger sorting and filtering so do it after all relevant data is loaded.
     void expandRecursively();
+    void checkItemsIteratively(const QModelIndex &parent, Qt::CheckState state);
 
     TorrentContentModel *m_model;
     TorrentContentFilterModel *m_filterModel;


### PR DESCRIPTION
This change makes the torrent content view’s Select All and Select None actions respect the active file filter. Instead of applying check state changes to every file in the torrent, the widget now traverses only the visible rows in the filtered proxy model and updates file nodes directly, leaving hidden files untouched. Folders continue to derive their state from their visible children, which keeps the behavior consistent when filters are cleared or changed. 

Closes #6569.
