### PR TITLE
Use native macOS file opening

### DIFF
--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -44,6 +44,7 @@ namespace MacUtils
     void askForNotificationPermission();
     void displayNotification(const QString &title, const QString &message);
     void openFiles(const PathList &pathList);
+    void openPath(const Path &path);
 
     bool isMagnetLinkAssocSet();
     void setMagnetLinkAssoc();

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -144,6 +144,18 @@ namespace MacUtils
         }
     }
 
+    void openPath(const Path &path)
+    {
+        @autoreleasepool
+        {
+            NSURL *url = [NSURL fileURLWithPath:path.toString().toNSString()];
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
+            {
+                [[NSWorkspace sharedWorkspace] openURL:url];
+            });
+        }
+    }
+
     bool isMagnetLinkAssocSet()
     {
         @autoreleasepool

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -65,9 +65,13 @@
 #include "base/tag.h"
 #include "base/utils/fs.h"
 #include "base/utils/version.h"
+#ifdef Q_OS_MACOS
+#include "macutilities.h"
+#endif
 
 namespace
 {
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
     QUrl toURL(const Path &path)
     {
         // Hack to access samba shares with QDesktopServices::openUrl
@@ -75,6 +79,7 @@ namespace
             ? QUrl(u"file:" + path.data())
             : QUrl::fromLocalFile(path.data());
     }
+#endif
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     void invokeFileManager(const Path &path)
@@ -200,8 +205,6 @@ QPoint Utils::Gui::screenCenter(const QWidget *w)
 // Open the given path with an appropriate application
 void Utils::Gui::openPath(const Path &path)
 {
-    const QUrl url = toURL(path);
-
 #ifdef Q_OS_WIN
     auto *thread = QThread::create([path]()
     {
@@ -217,8 +220,10 @@ void Utils::Gui::openPath(const Path &path)
     thread->setObjectName("Utils::Gui::openPath thread");
     QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
+#elif defined(Q_OS_MACOS)
+    MacUtils::openPath(path);
 #else
-    QDesktopServices::openUrl(url);
+    QDesktopServices::openUrl(toURL(path));
 #endif
 }
 


### PR DESCRIPTION
## Summary
- route `Utils::Gui::openPath()` through `NSWorkspace openURL:` on macOS
- keep the existing Qt Desktop Services path for other Unix platforms
- compile the shared local-file URL helper only on platforms that still use it

Closes #22395

## Root cause
On affected Qt/macOS combinations, `QDesktopServices::openUrl(QUrl::fromLocalFile(...))` can fail to open local paths containing spaces or bracket characters. qBittorrent already uses native `NSWorkspace` APIs for revealing files on macOS, so direct file opening should use the same native path.

## Validation
- cmake --build build --target qbittorrent
- QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v
