### PR TITLE
Fix macOS About dialog close handling

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1012,6 +1012,12 @@ void MainWindow::on_actionExit_triggered()
 #ifdef Q_OS_MACOS
 void MainWindow::on_actionCloseWindow_triggered()
 {
+    if (m_aboutDlg && (QApplication::activeWindow() == m_aboutDlg))
+    {
+        m_aboutDlg->close();
+        return;
+    }
+
     // On macOS window close is basically equivalent to window hide.
     // If you decide to implement this functionality for other OS,
     // then you will also need ui lock checks like in actionExit.
@@ -1099,6 +1105,8 @@ void MainWindow::on_actionAbout_triggered()
     // About dialog
     if (m_aboutDlg)
     {
+        m_aboutDlg->show();
+        m_aboutDlg->raise();
         m_aboutDlg->activateWindow();
     }
     else


### PR DESCRIPTION
## Summary
- close the About dialog when macOS routes Cmd+W through the main Close Window action while About is active
- raise and activate an existing About dialog when the About menu action is triggered again

Closes #12710

## Root cause
The macOS Close Window menu action belongs to the main window, so Cmd+W can reach `MainWindow::on_actionCloseWindow_triggered()` even when the modeless About dialog is active. The existing About action also only called `activateWindow()`, which may not bring an obscured modeless dialog back above the main window.

## Validation
- cmake --build build --target qbittorrent
- QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v
