### PR TITLE
Accept Add Torrent dialog with keypad Enter

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -247,6 +247,9 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
 
     connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    const auto *acceptKeypadEnterShortcut = new QShortcut(Qt::Key_Enter, this);
+    connect(acceptKeypadEnterShortcut, &QShortcut::activated
+            , m_ui->buttonBox->button(QDialogButtonBox::Ok), &QPushButton::click);
     connect(m_ui->buttonSave, &QPushButton::clicked, this, &AddNewTorrentDialog::saveTorrentFile);
     connect(m_ui->savePath, &FileSystemPathEdit::selectedPathChanged, this, &AddNewTorrentDialog::onSavePathChanged);
     connect(m_ui->downloadPath, &FileSystemPathEdit::selectedPathChanged, this, &AddNewTorrentDialog::onDownloadPathChanged);


### PR DESCRIPTION
## Summary
- add a window-scoped keypad Enter shortcut to the Add Torrent dialog
- route it through the existing OK button so disabled/validation behavior is preserved

Closes #16904

## Root cause
The Add Torrent dialog relies on the platform/default dialog handling for Enter/Return activation. On macOS, the numeric keypad Enter key is reported as `Qt::Key_Enter` and does not reliably activate the dialog default button.

## Validation
- cmake --build build --target qbittorrent
- QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v
