### PR TITLE
Add macOS fullscreen shortcut

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -914,6 +914,11 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionExit->setShortcut(Qt::CTRL | Qt::Key_Q);
 #ifdef Q_OS_MACOS
     m_ui->actionCloseWindow->setShortcut(QKeySequence::Close);
+    const auto *toggleFullScreenShortcut = new QShortcut((Qt::CTRL | Qt::META | Qt::Key_F), this);
+    connect(toggleFullScreenShortcut, &QShortcut::activated, this, [this]
+    {
+        isFullScreen() ? showNormal() : showFullScreen();
+    });
 #else
     m_ui->actionCloseWindow->setVisible(false);
 #endif


### PR DESCRIPTION
## Description
Adds the standard macOS fullscreen shortcut, Ctrl+Cmd+F, to the main window. The shortcut toggles between `showFullScreen()` and `showNormal()` and is compiled only for macOS.

Fixes #12500.

## Validation
- `cmake --build build --target qbittorrent`
- `QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v`