### PR TITLE
Minimize on ESC

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -2176,6 +2176,19 @@ void Preferences::setAddNewTorrentDialogAttached(const bool attached)
     setValue(u"AddNewTorrentDialog/Attached"_s, attached);
 }
 
+bool Preferences::isMinimizeOnEscEnabled() const
+{
+    return value(u"Preferences/Desktop/MinimizeOnEsc"_s, false);
+}
+
+void Preferences::setMinimizeOnEscEnabled(const bool enabled)
+{
+    if (enabled == isMinimizeOnEscEnabled())
+        return;
+
+    setValue(u"Preferences/Desktop/MinimizeOnEsc"_s, enabled);
+}
+
 void Preferences::apply()
 {
     if (SettingsStorage::instance()->save())

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -440,6 +440,9 @@ public:
     void setAddNewTorrentDialogSavePathHistoryLength(int value);
     bool isAddNewTorrentDialogAttached() const;
     void setAddNewTorrentDialogAttached(bool attached);
+    bool isMinimizeOnEscEnabled() const;
+    void setMinimizeOnEscEnabled(bool value);
+
 
 public slots:
     void setStatusFilterState(bool checked);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -443,7 +443,6 @@ public:
     bool isMinimizeOnEscEnabled() const;
     void setMinimizeOnEscEnabled(bool value);
 
-
 public slots:
     void setStatusFilterState(bool checked);
     void setCategoryFilterState(bool checked);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -936,7 +936,7 @@ void MainWindow::createKeyboardShortcuts()
     if (pref->isMinimizeOnEscEnabled())
     {
         const auto *escMinimize = new QShortcut(Qt::Key_Escape, this);
-        connect(escMinimize, &QShortcut::activated, this, &MainWindow::hide);
+        connect(escMinimize, &QShortcut::activated, this, &MainWindow::showMinimized);
     }
 
     m_ui->actionDocumentation->setShortcut(QKeySequence::HelpContents);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -931,6 +931,14 @@ void MainWindow::createKeyboardShortcuts()
     const auto *switchSearchFilterShortcutAlternative = new QShortcut((Qt::CTRL | Qt::Key_E), m_transferListWidget);
     connect(switchSearchFilterShortcutAlternative, &QShortcut::activated, this, &MainWindow::toggleFocusBetweenLineEdits);
 
+    Preferences *const pref = Preferences::instance();
+
+    if (pref->isMinimizeOnEscEnabled())
+    {
+        const auto *escMinimize = new QShortcut(Qt::Key_Escape, this);
+        connect(escMinimize, &QShortcut::activated, this, &MainWindow::hide);
+    }
+
     m_ui->actionDocumentation->setShortcut(QKeySequence::HelpContents);
     m_ui->actionOptions->setShortcut(Qt::ALT | Qt::Key_O);
     m_ui->actionStatistics->setShortcut(Qt::CTRL | Qt::Key_I);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1485,6 +1485,7 @@ void MainWindow::updateMinimizeOnEscShortcut()
 {
     if (Preferences::instance()->isMinimizeOnEscEnabled())
     {
+        // Intentionally separate if-statement so it doesn't call the else condition if m_minimizeOnEscShortcut is not null
         if (!m_minimizeOnEscShortcut)
         {
             m_minimizeOnEscShortcut = new QShortcut(Qt::Key_Escape, this);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -931,13 +931,7 @@ void MainWindow::createKeyboardShortcuts()
     const auto *switchSearchFilterShortcutAlternative = new QShortcut((Qt::CTRL | Qt::Key_E), m_transferListWidget);
     connect(switchSearchFilterShortcutAlternative, &QShortcut::activated, this, &MainWindow::toggleFocusBetweenLineEdits);
 
-    Preferences *const pref = Preferences::instance();
-
-    if (pref->isMinimizeOnEscEnabled())
-    {
-        const auto *escMinimize = new QShortcut(Qt::Key_Escape, this);
-        connect(escMinimize, &QShortcut::activated, this, &MainWindow::showMinimized);
-    }
+    updateMinimizeOnEscShortcut();
 
     m_ui->actionDocumentation->setShortcut(QKeySequence::HelpContents);
     m_ui->actionOptions->setShortcut(Qt::ALT | Qt::Key_O);
@@ -1406,6 +1400,8 @@ void MainWindow::loadPreferences()
 {
     const Preferences *pref = Preferences::instance();
 
+    updateMinimizeOnEscShortcut();
+
     // General
     if (pref->isToolbarDisplayed())
     {
@@ -1483,6 +1479,23 @@ void MainWindow::loadPreferences()
 #endif
 
     qDebug("GUI settings loaded");
+}
+
+void MainWindow::updateMinimizeOnEscShortcut()
+{
+    if (Preferences::instance()->isMinimizeOnEscEnabled())
+    {
+        if (!m_minimizeOnEscShortcut)
+        {
+            m_minimizeOnEscShortcut = new QShortcut(Qt::Key_Escape, this);
+            connect(m_minimizeOnEscShortcut, &QShortcut::activated, this, &MainWindow::showMinimized);
+        }
+    }
+    else
+    {
+        delete m_minimizeOnEscShortcut;
+        m_minimizeOnEscShortcut = nullptr;
+    }
 }
 
 void MainWindow::loadSessionStats()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -45,6 +45,7 @@ class QSplitter;
 class QString;
 class QTabWidget;
 class QTimer;
+class QShortcut;
 
 class AboutDialog;
 class DownloadFromURLDialog;
@@ -128,6 +129,7 @@ private slots:
     void displayRSSTab();
     void displayExecutionLogTab();
     void toggleFocusBetweenLineEdits();
+    void updateMinimizeOnEscShortcut();
     void loadSessionStats();
     void reloadTorrentStats(const QList<BitTorrent::Torrent *> &torrents);
     void loadPreferences();
@@ -250,6 +252,7 @@ private:
     PowerManagement *m_pwr = nullptr;
     QTimer *m_preventTimer = nullptr;
     QMenu *m_toolbarMenu = nullptr;
+    QShortcut *m_minimizeOnEscShortcut = nullptr;
 
     SettingValue<bool> m_storeExecutionLogEnabled;
     SettingValue<bool> m_storeDownloadTrackerFavicon;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -562,6 +562,7 @@ void OptionsDialog::saveBehaviorTabOptions() const
     pref->setStatusbarFreeDiskSpaceDisplayed(m_ui->checkBoxFreeDiskSpaceStatusBar->isChecked());
     pref->setStatusbarExternalIPDisplayed(m_ui->checkBoxExternalIPStatusBar->isChecked());
     session->setPerformanceWarningEnabled(m_ui->checkBoxPerformanceWarning->isChecked());
+    pref->setMinimizeOnEscEnabled(m_ui->checkMinimizeOnEsc->isChecked());
 }
 
 void OptionsDialog::loadDownloadsTabOptions()
@@ -1116,6 +1117,8 @@ void OptionsDialog::loadSpeedTabOptions()
     connect(m_ui->checkShowSpeedInDock, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkShowMenuBarIcon, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 #endif
+
+    connect(m_ui->checkMinimizeOnEsc, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 }
 
 void OptionsDialog::saveSpeedTabOptions() const
@@ -1142,8 +1145,6 @@ void OptionsDialog::saveSpeedTabOptions() const
     pref->setSpeedInDockEnabled(m_ui->checkShowSpeedInDock->isChecked());
     pref->setMacOSMenuBarIconEnabled(m_ui->checkShowMenuBarIcon->isChecked());
 #endif
-
-    pref->setMinimizeOnEscEnabled(m_ui->checkMinimizeOnEsc->isChecked());
 }
 
 void OptionsDialog::loadBittorrentTabOptions()

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1095,6 +1095,8 @@ void OptionsDialog::loadSpeedTabOptions()
     m_ui->checkShowMenuBarIcon->hide();
 #endif
 
+    m_ui->checkMinimizeOnEsc->setChecked(pref->isMinimizeOnEscEnabled());
+
     connect(m_ui->spinUploadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinDownloadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
 
@@ -1140,6 +1142,8 @@ void OptionsDialog::saveSpeedTabOptions() const
     pref->setSpeedInDockEnabled(m_ui->checkShowSpeedInDock->isChecked());
     pref->setMacOSMenuBarIconEnabled(m_ui->checkShowMenuBarIcon->isChecked());
 #endif
+
+    pref->setMinimizeOnEscEnabled(m_ui->checkMinimizeOnEsc->isChecked());
 }
 
 void OptionsDialog::loadBittorrentTabOptions()

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -751,7 +751,7 @@
                <item>
                 <widget class="QCheckBox" name="checkMinimizeOnEsc">
                  <property name="text">
-                  <string>Minimize on ESC (Restart required)</string>
+                  <string>Minimize on ESC</string>
                  </property>
                 </widget>
                </item>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -748,6 +748,13 @@
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QCheckBox" name="checkMinimizeOnEsc">
+                 <property name="text">
+                  <string>Minimize on ESC (Restart required)</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>


### PR DESCRIPTION
Closes #6880.

Allows the desktop app to be minimized when ESC is pressed. 

The shortcut is configurable.

<img width="570" height="444" alt="Screenshot 2026-06-07 at 5 58 07 PM" src="https://github.com/user-attachments/assets/b01de7ba-6b68-46ee-afbf-9e407028e6a6" />
