### PR TITLE
Constrain macOS search tab width

### DIFF
--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -52,6 +52,7 @@
 #include <QSortFilterProxyModel>
 #include <QStringList>
 #include <QStringListModel>
+#include <QTabBar>
 #include <QThread>
 
 #include "base/global.h"
@@ -352,7 +353,13 @@ SearchWidget::SearchWidget(IGUIApplication *app, QWidget *parent)
     m_ui->setupUi(this);
 
     m_ui->stopButton->hide();
-    m_ui->tabWidget->tabBar()->installEventFilter(this);
+    auto *tabBar = m_ui->tabWidget->tabBar();
+    tabBar->installEventFilter(this);
+#ifdef Q_OS_MACOS
+    tabBar->setElideMode(Qt::ElideRight);
+    tabBar->setExpanding(false);
+    tabBar->setUsesScrollButtons(true);
+#endif
 
     const QString searchPatternHint = u"<html><head/><body><p>"
         + tr("A phrase to search for.") + u"<br>"


### PR DESCRIPTION
## Summary
- enable elided labels and scroll buttons for the Search tab bar on macOS
- prevent many open search tabs from forcing the main window minimum width to grow
- leave non-macOS tab behavior unchanged

Closes #20219

## Root cause
On macOS, the search tab bar can contribute the full width of every open search tab to the widget size hint. With enough tabs, the main window cannot be shrunk until tabs are closed.

## Validation
- cmake --build build --target qbittorrent
- QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v
