### PR TITLE
Forward macOS file-open events to the main instance

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -857,7 +857,27 @@ void Application::allTorrentsFinished()
 
 bool Application::callMainInstance()
 {
-    return m_instanceManager->sendMessage(serializeParams(commandLineArgs()));
+    QStringList messages;
+
+    const auto appendMessage = [&messages](const QBtCommandLineParameters &params)
+    {
+        const QString message = serializeParams(params);
+        if (!message.isEmpty() && !messages.contains(message))
+            messages.append(message);
+    };
+
+    appendMessage(commandLineArgs());
+    for (const QBtCommandLineParameters &params : asConst(m_paramsQueue))
+        appendMessage(params);
+
+    if (messages.isEmpty())
+        messages.append(QString());
+
+    bool result = true;
+    for (const QString &message : asConst(messages))
+        result = m_instanceManager->sendMessage(message) && result;
+
+    return result;
 }
 
 void Application::processParams(const QBtCommandLineParameters &params)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -46,6 +46,9 @@
 #endif
 
 #include <QCoreApplication>
+#if defined(Q_OS_MACOS) && !defined(DISABLE_GUI)
+#include <QEventLoop>
+#endif
 #include <QString>
 #include <QThread>
 
@@ -246,7 +249,17 @@ int main(int argc, char *argv[])
             }
 #endif
 
+#if defined(Q_OS_MACOS) && !defined(DISABLE_GUI)
+            const auto eventDeliveryDeadline = std::chrono::steady_clock::now() + 300ms;
+            while (std::chrono::steady_clock::now() < eventDeliveryDeadline)
+            {
+                QCoreApplication::processEvents(QEventLoop::AllEvents);
+                QThread::msleep(10);
+            }
+            QCoreApplication::processEvents(QEventLoop::AllEvents);
+#else
             QThread::msleep(300);
+#endif
             app->callMainInstance();
 
             return EXIT_SUCCESS;


### PR DESCRIPTION
## Description
When qBittorrent is already running on macOS, Launch Services can deliver an opened `.torrent` file to the secondary process as a `QFileOpenEvent` instead of a command-line argument. The secondary process previously slept, forwarded only its parsed command line, and exited, so those queued file-open events could be dropped.

This gives macOS secondary instances a short event-processing window before forwarding, and forwards any queued file-open parameters to the main instance. Empty launches still forward an empty activation message.

Fixes #19986.

## Validation
- `cmake --build build --target qbittorrent`
- `QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v`