### PR TITLE
Ignore content checkbox double-click activation

### DIFF
--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -38,7 +38,10 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QModelIndexList>
+#include <QMouseEvent>
 #include <QShortcut>
+#include <QStyle>
+#include <QStyleOptionViewItem>
 #include <QWheelEvent>
 
 #include "base/bittorrent/torrentcontenthandler.h"
@@ -247,6 +250,41 @@ void TorrentContentWidget::mousePressEvent(QMouseEvent *event)
     QTreeView::mousePressEvent(event);
 }
 
+void TorrentContentWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (m_ignoreNextCheckIndicatorRelease)
+    {
+        m_ignoreNextCheckIndicatorRelease = false;
+
+        const QPoint position = event->position().toPoint();
+        const QModelIndex nameIndex = indexAt(position).siblingAtColumn(TorrentContentModelItem::COL_NAME);
+        if (isCheckIndicatorAt(nameIndex, position))
+        {
+            event->accept();
+            return;
+        }
+    }
+
+    QTreeView::mouseReleaseEvent(event);
+}
+
+void TorrentContentWidget::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    const QPoint position = event->position().toPoint();
+    const QModelIndex nameIndex = indexAt(position).siblingAtColumn(TorrentContentModelItem::COL_NAME);
+    if (isCheckIndicatorAt(nameIndex, position))
+    {
+        const Qt::CheckState state = static_cast<Qt::CheckState>(nameIndex.data(Qt::CheckStateRole).toInt());
+        model()->setData(nameIndex, ((state == Qt::Checked) ? Qt::Unchecked : Qt::Checked), Qt::CheckStateRole);
+
+        m_ignoreNextCheckIndicatorRelease = true;
+        event->accept();
+        return;
+    }
+
+    QTreeView::mouseDoubleClickEvent(event);
+}
+
 void TorrentContentWidget::keyPressEvent(QKeyEvent *event)
 {
     if ((event->key() != Qt::Key_Space) && (event->key() != Qt::Key_Select))
@@ -341,6 +379,23 @@ void TorrentContentWidget::applyPrioritiesByOrder()
         const QPersistentModelIndex &index = selectedRows[i];
         model()->setData(index, static_cast<int>(priority));
     }
+}
+
+bool TorrentContentWidget::isCheckIndicatorAt(const QModelIndex &index, const QPoint &position) const
+{
+    if (!index.isValid() || (index.column() != TorrentContentModelItem::COL_NAME)
+        || !index.data(Qt::CheckStateRole).isValid())
+    {
+        return false;
+    }
+
+    QStyleOptionViewItem option;
+    initViewItemOption(&option);
+    option.rect = visualRect(index);
+    option.features |= QStyleOptionViewItem::HasCheckIndicator;
+    option.checkState = static_cast<Qt::CheckState>(index.data(Qt::CheckStateRole).toInt());
+
+    return style()->subElementRect(QStyle::SE_ItemViewItemCheckIndicator, &option, this).contains(position);
 }
 
 void TorrentContentWidget::openSelectedFile()

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -107,10 +107,13 @@ signals:
 private:
     void setModel(QAbstractItemModel *model) override;
     void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void rowsInserted(const QModelIndex &parent, int start, int end) override;
 
+    bool isCheckIndicatorAt(const QModelIndex &index, const QPoint &position) const;
     QModelIndex currentNameCell() const;
     void displayColumnHeaderMenu();
     void displayContextMenu();
@@ -137,4 +140,5 @@ private:
 
     bool m_contentDragAllowed = false;
     bool m_contentDragEnabled = false;
+    bool m_ignoreNextCheckIndicatorRelease = false;
 };


### PR DESCRIPTION
## Description
Suppresses torrent-content row double-click activation when the double-click lands on the name-column checkbox indicator. The checkbox still toggles for the second click, but the row double-click action no longer opens or renames the item.

Fixes #14343.

## Validation
- `cmake --build build --target qbittorrent`
- `QT_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins:$(brew --prefix qt)/plugins" QT_QPA_PLATFORM_PLUGIN_PATH="$(brew --prefix qt)/share/qt/plugins/platforms:$(brew --prefix qt)/plugins/platforms" build/qbittorrent.app/Contents/MacOS/qbittorrent -v`