### PR TITLE
Fix macOS search tab close shortcut

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1012,6 +1012,9 @@ void MainWindow::on_actionExit_triggered()
 #ifdef Q_OS_MACOS
 void MainWindow::on_actionCloseWindow_triggered()
 {
+    if ((currentTabWidget() == m_searchWidget) && m_searchWidget->closeCurrentTab())
+        return;
+
     // On macOS window close is basically equivalent to window hide.
     // If you decide to implement this functionality for other OS,
     // then you will also need ui lock checks like in actionExit.

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -432,12 +432,7 @@ SearchWidget::SearchWidget(IGUIApplication *app, QWidget *parent)
     connect(focusSearchHotkeyAlternative, &QShortcut::activated, this, &SearchWidget::toggleFocusBetweenLineEdits);
 
     const auto *closeTabHotkey = new QShortcut(QKeySequence::Close, this);
-    connect(closeTabHotkey, &QShortcut::activated, this, [this]()
-    {
-        const int currentIndex = m_ui->tabWidget->currentIndex();
-        if (currentIndex >= 0)
-            closeTab(currentIndex);
-    });
+    connect(closeTabHotkey, &QShortcut::activated, this, &SearchWidget::closeCurrentTab);
 
     m_historyLength = Preferences::instance()->searchHistoryLength();
     m_storeOpenedTabs = Preferences::instance()->storeOpenedSearchTabs();
@@ -945,6 +940,16 @@ void SearchWidget::closeTab(const int index)
 
     QMetaObject::invokeMethod(m_dataStorage, [this, tabID] { m_dataStorage->removeTab(tabID); });
     saveSession();
+}
+
+bool SearchWidget::closeCurrentTab()
+{
+    const int currentIndex = m_ui->tabWidget->currentIndex();
+    if (currentIndex < 0)
+        return false;
+
+    closeTab(currentIndex);
+    return true;
 }
 
 void SearchWidget::closeAllTabs()

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -58,6 +58,7 @@ public:
     ~SearchWidget() override;
 
     void giveFocusToSearchInput();
+    bool closeCurrentTab();
 
 signals:
     void searchFinished(bool failed);


### PR DESCRIPTION
## Summary
- route macOS Close Window/Cmd+W through the active Search page first
- expose a SearchWidget helper to close the current search-result tab
- keep the existing close-window behavior when Search has no tab to close

Closes #24214

## Root cause
On macOS the main-window Close action owns QKeySequence::Close. That action can handle Cmd+W before the SearchWidget shortcut sees it, hiding the main window instead of closing the active search tab.

## Validation
- cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
- cmake --build build --target qbittorrent
- QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v
