### PR TITLE
Handle Home and End in macOS line edits

### DIFF
--- a/src/gui/lineedit.cpp
+++ b/src/gui/lineedit.cpp
@@ -75,6 +75,25 @@ LineEdit::LineEdit(QWidget *parent)
 
 void LineEdit::keyPressEvent(QKeyEvent *event)
 {
+#ifdef Q_OS_MACOS
+    if ((event->modifiers() & ~Qt::ShiftModifier) == Qt::NoModifier)
+    {
+        const bool mark = event->modifiers().testFlag(Qt::ShiftModifier);
+        if (event->key() == Qt::Key_Home)
+        {
+            home(mark);
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_End)
+        {
+            end(mark);
+            event->accept();
+            return;
+        }
+    }
+#endif
+
     if ((event->modifiers() == Qt::NoModifier) && (event->key() == Qt::Key_Escape))
     {
         clear();


### PR DESCRIPTION
## Summary
- handle physical Home/End keys in qBittorrent custom `LineEdit` on macOS
- preserve Shift+Home/End text selection
- leave existing platform/default handling unchanged elsewhere

Closes #10576

## Root cause
The affected search/filter fields use qBittorrent's custom `LineEdit`. On macOS, physical Home/End key events do not reliably reach the expected QLineEdit cursor movement behavior, so the custom widget needs to handle those keys before falling back to Qt.

## Validation
- cmake --build build --target qbittorrent
- QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v
