### PR TITLE
Add plugins support

### DIFF
--- a/examples/plugins/EmailNotifier.lua
+++ b/examples/plugins/EmailNotifier.lua
@@ -1,0 +1,12 @@
+NAME = "Email Notifier Example"
+VERSION = "0.1"
+
+function onTorrentFinished(torrent)
+    local content = string.format("Torrent name: %s\n",  torrent.name) ..
+        string.format("Torrent size: %s\n", qBittorrent.friendlySizeUnit(torrent.wantedSize)) ..
+        string.format("Save path: %s\n\n", torrent.savePath) ..
+        string.format("The torrent was downloaded in %s.\n\n\n", qBittorrent.friendlyDuration(torrent.activeTime)) ..
+        "Thank you for using qBittorrent."
+    local subject = string.format("Torrent '%s' has finished downloading", torrent.name)
+    qBittorrent.sendMail(subject, content)
+end

--- a/examples/plugins/EventHandler.lua
+++ b/examples/plugins/EventHandler.lua
@@ -1,0 +1,148 @@
+NAME = "Event Handler Example"
+VERSION = "0.1"
+
+function onTorrentAdded(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' is added.", NAME, torrent.name))
+
+    qBittorrent.debug(string.format("Torrent: %s", torrent.name))
+    qBittorrent.debug(string.format("  ID: %s", torrent.id))
+    qBittorrent.debug(string.format("  Info hash v1: %s", torrent.infoHashV1))
+    qBittorrent.debug(string.format("  Info hash v2: %s", torrent.infoHashV2))
+    qBittorrent.debug(string.format("  Creator: %s", torrent.creator))
+    qBittorrent.debug(string.format("  Creation time: %s", qBittorrent.formatDateTime(torrent.creationTime)))
+    qBittorrent.debug(string.format("  Comment: %s", torrent.comment))
+    qBittorrent.debug(string.format("  Category: %s", torrent.category))
+    qBittorrent.debug(string.format("  Tags: %s", table.concat(torrent.tags, ", ")))
+    qBittorrent.debug(string.format("  Save path: %s", torrent.savePath))
+    qBittorrent.debug(string.format("  Download path: %s", torrent.downloadPath))
+    qBittorrent.debug(string.format("  Content path: %s", torrent.contentPath))
+    qBittorrent.debug(string.format("  Root path: %s", torrent.rootPath))
+    qBittorrent.debug(string.format("  Current tracker: %s", torrent.currentTracker))
+    qBittorrent.debug("  Trackers:")
+    for _, trackerStatus in ipairs(torrent.trackerStatuses) do
+        qBittorrent.debug(string.format("    %s", trackerStatus.url))
+    end
+    qBittorrent.debug("  URL seeds:")
+    for _, urlSeed in ipairs(torrent.urlSeeds) do
+        qBittorrent.debug(string.format("    %s", urlSeed))
+    end
+    qBittorrent.debug(string.format("  Has metadata: %s", tostring(torrent.hasMetadata)))
+end
+
+function onTorrentMetadataReady(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' has metadata ready.", NAME, torrent.name))
+
+    qBittorrent.debug(string.format("Torrent: %s", torrent.name))
+    qBittorrent.debug(string.format("  ID: %s", torrent.id))
+    qBittorrent.debug(string.format("  Info hash v1: %s", torrent.infoHashV1))
+    qBittorrent.debug(string.format("  Info hash v2: %s", torrent.infoHashV2))
+    qBittorrent.debug(string.format("  Private: %s", tostring(torrent.private)))
+    qBittorrent.debug(string.format("  Total size: %s", qBittorrent.friendlySizeUnit(torrent.totalSize)))
+    qBittorrent.debug(string.format("  Piece size: %s", qBittorrent.friendlySizeUnit(torrent.pieceSize)))
+    qBittorrent.debug(string.format("  Pieces count: %d", torrent.piecesCount))
+    qBittorrent.debug(string.format("  Files count: %d", torrent.filesCount))
+    qBittorrent.debug("  Files:")
+    for i = 0, (torrent.filesCount - 1) do
+        qBittorrent.debug(string.format("    %s (%s)", torrent:filePath(i)
+                , qBittorrent.friendlySizeUnit(torrent:fileSize(i))))
+    end
+end
+
+function onTorrentFinished(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' is finished.", NAME, torrent.name))
+end
+
+function onTorrentStarted(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' is started.", NAME, torrent.name) )
+end
+
+function onTorrentStopped(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' is stopped.", NAME, torrent.name))
+end
+
+function onTorrentSavePathChanged(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' has changed save path.", NAME, torrent.name))
+end
+
+function onTorrentSavingModeChanged(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' has changed saving mode.", NAME, torrent.name))
+end
+
+function onTorrentCategoryChanged(torrent, oldCategory)
+    qBittorrent.log(string.format("%s: Torrent '%s' has changed category.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Old category: %s. New category: %s.", torrent.name, oldCategory, torrent.category))
+end
+
+function onTorrentTagAdded(torrent, tag)
+    qBittorrent.log(string.format("%s: Torrent '%s' has tag added.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Added tag: %s.", torrent.name, tag))
+end
+
+function onTorrentTagRemoved(torrent, tag)
+    qBittorrent.log(string.format("%s: Torrent '%s' has tag removed.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Removed tag: %s.", torrent.name, tag))
+end
+
+function onTorrentContentFileRenamed(torrent, fileIndex, oldPath)
+    qBittorrent.log(string.format("%s: Torrent '%s' has file renamed.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Renamed file: '%s'. Old NAME: '%s'.", torrent.name, torrent:filePath(fileIndex), oldPath))
+end
+
+function onTorrentContentFolderRenamed(torrent, newPath, oldPath, renamedFiles)
+    qBittorrent.log(string.format("%s: Torrent '%s' has folder renamed.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Renamed folder: '%s'. Old NAME: '%s'.", torrent.name, newPath, oldPath))
+end
+
+function onTorrentContentFolderRenamingFailed(torrent, newPath, oldPath, renamedFiles, failedFileIndexes)
+    qBittorrent.log(string.format("%s: Torrent '%s' has folder renaming failed.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Folder: '%s'. New NAME: '%s'.", torrent.name, oldPath, newPath))
+end
+
+function onTorrentIOError(torrent, message)
+    qBittorrent.log(string.format("%s: Torrent '%s' has IO error.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. IO error message: %s.", torrent.name, message))
+end
+
+function onTorrentAboutToBeRemoved(torrent)
+    qBittorrent.log(string.format("%s: Torrent '%s' is about to be removed.", NAME, torrent.name))
+end
+
+function onTorrentAnnounceSuccess(torrent, tracker)
+    qBittorrent.log(string.format("%s: Torrent '%s' has announced successfully.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Announced tracker: %s.", torrent.name, tracker))
+end
+
+function onTorrentAnnounceWarning(torrent, tracker)
+    qBittorrent.log(string.format("%s: Torrent '%s' has announced with warning.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Announced tracker: %s.", torrent.name, tracker))
+end
+
+function onTorrentAnnounceError(torrent, tracker)
+    qBittorrent.log(string.format("%s: Torrent '%s' has failed announce.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Failed tracker: %s.", torrent.name, tracker))
+end
+
+function onTorrentTrackersAdded(torrent, addedTrackers)
+    qBittorrent.log(string.format("%s: Torrent '%s' has added trackers.", NAME, torrent.name))
+
+    qBittorrent.debug(string.format("Torrent: %s. Added trackers:", torrent.name))
+    for _, tracker in ipairs(addedTrackers) do
+        qBittorrent.debug(string.format("\t%s", tracker.url))
+    end
+end
+
+function onTorrentTrackersRemoved(torrent, removedTrackers)
+    qBittorrent.log(string.format("%s: Torrent '%s' has removed trackers.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Removed trackers:", torrent.name))
+    for _, tracker in ipairs(removedTrackers) do
+        qBittorrent.debug(string.format("\t%s", tracker))
+    end
+end
+
+function onTorrentTrackerStatusesUpdated(torrent, updatedTrackers)
+    qBittorrent.log(string.format("%s: Torrent '%s' has updated tracker statuses.", NAME, torrent.name))
+    qBittorrent.debug(string.format("Torrent: %s. Updated trackers:", torrent.name))
+    for trackerURL, trackerStatus in pairs(updatedTrackers) do
+        qBittorrent.debug(string.format("\t%s", trackerURL))
+    end
+end

--- a/examples/plugins/Invocable.lua
+++ b/examples/plugins/Invocable.lua
@@ -1,0 +1,6 @@
+NAME = "Invocable Example"
+VERSION = "0.1"
+
+function invoke()
+    qBittorrent.log(string.format("%s: Invoked.", NAME))
+end

--- a/examples/plugins/RunExternalProgram.lua
+++ b/examples/plugins/RunExternalProgram.lua
@@ -1,0 +1,16 @@
+NAME = "Run External Program Example"
+VERSION = "0.1"
+
+function onTorrentAdded(torrent)
+    local testFile = string.format("%s/%s.txt", torrent.savePath, torrent.name)
+    qBittorrent.exec(string.format("touch \"%s\"", testFile))
+end
+
+function onTorrentFinished(torrent)
+    qBittorrent.exec(string.format("/usr/bin/nemo \"%s\"", torrent.savePath))
+end
+
+function onTorrentAboutToBeRemoved(torrent)
+    local testFile = string.format("%s/%s.txt", torrent.savePath, torrent.name)
+    qBittorrent.exec(string.format("rm \"%s\"", testFile))
+end

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015-2025  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez
  *
  * This program is free software; you can redistribute it and/or
@@ -67,6 +67,7 @@
 #endif
 
 #include "base/addtorrentmanager.h"
+#include "base/bittorrent/addtorrentparams.h"
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrent.h"
@@ -78,6 +79,7 @@
 #include "base/net/proxyconfigurationmanager.h"
 #include "base/net/reverseresolution.h"
 #include "base/net/smtpclient.h"
+#include "base/plugins/pluginsengine.h"
 #include "base/preferences.h"
 #include "base/profile.h"
 #include "base/rss/rss_autodownloader.h"
@@ -938,13 +940,14 @@ int Application::exec()
         connect(m_desktopIntegration, &DesktopIntegration::activationRequested, this, &Application::createStartupProgressDialog);
     }
 #endif
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::restored, this, [this]()
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::restored, this, [this]
     {
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentAdded, this, &Application::torrentAdded);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentFinished, this, &Application::torrentFinished);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::allTorrentsFinished, this, &Application::allTorrentsFinished, Qt::QueuedConnection);
 
         m_addTorrentManager = new AddTorrentManagerImpl(this, BitTorrent::Session::instance(), this);
+        PluginsEngine::initInstance();
 
         Net::GeoIPManager::initInstance();
         Net::ReverseResolution::initInstance();
@@ -1463,6 +1466,8 @@ void Application::cleanup()
 #ifndef DISABLE_WEBUI
     delete m_webui;
 #endif
+
+    PluginsEngine::freeInstance();
 
     delete RSS::AutoDownloader::instance();
     delete RSS::Session::instance();

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2022  Mike Tzou (Chocobo1)
- * Copyright (C) 2015, 2019  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez
  *
  * This program is free software; you can redistribute it and/or
@@ -42,7 +42,6 @@
 #include <QApplication>
 #endif
 
-#include "base/bittorrent/addtorrentparams.h"
 #include "base/interfaces/iapplication.h"
 #include "base/path.h"
 #include "base/settingvalue.h"

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -87,7 +87,13 @@ add_library(qbt_base STATIC
     orderedset.h
     path.h
     pathfwd.h
-    pluginsengine.h
+    plugins/luaclasses.h
+    plugins/luafunctions.h
+    plugins/luanamespace.h
+    plugins/luastack.h
+    plugins/plugin.h
+    plugins/pluginsengine.h
+    plugins/pluginversion.h
     preferences.h
     profile.h
     profile_p.h
@@ -186,7 +192,10 @@ add_library(qbt_base STATIC
     net/reverseresolution.cpp
     net/smtpclient.cpp
     path.cpp
-    pluginsengine.cpp
+    plugins/luaclasses.cpp
+    plugins/luafunctions.cpp
+    plugins/plugin.cpp
+    plugins/pluginsengine.cpp
     preferences.cpp
     profile.cpp
     profile_p.cpp

--- a/src/base/plugins/luaclasses.cpp
+++ b/src/base/plugins/luaclasses.cpp
@@ -1,0 +1,281 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "luaclasses.h"
+
+#include <LuaBridge/LuaBridge.h>
+#include <LuaBridge/Vector.h>
+
+#include <QDateTime>
+#include <QString>
+
+#include "base/bittorrent/addtorrenterror.h"
+#include "base/bittorrent/infohash.h"
+#include "base/bittorrent/sharelimits.h"
+#include "base/bittorrent/torrent.h"
+#include "base/bittorrent/trackerentry.h"
+#include "base/bittorrent/trackerentrystatus.h"
+#include "luanamespace.h"
+#include "luastack.h"
+
+namespace
+{
+    qint64 toSecondsSinceEpoch(const BitTorrent::AnnounceTimePoint &time)
+    {
+        const auto now = std::chrono::system_clock::now();
+        const auto timepointNow = BitTorrent::AnnounceTimePoint::clock::now();
+        const auto timeEpoch = (now + (time - timepointNow)).time_since_epoch();
+        return std::chrono::duration_cast<std::chrono::seconds>(timeEpoch).count();
+    }
+
+    void registerLuaClassTorrent(lua_State *luaState)
+    {
+        using Torrent = BitTorrent::Torrent;
+
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        auto cls = qBittorrentNS.beginClass<Torrent>("Torrent");
+
+        cls.addProperty("id", +[](const Torrent *torrent) { return torrent->id().toString(); });
+        cls.addProperty("infoHashV1", +[](const Torrent *torrent) { return torrent->infoHash().v1().toString(); });
+        cls.addProperty("infoHashV2", +[](const Torrent *torrent) { return torrent->infoHash().v2().toString(); });
+        cls.addProperty("hasMetadata", +[](const Torrent *torrent) { return torrent->hasMetadata(); });
+        cls.addProperty("name", &Torrent::name, &Torrent::setName);
+        cls.addProperty("creationTime", +[](const Torrent *torrent) { return torrent->creationDate().toSecsSinceEpoch(); });
+        cls.addProperty("creator", &Torrent::creator);
+        cls.addProperty("comment", &Torrent::comment, &Torrent::setComment);
+
+        // metadata
+        cls.addProperty("filesCount", +[](const Torrent *torrent) { return torrent->filesCount(); });
+        cls.addFunction("filePath", &Torrent::filePath);
+        cls.addFunction("fileSize", &Torrent::fileSize);
+        cls.addProperty("pieceSize", &Torrent::pieceLength);
+        cls.addProperty("piecesCount", &Torrent::piecesCount);
+        cls.addProperty("totalSize", &Torrent::totalSize);
+        cls.addProperty("private", &Torrent::isPrivate);
+
+        cls.addProperty("savePath", &Torrent::savePath, &Torrent::setSavePath);
+        cls.addProperty("downloadPath", &Torrent::downloadPath, &Torrent::setDownloadPath);
+        cls.addProperty("category", &Torrent::category, +[](Torrent *torrent, const QString &category)
+        {
+            torrent->setCategory(category);
+        });
+        cls.addProperty("tags", +[](const Torrent *torrent) -> std::vector<QString>
+        {
+            const auto tags = torrent->tags();
+            return {tags.cbegin(), tags.cend()};
+        });
+        cls.addFunction("hasTag", &Torrent::hasTag);
+        cls.addFunction("addTag", &Torrent::addTag);
+        cls.addFunction("removeTag", &Torrent::removeTag);
+        cls.addFunction("clearTags", &Torrent::clearTags);
+
+        cls.addProperty("addedTime", +[](const Torrent *torrent) { return torrent->addedTime().toSecsSinceEpoch(); });
+        cls.addProperty("completedTime", +[](const Torrent *torrent) { return torrent->completedTime().toSecsSinceEpoch(); });
+        cls.addProperty("lastSeenComplete", +[](const Torrent *torrent) { return torrent->lastSeenComplete().toSecsSinceEpoch(); });
+        cls.addProperty("activeTime", &Torrent::activeTime);
+        cls.addProperty("finishedTime", &Torrent::finishedTime);
+        cls.addProperty("timeSinceActivity", &Torrent::timeSinceActivity);
+        cls.addProperty("timeSinceDownload", &Torrent::timeSinceDownload);
+        cls.addProperty("timeSinceUpload", &Torrent::timeSinceUpload);
+
+        cls.addProperty("wantedSize", &Torrent::wantedSize);
+        cls.addProperty("completedSize", &Torrent::completedSize);
+        cls.addProperty("wastedSize", &Torrent::wastedSize);
+        cls.addProperty("piecesHave", &Torrent::piecesHave);
+        cls.addProperty("progress", &Torrent::progress);
+
+        cls.addProperty("rootPath", &Torrent::rootPath);
+        cls.addProperty("contentPath", &Torrent::contentPath);
+
+        cls.addProperty("currentTracker", &Torrent::currentTracker);
+        cls.addProperty("trackerStatuses", &Torrent::trackers);
+        cls.addProperty("urlSeeds", &Torrent::urlSeeds);
+
+        cls.addProperty("shareLimits", &Torrent::shareLimits, &Torrent::setShareLimits);
+        cls.addProperty("effectiveShareLimits", &Torrent::effectiveShareLimits);
+
+        cls.addProperty("hasMissingFiles", &Torrent::hasMissingFiles);
+        cls.addProperty("hasError", &Torrent::hasError);
+        cls.addProperty("error", &Torrent::error);
+
+        cls.addProperty("queuePosition", &Torrent::queuePosition);
+
+        cls.addFunction("start", &Torrent::start);
+        cls.addFunction("stop", &Torrent::stop);
+    }
+
+    void registerLuaClassTrackerEntry(lua_State *luaState)
+    {
+        using TrackerEntry = BitTorrent::TrackerEntry;
+
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        auto cls = qBittorrentNS.beginClass<TrackerEntry>("TrackerEntry");
+
+        cls.addConstructor<void ()>();
+        cls.addProperty("url", &TrackerEntry::url);
+        cls.addProperty("tier", &TrackerEntry::tier);
+    }
+
+    void registerLuaEnumTrackerEndpointState(lua_State *luaState)
+    {
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        qBittorrentNS.beginNamespace("TrackerEndpointState")
+            .addProperty("NotContacted", +[] { return BitTorrent::TrackerEndpointState::NotContacted; })
+            .addProperty("Working", +[] { return BitTorrent::TrackerEndpointState::Working; })
+            .addProperty("NotWorking", +[] { return BitTorrent::TrackerEndpointState::NotWorking; })
+            .addProperty("TrackerError", +[] { return BitTorrent::TrackerEndpointState::TrackerError; })
+            .addProperty("Unreachable", +[] { return BitTorrent::TrackerEndpointState::Unreachable; })
+            .endNamespace();
+    }
+
+    void registerLuaClassTrackerEndpointStatus(lua_State *luaState)
+    {
+        using TrackerEndpointStatus = BitTorrent::TrackerEndpointStatus;
+
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        auto cls = qBittorrentNS.beginClass<TrackerEndpointStatus>("TrackerEndpointStatus");
+
+        cls.addProperty("name", &TrackerEndpointStatus::name);
+        cls.addProperty("btVersion", &TrackerEndpointStatus::btVersion);
+
+        cls.addProperty("updating", &TrackerEndpointStatus::isUpdating);
+        cls.addProperty("state", &TrackerEndpointStatus::state);
+        cls.addProperty("message", &TrackerEndpointStatus::message);
+
+        cls.addProperty("numSeeds", &TrackerEndpointStatus::numSeeds);
+        cls.addProperty("numPeers", &TrackerEndpointStatus::numPeers);
+        cls.addProperty("numLeeches", &TrackerEndpointStatus::numLeeches);
+        cls.addProperty("numDownloaded", &TrackerEndpointStatus::numDownloaded);
+
+        cls.addProperty("nextAnnounceTime", +[](const BitTorrent::TrackerEndpointStatus &endpoint)
+        {
+            return toSecondsSinceEpoch(endpoint.nextAnnounceTime);
+        });
+        cls.addProperty("minAnnounceTime", +[](const BitTorrent::TrackerEndpointStatus &endpoint)
+        {
+            return toSecondsSinceEpoch(endpoint.minAnnounceTime);
+        });
+    }
+
+    void registerLuaClassTrackerEntryStatus(lua_State *luaState)
+    {
+        using TrackerEntryStatus = BitTorrent::TrackerEntryStatus;
+
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        auto cls = qBittorrentNS.beginClass<TrackerEntryStatus>("TrackerEntryStatus");
+
+        cls.addProperty("url", &TrackerEntryStatus::url);
+        cls.addProperty("tier", &TrackerEntryStatus::tier);
+
+        cls.addProperty("updating", &TrackerEntryStatus::isUpdating);
+        cls.addProperty("state", &TrackerEntryStatus::state);
+        cls.addProperty("message", &TrackerEntryStatus::message);
+
+        cls.addProperty("numSeeds", &TrackerEntryStatus::numSeeds);
+        cls.addProperty("numPeers", &TrackerEntryStatus::numPeers);
+        cls.addProperty("numLeeches", &TrackerEntryStatus::numLeeches);
+        cls.addProperty("numDownloaded", &TrackerEntryStatus::numDownloaded);
+
+        cls.addProperty("endpoints", &TrackerEntryStatus::endpoints);
+    }
+
+    void registerLuaEnumShareLimitAction(lua_State *luaState)
+    {
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        qBittorrentNS.beginNamespace("ShareLimitAction")
+            .addProperty("Default", +[] { return BitTorrent::ShareLimitAction::Default; })
+            .addProperty("Stop", +[] { return BitTorrent::ShareLimitAction::Stop; })
+            .addProperty("Remove", +[] { return BitTorrent::ShareLimitAction::Remove; })
+            .addProperty("RemoveWithContent", +[] { return BitTorrent::ShareLimitAction::RemoveWithContent; })
+            .addProperty("EnableSuperSeeding", +[] { return BitTorrent::ShareLimitAction::EnableSuperSeeding; })
+            .endNamespace();
+    }
+
+    void registerLuaEnumShareLimitsMode(lua_State *luaState)
+    {
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        qBittorrentNS.beginNamespace("ShareLimitsMode")
+            .addProperty("Default", +[] { return BitTorrent::ShareLimitsMode::Default; })
+            .addProperty("MatchAny", +[] { return BitTorrent::ShareLimitsMode::MatchAny; })
+            .addProperty("MatchAll", +[] { return BitTorrent::ShareLimitsMode::MatchAll; })
+            .endNamespace();
+    }
+
+    void registerLuaClassShareLimits(lua_State *luaState)
+    {
+        using ShareLimits = BitTorrent::ShareLimits;
+
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        auto cls = qBittorrentNS.beginClass<ShareLimits>("ShareLimits");
+
+        cls.addConstructor<void ()>();
+        cls.addProperty("ratioLimit", &ShareLimits::ratioLimit);
+        cls.addProperty("seedingTimeLimit", &ShareLimits::seedingTimeLimit);
+        cls.addProperty("inactiveSeedingTimeLimit", &ShareLimits::inactiveSeedingTimeLimit);
+        cls.addProperty("mode", &ShareLimits::mode);
+        cls.addProperty("action", &ShareLimits::action);
+    }
+
+    void registerLuaEnumAddTorrentErrorKind(lua_State *luaState)
+    {
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        qBittorrentNS.beginNamespace("AddTorrentErrorKind")
+            .addProperty("DuplicateTorrent", +[] { return BitTorrent::AddTorrentError::Kind::DuplicateTorrent; })
+            .addProperty("Other", +[] { return BitTorrent::AddTorrentError::Kind::Other; })
+            .endNamespace();
+    }
+
+    void registerLuaClassAddTorrentError(lua_State *luaState)
+    {
+        using AddTorrentError = BitTorrent::AddTorrentError;
+
+        auto qBittorrentNS = luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE);
+        auto cls = qBittorrentNS.beginClass<AddTorrentError>("AddTorrentError");
+
+        cls.addProperty("kind", &AddTorrentError::kind);
+        cls.addProperty("message", &AddTorrentError::message);
+    }
+}
+
+void registerLuaClasses(lua_State *luaState)
+{
+    registerLuaClassTorrent(luaState);
+
+    registerLuaClassTrackerEntry(luaState);
+
+    registerLuaEnumTrackerEndpointState(luaState);
+    registerLuaClassTrackerEndpointStatus(luaState);
+    registerLuaClassTrackerEntryStatus(luaState);
+
+    registerLuaEnumShareLimitAction(luaState);
+    registerLuaEnumShareLimitsMode(luaState);
+    registerLuaClassShareLimits(luaState);
+
+    registerLuaEnumAddTorrentErrorKind(luaState);
+    registerLuaClassAddTorrentError(luaState);
+}

--- a/src/base/plugins/luaclasses.h
+++ b/src/base/plugins/luaclasses.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,13 +28,6 @@
 
 #pragma once
 
-#include <QObject>
+#include <lua/lua.hpp>
 
-class PluginsEngine : public QObject
-{
-    Q_OBJECT
-    Q_DISABLE_COPY_MOVE(PluginsEngine)
-
-public:
-    explicit PluginsEngine(QObject *parent = nullptr);
-};
+void registerLuaClasses(lua_State *luaState);

--- a/src/base/plugins/luafunctions.cpp
+++ b/src/base/plugins/luafunctions.cpp
@@ -1,0 +1,170 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "luafunctions.h"
+
+#include <QtSystemDetection>
+#if defined(Q_OS_WIN)
+#include <windows.h>
+#include <shellapi.h>
+#endif
+
+#include <QDateTime>
+#include <QDebug>
+#include <QLocale>
+#include <QProcess>
+#include <QStringList>
+
+#include "base/logger.h"
+#include "base/net/smtpclient.h"
+#include "base/preferences.h"
+#include "base/utils/misc.h"
+
+#ifndef Q_OS_WIN
+#include "base/utils/string.h"
+#endif
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace LuaFunctions
+{
+    void debug(const QString &message)
+    {
+        qDebug() << qUtf8Printable(message);
+    }
+
+    void log(const QString &message)
+    {
+        LogMsg(message);
+    }
+
+    bool exec(const QString &command)
+    {
+    // The processing sequence is different for Windows and other OS, this is intentional
+    #ifdef Q_OS_WIN
+        const std::wstring programWStr = command.toStdWString();
+
+        // Need to split arguments manually because QProcess::startDetached(QString)
+        // will strip off empty parameters.
+        // E.g. `python.exe "1" "" "3"` will become `python.exe "1" "3"`
+        int argCount = 0;
+        std::unique_ptr<LPWSTR[], decltype(&::LocalFree)> args {::CommandLineToArgvW(programWStr.c_str(), &argCount), ::LocalFree};
+
+        if (argCount <= 0)
+            return false;
+
+        QStringList argList;
+        for (int i = 1; i < argCount; ++i)
+            argList += QString::fromWCharArray(args[i]);
+
+        QProcess proc;
+        proc.setProgram(QString::fromWCharArray(args[0]));
+        proc.setArguments(argList);
+        proc.setCreateProcessArgumentsModifier([](QProcess::CreateProcessArguments *args)
+        {
+            args->flags |= CREATE_NO_WINDOW;
+            args->flags &= ~(CREATE_NEW_CONSOLE | DETACHED_PROCESS);
+
+            args->inheritHandles = false;
+            args->startupInfo->dwFlags &= ~STARTF_USESTDHANDLES;
+            ::CloseHandle(args->startupInfo->hStdInput);
+            ::CloseHandle(args->startupInfo->hStdOutput);
+            ::CloseHandle(args->startupInfo->hStdError);
+            args->startupInfo->hStdInput = nullptr;
+            args->startupInfo->hStdOutput = nullptr;
+            args->startupInfo->hStdError = nullptr;
+        });
+
+        if (proc.startDetached())
+            return true;
+    #else // Q_OS_WIN
+        QStringList args = Utils::String::splitCommand(command);
+
+        if (args.isEmpty())
+            return false;
+
+        for (QString &arg : args)
+        {
+            // strip redundant quotes
+            if (arg.startsWith(u'"') && arg.endsWith(u'"'))
+                arg = arg.mid(1, (arg.size() - 2));
+        }
+
+        const QString exe = args.takeFirst();
+        QProcess proc;
+        proc.setProgram(exe);
+        proc.setArguments(args);
+
+        if (proc.startDetached())
+            return true;
+    #endif
+        return false;
+    }
+
+    void sendMail(const QString &subject, const QString &body, QObject *context)
+    {
+        const auto *pref = Preferences::instance();
+        Net::SMTPClient::sendMail(pref->getMailNotificationSender(), pref->getMailNotificationEmail()
+                , subject, body, context);
+    }
+
+    QString friendlySizeUnit1(const qint64 bytes)
+    {
+        return Utils::Misc::friendlyUnit(bytes, false, -1);
+    }
+
+    QString friendlySizeUnit2(const qint64 bytes, const int precision)
+    {
+        return Utils::Misc::friendlyUnit(bytes, false, precision);
+    }
+
+    QString friendlySpeedUnit1(const qint64 bytes)
+    {
+        return Utils::Misc::friendlyUnit(bytes, true, -1);
+    }
+
+    QString friendlySpeedUnit2(const qint64 bytes, const int precision)
+    {
+        return Utils::Misc::friendlyUnit(bytes, true, precision);
+    }
+
+    QString friendlyDuration(const qint64 seconds)
+    {
+        return Utils::Misc::userFriendlyDuration(seconds);
+    }
+
+    QString formatDateTime1(const QString &format, const qint64 luaTime)
+    {
+        return QLocale::system().toString(QDateTime::fromSecsSinceEpoch(luaTime), format);
+    }
+
+    QString formatDateTime2(const qint64 luaTime)
+    {
+        return QLocale::system().toString(QDateTime::fromSecsSinceEpoch(luaTime), QLocale::ShortFormat);
+    }
+}

--- a/src/base/plugins/luafunctions.h
+++ b/src/base/plugins/luafunctions.h
@@ -1,0 +1,53 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QtTypes>
+#include <QString>
+
+namespace LuaFunctions
+{
+    void debug(const QString &message);
+    void log(const QString &message);
+
+    bool exec(const QString &command);
+
+    void sendMail(const QString &subject, const QString &body, QObject *context);
+
+    QString friendlySizeUnit1(qint64 bytes);
+    QString friendlySizeUnit2(qint64 bytes, int precision);
+
+    QString friendlySpeedUnit1(qint64 bytes);
+    QString friendlySpeedUnit2(qint64 bytes, int precision);
+
+    QString friendlyDuration(qint64 seconds);
+
+    QString formatDateTime1(const QString &format, qint64 luaTime);
+    QString formatDateTime2(qint64 luaTime);
+}

--- a/src/base/plugins/luanamespace.h
+++ b/src/base/plugins/luanamespace.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,14 +26,6 @@
  * exception statement from your version.
  */
 
-#include "pluginsengine.h"
+#pragma once
 
-#include <lua/lua.hpp>
-
-PluginsEngine::PluginsEngine(QObject *parent)
-    : QObject(parent)
-{
-    lua_State *luaState = luaL_newstate();
-    Q_ASSERT(luaState);
-    lua_close(luaState);
-}
+inline const char *QBT_NAMESPACE = "qBittorrent";

--- a/src/base/plugins/luastack.h
+++ b/src/base/plugins/luastack.h
@@ -1,0 +1,314 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <lua/lua.hpp>
+#include <LuaBridge/LuaBridge.h>
+
+#include <QHash>
+#include <QList>
+#include <QString>
+#include <QUrl>
+
+#include "base/bittorrent/addtorrenterror.h"
+#include "base/bittorrent/sharelimits.h"
+#include "base/bittorrent/trackerentrystatus.h"
+#include "base/path.h"
+
+namespace luabridge
+{
+    // LuaBridge Stack specialization for `QString`.
+    template <>
+    struct Stack<QString>
+    {
+        [[nodiscard]] static Result push(lua_State *luaState, const QString &str)
+        {
+#if LUABRIDGE_SAFE_STACK_CHECKS
+            if (!lua_checkstack(luaState, 1))
+                return makeErrorCode(ErrorCode::LuaStackOverflow);
+#endif
+
+            const QByteArray utf8data = str.toUtf8();
+            lua_pushlstring(luaState, utf8data.constData(), utf8data.size());
+            return {};
+        }
+
+        [[nodiscard]] static TypeResult<QString> get(lua_State *luaState, const int index)
+        {
+            size_t len = 0;
+            const char *str = nullptr;
+
+            if (lua_type(luaState, index) == LUA_TSTRING)
+            {
+                str = lua_tolstring(luaState, index, &len);
+            }
+#if !LUABRIDGE_STRICT_STACK_CONVERSIONS
+            else
+            {
+#if LUABRIDGE_SAFE_STACK_CHECKS
+                if (!lua_checkstack(luaState, 1))
+                    return makeErrorCode(ErrorCode::LuaStackOverflow);
+#endif
+
+                // Lua reference manual:
+                // If the value is a number, then lua_tolstring also changes the actual value in the stack
+                // to a string. (This change confuses lua_next when lua_tolstring is applied to keys during
+                // a table traversal.)
+                lua_pushvalue(luaState, index);
+                str = lua_tolstring(luaState, -1, &len);
+                const auto string = QString::fromUtf8(str, len);
+                lua_pop(luaState, 1); // Pop the temporary string
+                return string;
+            }
+#endif
+
+            if (str == nullptr)
+                return makeErrorCode(ErrorCode::InvalidTypeCast);
+
+            return QString::fromUtf8(str, len);
+        }
+
+        [[nodiscard]] static bool isInstance(lua_State *luaState, const int index)
+        {
+            return lua_type(luaState, index) == LUA_TSTRING;
+        }
+    };
+
+    // LuaBridge Stack specialization for `QUrl`.
+    template <>
+    struct Stack<QUrl>
+    {
+        [[nodiscard]] static Result push(lua_State *luaState, const QUrl &url)
+        {
+            return Stack<QString>::push(luaState, url.toString());
+        }
+
+        [[nodiscard]] static TypeResult<QUrl> get(lua_State *luaState, const int index)
+        {
+            return QUrl(Stack<QString>::get(luaState, index).valueOr(QString()));
+        }
+
+        [[nodiscard]] static bool isInstance(lua_State *luaState, const int index)
+        {
+            return lua_type(luaState, index) == LUA_TSTRING;
+        }
+    };
+
+    // LuaBridge Stack specialization for `Path`.
+    template <>
+    struct Stack<Path>
+    {
+        [[nodiscard]] static Result push(lua_State *luaState, const Path &path)
+        {
+            return Stack<QString>::push(luaState, path.toString());
+        }
+
+        [[nodiscard]] static TypeResult<Path> get(lua_State *luaState, const int index)
+        {
+            return Path(Stack<QString>::get(luaState, index).valueOr(QString()));
+        }
+
+        [[nodiscard]] static bool isInstance(lua_State *luaState, const int index)
+        {
+            return lua_type(luaState, index) == LUA_TSTRING;
+        }
+    };
+
+    // LuaBridge Stack specialization for `QList`.
+    template <typename T>
+    struct Stack<QList<T>>
+    {
+        using Type = QList<T>;
+
+        [[nodiscard]] static Result push(lua_State *luaState, const Type &list)
+        {
+#if LUABRIDGE_SAFE_STACK_CHECKS
+            if (!lua_checkstack(luaState, 3))
+                return makeErrorCode(ErrorCode::LuaStackOverflow);
+#endif
+
+            StackRestore stackRestore {luaState};
+
+            const qsizetype listSize = list.size();
+            lua_createtable(luaState, static_cast<int>(listSize), 0);
+
+            for (qsizetype i = 0; i < listSize; ++i)
+            {
+                lua_pushinteger(luaState, static_cast<lua_Integer>(i + 1));
+
+                auto result = Stack<T>::push(luaState, list[i]);
+                if (!result)
+                    return result;
+
+                lua_settable(luaState, -3);
+            }
+
+            stackRestore.reset();
+            return {};
+        }
+
+        [[nodiscard]] static TypeResult<Type> get(lua_State *luaState, const int index)
+        {
+            if (!lua_istable(luaState, index))
+                return makeErrorCode(ErrorCode::InvalidTypeCast);
+
+            const StackRestore stackRestore {luaState};
+
+            Type list;
+            list.reserve(static_cast<qsizetype>(get_length(luaState, index)));
+
+            const int absIndex = lua_absindex(luaState, index);
+            lua_pushnil(luaState);
+
+            while (lua_next(luaState, absIndex) != 0)
+            {
+                auto item = Stack<T>::get(luaState, -1);
+                if (!item)
+                    return makeErrorCode(ErrorCode::InvalidTypeCast);
+
+                list.emplace_back(*item);
+                lua_pop(luaState, 1);
+            }
+
+            return list;
+        }
+
+        [[nodiscard]] static bool isInstance(lua_State *luaState, const int index)
+        {
+            return lua_istable(luaState, index);
+        }
+    };
+
+    // LuaBridge Stack specialization for `QHash`.
+    template <class K, class V>
+    struct Stack<QHash<K, V>>
+    {
+        using Type = QHash<K, V>;
+
+        [[nodiscard]] static Result push(lua_State *luaState, const Type &hashTable)
+        {
+#if LUABRIDGE_SAFE_STACK_CHECKS
+            if (!lua_checkstack(luaState, 3))
+                return makeErrorCode(ErrorCode::LuaStackOverflow);
+#endif
+
+            StackRestore stackRestore {luaState};
+            lua_createtable(luaState, 0, static_cast<int>(hashTable.size()));
+
+            for (auto it = hashTable.cbegin(); it != hashTable.cend(); ++it)
+            {
+                auto result = Stack<K>::push(luaState, it.key());
+                if (!result)
+                    return result;
+
+                result = Stack<V>::push(luaState, it.value());
+                if (!result)
+                    return result;
+
+                lua_settable(luaState, -3);
+            }
+
+            stackRestore.reset();
+            return {};
+        }
+
+        [[nodiscard]] static TypeResult<Type> get(lua_State *luaState, const int index)
+        {
+            if (!lua_istable(luaState, index))
+                return makeErrorCode(ErrorCode::InvalidTypeCast);
+
+            const StackRestore stackRestore {luaState};
+
+            Type hashTable;
+
+            int absIndex = lua_absindex(luaState, index);
+            lua_pushnil(luaState);
+
+            while (lua_next(luaState, absIndex) != 0)
+            {
+                const auto value = Stack<V>::get(luaState, -1);
+                if (!value)
+                    return makeErrorCode(ErrorCode::InvalidTypeCast);
+
+                const auto key = Stack<K>::get(luaState, -2);
+                if (!key)
+                    return makeErrorCode(ErrorCode::InvalidTypeCast);
+
+                hashTable.emplace(*key, *value);
+                lua_pop(luaState, 1);
+            }
+
+            return hashTable;
+        }
+
+        [[nodiscard]] static bool isInstance(lua_State *luaState, const int index)
+        {
+            return lua_istable(luaState, index);
+        }
+    };
+
+    template <>
+    struct Stack<BitTorrent::TrackerEndpointState>
+        : Enum<BitTorrent::TrackerEndpointState
+            , BitTorrent::TrackerEndpointState::NotContacted
+            , BitTorrent::TrackerEndpointState::Working
+            , BitTorrent::TrackerEndpointState::NotWorking
+            , BitTorrent::TrackerEndpointState::TrackerError
+            , BitTorrent::TrackerEndpointState::Unreachable>
+    {
+    };
+
+    template <>
+    struct Stack<BitTorrent::ShareLimitAction>
+        : Enum<BitTorrent::ShareLimitAction
+            , BitTorrent::ShareLimitAction::Default
+            , BitTorrent::ShareLimitAction::Stop
+            , BitTorrent::ShareLimitAction::Remove
+            , BitTorrent::ShareLimitAction::RemoveWithContent
+            , BitTorrent::ShareLimitAction::EnableSuperSeeding>
+    {
+    };
+
+    template <>
+    struct Stack<BitTorrent::ShareLimitsMode>
+        : Enum<BitTorrent::ShareLimitsMode
+               , BitTorrent::ShareLimitsMode::Default
+               , BitTorrent::ShareLimitsMode::MatchAny
+               , BitTorrent::ShareLimitsMode::MatchAll>
+    {
+    };
+
+    template <>
+    struct Stack<BitTorrent::AddTorrentError::Kind>
+        : Enum<BitTorrent::AddTorrentError::Kind
+            , BitTorrent::AddTorrentError::Kind::DuplicateTorrent
+            , BitTorrent::AddTorrentError::Kind::Other>
+    {
+    };
+}

--- a/src/base/plugins/plugin.cpp
+++ b/src/base/plugins/plugin.cpp
@@ -1,0 +1,196 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "plugin.h"
+
+#include <chrono>
+
+#include <QDeadlineTimer>
+#include <QHash>
+#include <QScopeGuard>
+#include <QString>
+
+#include "base/path.h"
+#include "base/utils/io.h"
+#include "luaclasses.h"
+#include "luafunctions.h"
+#include "luanamespace.h"
+#include "luastack.h"
+
+using namespace std::chrono_literals;
+using namespace Qt::Literals::StringLiterals;
+
+// This timeout is used to interrupt the execution
+// of the faulty script (e.g., if it enters an endless loop, etc.)
+const std::chrono::milliseconds LUA_TIMEOUT = 1s;
+
+namespace
+{
+    QHash<lua_State *, QDeadlineTimer> LUA_DEADLINES_REGISTRY;
+
+    void checkLuaDeadline(lua_State *luaState, lua_Debug *)
+    {
+        const QDeadlineTimer &deadlineTimer = LUA_DEADLINES_REGISTRY.value(luaState);
+        if (deadlineTimer.hasExpired())
+            luaL_error(luaState, Plugin::tr("Timed out.").toUtf8().constData());
+    }
+
+    void resetLuaDeadline(lua_State *luaState)
+    {
+        QDeadlineTimer &deadlineTimer = LUA_DEADLINES_REGISTRY[luaState];
+        deadlineTimer.setRemainingTime(LUA_TIMEOUT);
+    }
+}
+
+nonstd::expected<std::shared_ptr<Plugin>, QString> Plugin::load(const Path &pluginPath)
+{
+    lua_State *luaState = luaL_newstate();
+    if (!luaState)
+        return nonstd::make_unexpected(tr("Failed to allocate Lua state."));
+
+    LUA_DEADLINES_REGISTRY.emplace(luaState);
+
+    [[maybe_unused]] auto scopeGuard = qScopeGuard([luaState]
+    {
+        LUA_DEADLINES_REGISTRY.remove(luaState);
+        lua_close(luaState);
+    });
+
+    lua_sethook(luaState, checkLuaDeadline, LUA_MASKCOUNT, 100);
+
+    const auto result = Utils::IO::readFile(pluginPath, 1024 * 1024);
+    if (!result)
+        return nonstd::make_unexpected(result.error().message);
+
+    using namespace luabridge;
+
+    enableExceptions(luaState);
+
+    if (luaL_loadstring(luaState, result.value().constData()) != LUA_OK)
+    {
+        const auto message = LuaRef::fromStack(luaState, -1).cast<QString>().valueOr(u""_s);
+        return nonstd::make_unexpected(message);
+    }
+
+    const int libLoadMask = LUA_GLIBK | LUA_STRLIBK | LUA_TABLIBK | LUA_MATHLIBK | LUA_UTF8LIBK | LUA_COLIBK;
+    luaL_openselectedlibs(luaState, libLoadMask, 0);
+
+    {
+        LuaRef baseLib = getGlobal(luaState, LUA_GNAME);
+        baseLib["collectgarbage"] = nullptr;
+        baseLib["dofile"] = nullptr;
+        baseLib["getmetatable"] = nullptr;
+        baseLib["setmetatable"] = nullptr;
+        baseLib["load"] = nullptr;
+        baseLib["loadfile"] = nullptr;
+        baseLib["rawequal"] = nullptr;
+        baseLib["rawlen"] = nullptr;
+        baseLib["rawget"] = nullptr;
+        baseLib["rawset"] = nullptr;
+        baseLib["warn"] = nullptr;
+    }
+
+    {
+        LuaRef stringLib = getGlobal(luaState, LUA_STRLIBNAME);
+        stringLib["dump"] = nullptr;
+    }
+
+    ::resetLuaDeadline(luaState);
+    if (lua_pcall(luaState, 0, 0, 0) != LUA_OK)
+    {
+        const auto message = LuaRef::fromStack(luaState, -1).cast<QString>().valueOr(u""_s);
+        return nonstd::make_unexpected(message);
+    }
+
+    const auto pluginName = getGlobal(luaState, "NAME").cast<QString>().valueOr(u""_s);
+    if (pluginName.isEmpty())
+        return nonstd::make_unexpected(tr("Plugin name is missing or invalid."));
+
+    const PluginVersion pluginVersion = std::invoke([luaState]
+    {
+        const auto pluginVersionStr = getGlobal(luaState, "VERSION").cast<QString>().valueOr(u""_s);
+        return PluginVersion::fromString(pluginVersionStr);
+    });
+    if (!pluginVersion.isValid())
+        return nonstd::make_unexpected(tr("Plugin version is missing or invalid."));
+
+    scopeGuard.dismiss();
+    return std::shared_ptr<Plugin>(new Plugin(luaState, pluginName, pluginVersion));
+}
+
+Plugin::Plugin(lua_State *luaState, const QString &name, const PluginVersion &version)
+    : m_luaState {luaState}
+    , m_name {name}
+    , m_version {version}
+{
+    m_isInvocable = luabridge::getGlobal(luaState, "invoke").isFunction();
+
+    luabridge::getGlobalNamespace(luaState).beginNamespace(QBT_NAMESPACE)
+        .addFunction("debug", LuaFunctions::debug)
+        .addFunction("log", LuaFunctions::log)
+        .addFunction("exec", LuaFunctions::exec)
+        .addFunction("sendMail", luabridge::bind_back(LuaFunctions::sendMail, this))
+        .addFunction("friendlySizeUnit", LuaFunctions::friendlySizeUnit1, LuaFunctions::friendlySizeUnit2)
+        .addFunction("friendlySpeedUnit", LuaFunctions::friendlySpeedUnit1, LuaFunctions::friendlySpeedUnit2)
+        .addFunction("friendlyDuration", LuaFunctions::friendlyDuration)
+        .addFunction("formatDateTime", LuaFunctions::formatDateTime1, LuaFunctions::formatDateTime2);
+
+    registerLuaClasses(luaState);
+}
+
+Plugin::~Plugin()
+{
+    LUA_DEADLINES_REGISTRY.remove(m_luaState);
+    lua_close(m_luaState);
+}
+
+QString Plugin::name() const
+{
+    return m_name;
+}
+
+PluginVersion Plugin::version() const
+{
+    return m_version;
+}
+
+bool Plugin::isInvocable() const
+{
+    return m_isInvocable;
+}
+
+void Plugin::invoke() const
+{
+    resetLuaDeadline();
+    luabridge::getGlobal(m_luaState, "invoke").call();
+}
+
+void Plugin::resetLuaDeadline() const
+{
+    ::resetLuaDeadline(m_luaState);
+}

--- a/src/base/plugins/plugin.h
+++ b/src/base/plugins/plugin.h
@@ -1,0 +1,81 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <lua/lua.hpp>
+#include <LuaBridge/LuaBridge.h>
+
+#include <QObject>
+
+#include "base/3rdparty/expected.hpp"
+#include "base/pathfwd.h"
+#include "pluginversion.h"
+
+class QString;
+struct lua_State;
+
+class Plugin final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(Plugin)
+
+public:
+    static nonstd::expected<std::shared_ptr<Plugin>, QString> load(const Path &pluginPath);
+
+    ~Plugin() override;
+
+    QString name() const;
+    PluginVersion version() const;
+    bool isInvocable() const;
+
+    void invoke() const;
+
+    template <typename... Args>
+    void call(const char *funcName, Args&&... args)
+    {
+        const luabridge::LuaRef func = luabridge::getGlobal(m_luaState, funcName);
+        if (func.isFunction())
+        {
+            resetLuaDeadline();
+            func.call(std::forward<Args>(args)...);
+        }
+    }
+
+private:
+    Plugin(lua_State *luaState, const QString &name, const PluginVersion &version);
+
+    void resetLuaDeadline() const;
+
+    lua_State *m_luaState = nullptr;
+    QString m_name;
+    PluginVersion m_version;
+    bool m_isInvocable = false;
+};

--- a/src/base/plugins/pluginsengine.cpp
+++ b/src/base/plugins/pluginsengine.cpp
@@ -1,0 +1,532 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "pluginsengine.h"
+
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMetaEnum>
+#include <QScopeGuard>
+
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrent.h"
+#include "base/global.h"
+#include "base/logger.h"
+#include "base/path.h"
+#include "base/profile.h"
+#include "base/utils/fs.h"
+#include "base/utils/io.h"
+#include "plugin.h"
+
+using namespace Qt::Literals::StringLiterals;
+
+const QString CONF_FILE_NAME = u"plugins.json"_s;
+const QString OPTION_ENABLED = u"enabled"_s;
+
+namespace
+{
+    struct PluginEntryConfig
+    {
+        bool enabled = false;
+    };
+
+    PluginEntryConfig parsePluginEntryConfig(const QJsonObject &jsonObj)
+    {
+        return {.enabled = jsonObj.value(OPTION_ENABLED).toBool()};
+    }
+
+    QJsonObject serializePluginEntryConfig(const PluginEntryConfig &config)
+    {
+        return {{OPTION_ENABLED, config.enabled}};
+    }
+}
+
+void PluginsEngine::initInstance()
+{
+    if (!PluginsEngine::m_instance)
+        PluginsEngine::m_instance = new PluginsEngine;
+}
+
+void PluginsEngine::freeInstance()
+{
+    delete PluginsEngine::m_instance;
+    PluginsEngine::m_instance = nullptr;
+}
+
+PluginsEngine *PluginsEngine::instance()
+{
+    return PluginsEngine::m_instance;
+}
+
+LuaVersion PluginsEngine::luaVersion()
+{
+    return LuaVersion(LUA_VERSION_MAJOR_N, LUA_VERSION_MINOR_N, LUA_VERSION_RELEASE_N);
+}
+
+LuaBridgeVersion PluginsEngine::luaBridgeVersion()
+{
+    // NOTE: Need to update it whenever LuaBridge built-in sources are updated to new version.
+    return LuaBridgeVersion(3, 0);
+}
+
+PluginsEngine::PluginsEngine(QObject *parent)
+    : QObject(parent)
+{
+    loadPlugins();
+    connectEventHandlers();
+}
+
+PluginsEngine::~PluginsEngine()
+{
+    if (m_configIsDirty)
+        storeConfig();
+}
+
+void PluginsEngine::loadConfig()
+{
+    const int fileMaxSize = 10 * 1024 * 1024;
+    const Path path = specialFolderLocation(SpecialFolder::Config) / Path(CONF_FILE_NAME);
+
+    const auto readResult = Utils::IO::readFile(path, fileMaxSize);
+    if (!readResult)
+    {
+        LogMsg(tr("Failed to load plugins configuration. %1").arg(readResult.error().message), Log::WARNING);
+        return;
+    }
+
+    QJsonParseError jsonError;
+    const QJsonDocument jsonDoc = QJsonDocument::fromJson(readResult.value(), &jsonError);
+    if (jsonError.error != QJsonParseError::NoError)
+    {
+        LogMsg(tr("Failed to parse plugins configuration from %1. Error: \"%2\"")
+                .arg(path.toString(), jsonError.errorString()), Log::WARNING);
+        return;
+    }
+
+    if (!jsonDoc.isObject())
+    {
+        LogMsg(tr("Failed to load plugins configuration from %1. Error: \"Invalid data format.\"")
+                .arg(path.toString()), Log::WARNING);
+        return;
+    }
+
+    const QJsonObject jsonObj = jsonDoc.object();
+    for (auto it = jsonObj.constBegin(); it != jsonObj.constEnd(); ++it)
+    {
+        const QString pluginID = it.key();
+        const PluginEntryConfig pluginEntryConfig = parsePluginEntryConfig(it.value().toObject());
+        if (const auto pluginsIter = m_plugins.find(pluginID); pluginsIter != m_plugins.end())
+            pluginsIter->enabled = pluginEntryConfig.enabled;
+    }
+}
+
+void PluginsEngine::storeConfig() const
+{
+    QJsonObject jsonObj;
+    for (const auto &[pluginID, pluginEntry] : asConst(m_plugins).asKeyValueRange())
+    {
+        jsonObj[pluginID] = serializePluginEntryConfig({.enabled = pluginEntry.enabled});
+    }
+
+    const Path path = specialFolderLocation(SpecialFolder::Config) / Path(CONF_FILE_NAME);
+    const QByteArray data = QJsonDocument(jsonObj).toJson();
+    const nonstd::expected<void, QString> result = Utils::IO::saveToFile(path, data);
+    if (!result)
+    {
+        LogMsg(tr("Couldn't store plugins configuration to %1. Error: %2")
+                .arg(path.toString(), result.error()), Log::WARNING);
+    }
+
+    m_configIsDirty = false;
+}
+
+PluginInfo PluginsEngine::getPluginInfo(const PluginEntry &pluginEntry) const
+{
+    return {
+        .id = pluginEntry.id,
+        .name = pluginEntry.plugin->name(),
+        .version = pluginEntry.plugin->version(),
+        .invocable = pluginEntry.plugin->isInvocable(),
+        .enabled = pluginEntry.enabled
+    };
+}
+
+Path PluginsEngine::pluginsPath()
+{
+    return specialFolderLocation(SpecialFolder::Data) / Path(u"plugins"_s);
+}
+
+QHash<QString, PluginInfo> PluginsEngine::allPlugins() const
+{
+    QHash<QString, PluginInfo> plugins;
+    plugins.reserve(m_plugins.size());
+    for (const auto &[pluginID, pluginEntry] : asConst(m_plugins).asKeyValueRange())
+        plugins.emplace(pluginID, getPluginInfo(pluginEntry));
+
+    return plugins;
+}
+
+std::optional<PluginInfo> PluginsEngine::pluginInfo(const QString &pluginID) const
+{
+    const auto pluginIter = m_plugins.constFind(pluginID);
+    if (pluginIter == m_plugins.constEnd())
+        return std::nullopt;
+
+    return getPluginInfo(*pluginIter);
+}
+
+bool PluginsEngine::installPlugin(const Path &pluginPath)
+{
+    if (!pluginPath.isAbsolute())
+    {
+        const QString message = tr("'%1' is invalid plugin path. An absolute path is expected.").arg(pluginPath.toString());
+        LogMsg(tr("Couldn't install plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+        emit pluginInstallationFailed(pluginPath, message);
+        return false;
+    }
+
+    if (m_pluginsToInstall.contains(pluginPath))
+    {
+        const QString message = tr("'%1' is already scheduled to install.").arg(pluginPath.toString());
+        LogMsg(tr("Couldn't install plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+        emit pluginInstallationFailed(pluginPath, message);
+        return false;
+    }
+
+    m_pluginsToInstall.enqueue(pluginPath);
+    if (m_pluginsToInstall.size() == 1)
+        installPluginDeferred();
+
+    return true;
+}
+
+void PluginsEngine::installPluginDeferred()
+{
+    if (!m_pluginsToInstall.isEmpty())
+        QMetaObject::invokeMethod(this, &PluginsEngine::installPluginImpl, Qt::QueuedConnection);
+}
+
+void PluginsEngine::installPluginImpl()
+{
+    if (m_pluginsToInstall.isEmpty())
+        return;
+
+    const Path pluginPath = m_pluginsToInstall.dequeue();
+    installPluginDeferred();
+
+    auto result = loadPlugin(pluginPath);
+    if (!result)
+    {
+        LogMsg(tr("Couldn't install plugin. File: %1. Reason: %2").arg(pluginPath.toString(), result.error()), Log::WARNING);
+        emit pluginInstallationFailed(pluginPath, result.error());
+        return;
+    }
+
+    PluginEntry pluginEntry = std::move(result).value();
+
+    const QString pluginID = pluginEntry.id;
+
+    const auto [isExistingPlugin, existingPluginEntry] = std::invoke([this, pluginID]() -> std::pair<bool, PluginEntry>
+    {
+        const auto iter = m_plugins.constFind(pluginID);
+        if (iter == m_plugins.constEnd())
+            return std::make_pair(false, PluginEntry());
+
+        return std::make_pair(true, *iter);
+    });
+
+    const Path targetPluginPath = pluginsPath() / Path(pluginPath.filename());
+
+    if (isExistingPlugin)
+    {
+        if (pluginEntry.plugin->version() == existingPluginEntry.plugin->version())
+        {
+            const QString message = tr("The same version of plugin '%1' is already installed.").arg(pluginID);
+            LogMsg(tr("Couldn't update plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+            emit pluginUpdateFailed(pluginPath, getPluginInfo(existingPluginEntry), getPluginInfo(pluginEntry), message);
+            return;
+        }
+
+        if (pluginEntry.plugin->version() < existingPluginEntry.plugin->version())
+        {
+            const QString message = tr("The newest version of plugin '%1' is already installed.").arg(pluginID);
+            LogMsg(tr("Couldn't update plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+            emit pluginUpdateFailed(pluginPath, getPluginInfo(existingPluginEntry), getPluginInfo(pluginEntry), message);
+            return;
+        }
+    }
+
+    if (!Utils::Fs::removeFile(targetPluginPath))
+    {
+        const QString message = tr("Couldn't remove file '%1'.").arg(targetPluginPath.toString());
+
+        if (isExistingPlugin)
+        {
+            LogMsg(tr("Couldn't update plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+            emit pluginUpdateFailed(pluginPath, getPluginInfo(existingPluginEntry), getPluginInfo(pluginEntry), message);
+        }
+        else
+        {
+            LogMsg(tr("Couldn't install plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+            emit pluginInstallationFailed(pluginPath, message);
+        }
+
+        return;
+    }
+
+    if (!Utils::Fs::copyFile(pluginPath, targetPluginPath))
+    {
+        const QString message = tr("Couldn't copy file '%1' to plugins directory.").arg(pluginPath.toString());
+
+        if (isExistingPlugin)
+        {
+            LogMsg(tr("Couldn't update plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+            emit pluginUpdateFailed(pluginPath, getPluginInfo(existingPluginEntry), getPluginInfo(pluginEntry), message);
+        }
+        else
+        {
+            LogMsg(tr("Couldn't install plugin. File: %1. Reason: %2").arg(pluginPath.toString(), message), Log::WARNING);
+            emit pluginInstallationFailed(pluginPath, message);
+        }
+
+        return;
+    }
+
+    if (isExistingPlugin)
+        pluginEntry.enabled = existingPluginEntry.enabled;
+
+    m_plugins.insert(pluginID, pluginEntry);
+
+    if (isExistingPlugin)
+    {
+        LogMsg(tr("Updated plugin. ID: %1. Version: %2.").arg(pluginID, pluginEntry.plugin->version().toString()));
+        emit pluginUpdated(pluginPath, getPluginInfo(existingPluginEntry), getPluginInfo(pluginEntry));
+    }
+    else
+    {
+        LogMsg(tr("Installed plugin. ID: %1. Version: %2.").arg(pluginID, pluginEntry.plugin->version().toString()));
+        emit pluginInstalled(pluginPath, getPluginInfo(pluginEntry));
+    }
+
+    m_configIsDirty = true;
+}
+
+bool PluginsEngine::uninstallPlugin(const QString &pluginID)
+{
+    if (!m_plugins.contains(pluginID))
+    {
+        const QString message = tr("Plugin '%1' is not installed.").arg(pluginID);
+        LogMsg(tr("Couldn't uninstall plugin. ID: %1. Reason: %2").arg(pluginID, message), Log::WARNING);
+        emit pluginUninstallationFailed(pluginID, message);
+        return false;
+    }
+
+    if (m_pluginsToUninstall.contains(pluginID))
+    {
+        const QString message = tr("Plugin '%1' is already scheduled to uninstall.").arg(pluginID);
+        LogMsg(tr("Couldn't uninstall plugin. ID: %1. Reason: %2").arg(pluginID, message), Log::WARNING);
+        emit pluginUninstallationFailed(pluginID, message);
+        return false;
+    }
+
+    m_pluginsToUninstall.enqueue(pluginID);
+    if (m_pluginsToUninstall.size() == 1)
+        uninstallPluginDeferred();
+
+    return true;
+}
+
+void PluginsEngine::uninstallPluginDeferred()
+{
+    if (!m_pluginsToUninstall.isEmpty())
+        QMetaObject::invokeMethod(this, &PluginsEngine::uninstallPluginImpl, Qt::QueuedConnection);
+    else
+        storeConfig();
+}
+
+void PluginsEngine::uninstallPluginImpl()
+{
+    if (m_pluginsToUninstall.isEmpty())
+        return;
+
+    const QString pluginID = m_pluginsToUninstall.dequeue();
+    if (auto result = Utils::Fs::removeFile(pluginsPath() / Path(pluginID + u".lua")))
+    {
+        const PluginEntry pluginEntry = m_plugins.take(pluginID);
+        LogMsg(tr("Uninstalled plugin. ID: %1.").arg(pluginID));
+        emit pluginUninstalled(pluginID);
+        m_configIsDirty = true;
+    }
+    else
+    {
+        const QString message = result.error();
+        LogMsg(tr("Couldn't uninstall plugin. ID: %1. Reason: %2").arg(pluginID, message), Log::WARNING);
+        emit pluginUninstallationFailed(pluginID, message);
+    }
+
+    uninstallPluginDeferred();
+}
+
+void PluginsEngine::loadPlugins()
+{
+    const QDir pluginsDir {pluginsPath().data()};
+    for (const QString &file : pluginsDir.entryList({u"*.lua"_s}))
+    {
+        if (auto result = loadPlugin(Path(pluginsDir.absoluteFilePath(file))))
+        {
+            PluginEntry &pluginEntry = result.value();
+            const QString pluginID = pluginEntry.id;
+            m_plugins.insert(pluginID, std::move(pluginEntry));
+            LogMsg(tr("Loaded plugin. ID: %1.").arg(pluginID));
+        }
+        else
+        {
+            LogMsg(tr("Couldn't load plugin. File: %1. Reason: %2").arg(file, result.error()), Log::WARNING);
+        }
+    }
+
+    loadConfig();
+}
+
+void PluginsEngine::connectEventHandlers()
+{
+    namespace BT = BitTorrent;
+
+    connectEventHandler(&BT::Session::addTorrentFailed, "onAddTorrentFailed");
+    connectEventHandler(&BT::Session::torrentsUpdated, "onTorrentsUpdated");
+
+    connect(BT::Session::instance(), &BT::Session::torrentAdded, this, [this](BT::Torrent *torrent)
+    {
+        callEventHandlers("onTorrentAdded", torrent);
+
+        if (torrent->hasMetadata())
+            callEventHandlers("onTorrentMetadataReady", torrent);
+    });
+
+    connectEventHandler(&BT::Session::torrentMetadataReceived, "onTorrentMetadataReady");
+    connectEventHandler(&BT::Session::torrentFinished, "onTorrentFinished");
+    connectEventHandler(&BT::Session::torrentStarted, "onTorrentStarted");
+    connectEventHandler(&BT::Session::torrentStopped, "onTorrentStopped");
+    connectEventHandler(&BT::Session::torrentSavePathChanged, "onTorrentSavePathChanged");
+    connectEventHandler(&BT::Session::torrentSavingModeChanged, "onTorrentSavingModeChanged");
+    connectEventHandler(&BT::Session::torrentCategoryChanged, "onTorrentCategoryChanged");
+    connectEventHandler(&BT::Session::torrentTagAdded, "onTorrentTagAdded");
+    connectEventHandler(&BT::Session::torrentTagRemoved, "onTorrentTagRemoved");
+    connectEventHandler(&BT::Session::torrentContentFileRenamed, "onTorrentContentFileRenamed");
+    connectEventHandler(&BT::Session::torrentContentFolderRenamed, "onTorrentContentFolderRenamed");
+    connectEventHandler(&BT::Session::torrentContentFolderRenamingFailed, "onTorrentContentFolderRenamingFailed");
+    connectEventHandler(&BT::Session::torrentIOError, "onTorrentIOError");
+    connectEventHandler(&BT::Session::torrentAboutToBeRemoved, "onTorrentAboutToBeRemoved");
+    connectEventHandler(&BT::Session::trackerSuccess, "onTorrentAnnounceSuccess");
+    connectEventHandler(&BT::Session::trackerWarning, "onTorrentAnnounceWarning");
+    connectEventHandler(&BT::Session::trackerError, "onTorrentAnnounceError");
+    connectEventHandler(&BT::Session::trackersAdded, "onTorrentTrackersAdded");
+    connectEventHandler(&BT::Session::trackersRemoved, "onTorrentTrackersRemoved");
+    connectEventHandler(&BT::Session::trackerEntryStatusesUpdated, "onTorrentTrackerStatusesUpdated");
+}
+
+template <typename Signal>
+void PluginsEngine::connectEventHandler(Signal &&signal, const char *eventHandlerName)
+{
+    connect(BitTorrent::Session::instance(), std::forward<Signal>(signal), this, [this, eventHandlerName](auto&&... args)
+    {
+        this->callEventHandlers(eventHandlerName, std::forward<decltype(args)>(args)...);
+    });
+}
+
+template <typename... Args>
+void PluginsEngine::callEventHandlers(const char *eventHandlerName, Args&&... args)
+{
+    for (const PluginEntry &pluginEntry : asConst(m_plugins))
+    {
+        if (!pluginEntry.enabled)
+            continue;
+
+        try
+        {
+            pluginEntry.plugin->call(eventHandlerName, std::forward<Args>(args)...);
+        }
+        catch (const std::exception &ex)
+        {
+            LogMsg(tr("Failed to call the plugin. Plugin: %1. Reason: %2")
+                    .arg(pluginEntry.id, QString::fromStdString(ex.what())), Log::WARNING);
+        }
+    }
+}
+
+void PluginsEngine::setPluginEnabled(const QString &pluginID, const bool enabled)
+{
+    Q_ASSERT(m_plugins.contains(pluginID));
+    if (!m_plugins.contains(pluginID)) [[unlikely]]
+        return;
+
+    PluginEntry &pluginEntry = m_plugins[pluginID];
+    if (pluginEntry.enabled != enabled)
+    {
+        pluginEntry.enabled = enabled;
+        emit pluginEnabledChanged(pluginID, pluginEntry.enabled);
+        storeConfig();
+    }
+}
+
+void PluginsEngine::invokePlugin(const QString &pluginID)
+{
+    const auto pluginIter = m_plugins.constFind(pluginID);
+    Q_ASSERT(pluginIter != m_plugins.constEnd());
+    if (pluginIter == m_plugins.constEnd()) [[unlikely]]
+        return;
+
+    const PluginEntry &pluginEntry = *pluginIter;
+    if (!pluginEntry.enabled)
+        return;
+
+    try
+    {
+        pluginEntry.plugin->invoke();
+    }
+    catch (const std::exception &ex)
+    {
+        LogMsg(tr("Failed to call the plugin. Plugin: %1. Reason: %2")
+                .arg(pluginEntry.id, QString::fromStdString(ex.what())), Log::WARNING);
+    }
+}
+
+nonstd::expected<PluginsEngine::PluginEntry, QString> PluginsEngine::loadPlugin(const Path &path)
+{
+    auto loadResult = Plugin::load(path);
+    if (!loadResult)
+        return loadResult.get_unexpected();
+
+    PluginEntry pluginEntry {
+        .plugin = loadResult.value(),
+        .id = path.removedExtension().filename(),
+    };
+
+    return pluginEntry;
+}

--- a/src/base/plugins/pluginsengine.h
+++ b/src/base/plugins/pluginsengine.h
@@ -1,0 +1,131 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <QHash>
+#include <QObject>
+#include <QQueue>
+
+#include "base/3rdparty/expected.hpp"
+#include "base/pathfwd.h"
+#include "base/utils/version.h"
+#include "pluginversion.h"
+
+using LuaVersion = Utils::Version<3>;
+using LuaBridgeVersion = Utils::Version<2>;
+
+class Plugin;
+
+namespace BitTorrent
+{
+    class Torrent;
+}
+
+struct PluginInfo
+{
+    QString id;
+    QString name;
+    PluginVersion version;
+    bool invocable = false;
+    bool enabled = false;
+};
+
+class PluginsEngine final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(PluginsEngine)
+
+public:
+    static void initInstance();
+    static void freeInstance();
+    static PluginsEngine *instance();
+
+    static LuaVersion luaVersion();
+    static LuaBridgeVersion luaBridgeVersion();
+
+    QHash<QString, PluginInfo> allPlugins() const;
+    std::optional<PluginInfo> pluginInfo(const QString &pluginID) const;
+
+    bool installPlugin(const Path &pluginPath);
+    bool uninstallPlugin(const QString &pluginID);
+    void setPluginEnabled(const QString &pluginID, bool enabled);
+
+    void invokePlugin(const QString &pluginID);
+
+signals:
+    void pluginInstalled(const Path &pluginPath, const PluginInfo &pluginInfo);
+    void pluginInstallationFailed(const Path &pluginPath, const QString &reason);
+    void pluginUpdated(const Path &pluginPath, const PluginInfo &oldPluginInfo
+            , const PluginInfo &newPluginInfo);
+    void pluginUpdateFailed(const Path &pluginPath, const PluginInfo &currentPluginInfo
+            , const PluginInfo &newPluginInfo, const QString &reason);
+    void pluginUninstalled(const QString &pluginID);
+    void pluginUninstallationFailed(const QString &pluginID, const QString &reason);
+    void pluginEnabledChanged(const QString &pluginID, bool isEnabled);
+
+private:
+    struct PluginEntry
+    {
+        std::shared_ptr<Plugin> plugin;
+        QString id;
+        bool enabled = false;
+    };
+
+    static Path pluginsPath();
+
+    explicit PluginsEngine(QObject *parent = nullptr);
+    ~PluginsEngine() override;
+
+    nonstd::expected<PluginEntry, QString> loadPlugin(const Path &path);
+    void installPluginDeferred();
+    void installPluginImpl();
+    void uninstallPluginDeferred();
+    void uninstallPluginImpl();
+
+    void loadConfig();
+    void loadPlugins();
+    void connectEventHandlers();
+    void storeConfig() const;
+    PluginInfo getPluginInfo(const PluginEntry &pluginEntry) const;
+
+    template <typename Signal>
+    void connectEventHandler(Signal &&signal, const char *eventHandlerName);
+
+    template <typename... Args>
+    void callEventHandlers(const char *eventHandlerName, Args&&... args);
+
+    QHash<QString, PluginEntry> m_plugins;
+    QQueue<Path> m_pluginsToInstall;
+    QQueue<QString> m_pluginsToUninstall;
+    mutable bool m_configIsDirty = false;
+
+    inline static PluginsEngine *m_instance = nullptr;
+};

--- a/src/base/plugins/pluginversion.h
+++ b/src/base/plugins/pluginversion.h
@@ -1,0 +1,33 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include "base/utils/version.h"
+
+using PluginVersion = Utils::Version<2>;

--- a/src/base/search/searchpluginmanager.h
+++ b/src/base/search/searchpluginmanager.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include <QHash>
-#include <QMetaType>
 #include <QObject>
 #include <QProcessEnvironment>
 
@@ -38,7 +37,6 @@
 #include "base/utils/version.h"
 
 using SearchPluginVersion = Utils::Version<2>;
-Q_DECLARE_METATYPE(SearchPluginVersion)
 
 namespace Net
 {

--- a/src/base/utils/version.h
+++ b/src/base/utils/version.h
@@ -33,6 +33,7 @@
 #include <type_traits>
 
 #include <QList>
+#include <QMetaType>
 #include <QString>
 #include <QStringView>
 
@@ -179,3 +180,5 @@ namespace Utils
         return !(left < right);
     }
 }
+
+Q_DECLARE_METATYPE(Utils::Version<2>)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -14,6 +14,7 @@ qt_wrap_ui(UI_HEADERS
     ipsubnetwhitelistoptionsdialog.ui
     mainwindow.ui
     optionsdialog.ui
+    plugins/pluginsdialog.ui
     previewselectdialog.ui
     properties/peersadditiondialog.ui
     properties/propertieswidget.ui
@@ -71,6 +72,7 @@ add_library(qbt_gui STATIC
     log/logmodel.h
     mainwindow.h
     optionsdialog.h
+    plugins/pluginsdialog.h
     powermanagement/inhibitor.h
     powermanagement/powermanagement.h
     previewlistdelegate.h
@@ -177,6 +179,7 @@ add_library(qbt_gui STATIC
     log/logmodel.cpp
     mainwindow.cpp
     optionsdialog.cpp
+    plugins/pluginsdialog.cpp
     powermanagement/inhibitor.cpp
     powermanagement/powermanagement.cpp
     previewlistdelegate.cpp

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -32,6 +33,7 @@
 
 #include "base/global.h"
 #include "base/path.h"
+#include "base/plugins/pluginsengine.h"
 #include "base/unicodestrings.h"
 #include "base/utils/io.h"
 #include "base/utils/misc.h"
@@ -44,8 +46,8 @@
 
 AboutDialog::AboutDialog(QWidget *parent)
     : QDialog(parent)
-    , m_ui(new Ui::AboutDialog)
-    , m_storeDialogSize(SETTINGS_KEY(u"Size"_s))
+    , m_ui {new Ui::AboutDialog}
+    , m_storeDialogSize {SETTINGS_KEY(u"Size"_s)}
 {
     m_ui->setupUi(this);
 
@@ -99,6 +101,8 @@ AboutDialog::AboutDialog(QWidget *parent)
     m_ui->labelBoostVer->setText(Utils::Misc::boostVersionString());
     m_ui->labelOpensslVer->setText(Utils::Misc::opensslVersionString());
     m_ui->labelZlibVer->setText(Utils::Misc::zlibVersionString());
+    m_ui->labelLuaVer->setText(PluginsEngine::luaVersion().toString());
+    m_ui->labelLuaBridgeVer->setText(PluginsEngine::luaBridgeVersion().toString());
 
     connect(m_ui->btnCopyToClipboard, &QAbstractButton::clicked, this, &AboutDialog::copyVersionsToClipboard);
 

--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -494,6 +494,46 @@
            </property>
           </widget>
          </item>
+         <item row="5" column="1">
+          <widget class="QLabel" name="labelLua">
+           <property name="text">
+            <string>Lua:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="labelLuaVer">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QLabel" name="labelLuaBridge">
+           <property name="text">
+            <string>LuaBridge:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="labelLuaBridgeVer">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2022-2024  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -67,6 +67,7 @@
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
 #include "base/path.h"
+#include "base/plugins/pluginsengine.h"
 #include "base/preferences.h"
 #include "base/rss/rss_folder.h"
 #include "base/rss/rss_session.h"
@@ -85,6 +86,7 @@
 #include "interfaces/iguiapplication.h"
 #include "lineedit.h"
 #include "optionsdialog.h"
+#include "plugins/pluginsdialog.h"
 #include "powermanagement/powermanagement.h"
 #include "properties/peerlistwidget.h"
 #include "properties/propertieswidget.h"
@@ -190,6 +192,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     m_ui->actionResumeSession->setIcon(UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s));
     m_ui->menuAutoShutdownOnDownloadsCompletion->setIcon(UIThemeManager::instance()->getIcon(u"task-complete"_s, u"application-exit"_s));
     m_ui->actionManageCookies->setIcon(UIThemeManager::instance()->getIcon(u"browser-cookies"_s, u"preferences-web-browser-cookies"_s));
+    m_ui->actionManagePlugins->setIcon(UIThemeManager::instance()->getIcon(u"plugins"_s));
     m_ui->menuLog->setIcon(UIThemeManager::instance()->getIcon(u"help-contents"_s));
     m_ui->actionCheckForUpdates->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));
     m_ui->actionOpenDestinationFolder->setIcon(UIThemeManager::instance()->getIcon(u"directory"_s));
@@ -357,6 +360,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 #endif
 
     connect(m_ui->actionManageCookies, &QAction::triggered, this, &MainWindow::manageCookies);
+    connect(m_ui->actionManagePlugins, &QAction::triggered, this, &MainWindow::managePlugins);
 
     // Initialise system sleep inhibition timer
     m_preventTimer->setSingleShot(true);
@@ -527,6 +531,8 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 
     connect(pref, &Preferences::changed, this, &MainWindow::optionsSaved);
 
+    populatePluginsMenu();
+
     qDebug("GUI Built");
 }
 
@@ -631,6 +637,13 @@ void MainWindow::manageCookies()
     auto *cookieDialog = new CookiesDialog(this);
     cookieDialog->setAttribute(Qt::WA_DeleteOnClose);
     cookieDialog->open();
+}
+
+void MainWindow::managePlugins()
+{
+    auto *pluginsDialog = new PluginsDialog(PluginsEngine::instance(), this);
+    pluginsDialog->setAttribute(Qt::WA_DeleteOnClose);
+    pluginsDialog->open();
 }
 
 void MainWindow::toolbarMenuRequested()
@@ -2024,3 +2037,80 @@ void MainWindow::pythonDownloadFinished(const Net::DownloadResult &result)
     installer->start(exePath.toString(), {u"/passive"_s});
 }
 #endif // Q_OS_WIN
+
+void MainWindow::populatePluginsMenu()
+{
+    auto *pluginsEngine = PluginsEngine::instance();
+
+    for (const PluginInfo &pluginInfo : asConst(pluginsEngine->allPlugins()))
+    {
+        if (pluginInfo.invocable && pluginInfo.enabled)
+            addPluginsMenuItem(pluginInfo);
+    }
+
+    connect(pluginsEngine, &PluginsEngine::pluginInstalled, this
+            , [this](const Path &, const PluginInfo &pluginInfo)
+    {
+        if (pluginInfo.invocable && pluginInfo.enabled)
+            addPluginsMenuItem(pluginInfo);
+    });
+
+    connect(pluginsEngine, &PluginsEngine::pluginUninstalled, this
+            , [this](const QString &pluginID)
+    {
+        removePluginsMenuItem(pluginID);
+    });
+
+    connect(pluginsEngine, &PluginsEngine::pluginUpdated, this
+            , [this](const Path &, const PluginInfo &oldPluginInfo, const PluginInfo &newPluginInfo)
+    {
+        if (newPluginInfo.enabled && newPluginInfo.invocable)
+        {
+            if (QAction *action = m_pluginActions.value(oldPluginInfo.id))
+                action->setText(newPluginInfo.name);
+            else
+                addPluginsMenuItem(newPluginInfo);
+        }
+        else
+        {
+            removePluginsMenuItem(oldPluginInfo.id);
+        }
+    });
+
+    connect(pluginsEngine, &PluginsEngine::pluginEnabledChanged, this
+            , [this, pluginsEngine](const QString &pluginID, bool isEnabled)
+    {
+        if (isEnabled)
+        {
+            if (const auto pluginInfo = pluginsEngine->pluginInfo(pluginID);
+                    pluginInfo && pluginInfo->invocable)
+            {
+                addPluginsMenuItem(*pluginInfo);
+            }
+        }
+        else
+        {
+            removePluginsMenuItem(pluginID);
+        }
+    });
+}
+
+void MainWindow::addPluginsMenuItem(const PluginInfo &pluginInfo)
+{
+    auto *pluginsEngine = PluginsEngine::instance();
+    auto *action = m_ui->menuPlugins->addAction(pluginInfo.name, this
+            , [pluginsEngine, pluginID = pluginInfo.id]
+    {
+        pluginsEngine->invokePlugin(pluginID);
+    });
+    m_pluginActions.insert(pluginInfo.id, action);
+}
+
+void MainWindow::removePluginsMenuItem(const QString &pluginID)
+{
+    if (QAction *action = m_pluginActions.take(pluginID))
+    {
+        m_ui->menuPlugins->removeAction(action);
+        delete action;
+    }
+}

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -62,6 +62,8 @@ class TorrentCreatorDialog;
 class TransferListFiltersWidget;
 class TransferListWidget;
 
+struct PluginInfo;
+
 #ifdef Q_OS_MACOS
 namespace MacUtils
 {
@@ -136,6 +138,7 @@ private slots:
 
     void addToolbarContextMenu();
     void manageCookies();
+    void managePlugins();
 
     void downloadFromURLList(const QStringList &urlList);
     void updateAltSpeedsBtn(bool alternative);
@@ -208,6 +211,10 @@ private:
     bool verifyPythonInstaller(const Path &installerPath) const;
 #endif
 
+    void populatePluginsMenu();
+    void addPluginsMenuItem(const PluginInfo &pluginInfo);
+    void removePluginsMenuItem(const QString &pluginID);
+
     Ui::MainWindow *m_ui = nullptr;
 
     QString m_windowTitle;
@@ -265,4 +272,6 @@ private:
     std::unique_ptr<MacUtils::Badger> m_badger;
     std::unique_ptr<MacUtils::StatusItem> m_statusItem;
 #endif
+
+    QHash<QString, QAction *> m_pluginActions;
 };

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -35,7 +35,7 @@
      <x>0</x>
      <y>0</y>
      <width>914</width>
-     <height>22</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">
@@ -125,10 +125,18 @@
     <addaction name="separator"/>
     <addaction name="actionLock"/>
    </widget>
+   <widget class="QMenu" name="menuPlugins">
+    <property name="title">
+     <string>Plugins</string>
+    </property>
+    <addaction name="actionManagePlugins"/>
+    <addaction name="separator"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
    <addaction name="menuOptions"/>
+   <addaction name="menuPlugins"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QToolBar" name="toolBar">
@@ -492,11 +500,19 @@
    </property>
   </action>
   <action name="actionOpenDestinationFolder">
+   <property name="text">
+    <string>Open Destination Folder</string>
+   </property>
    <property name="iconText">
     <string>Open Folder</string>
    </property>
+  </action>
+  <action name="actionManagePlugins">
    <property name="text">
-    <string>Open Destination Folder</string>
+    <string>Manage Plugins...</string>
+   </property>
+   <property name="toolTip">
+    <string>Manage installed plugins</string>
    </property>
   </action>
  </widget>

--- a/src/gui/plugins/pluginsdialog.cpp
+++ b/src/gui/plugins/pluginsdialog.cpp
@@ -1,0 +1,399 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "pluginsdialog.h"
+
+#include <QClipboard>
+#include <QDropEvent>
+#include <QFileDialog>
+#include <QHeaderView>
+#include <QImageReader>
+#include <QMenu>
+#include <QMessageBox>
+#include <QMimeData>
+#include <QSignalBlocker>
+
+#include "base/path.h"
+#include "gui/autoexpandabledialog.h"
+#include "gui/uithememanager.h"
+#include "gui/utils.h"
+#include "ui_pluginsdialog.h"
+
+#define SETTINGS_KEY(name) u"PluginsDialog/" name
+
+enum PluginColumns
+{
+    PLUGIN_ID,
+    PLUGIN_NAME,
+    PLUGIN_VERSION,
+    PLUGIN_INVOCABLE,
+    PLUGIN_STATE
+};
+
+PluginsDialog::PluginsDialog(PluginsEngine *pluginsEngine, QWidget *parent)
+    : QDialog(parent)
+    , m_ui {new Ui::PluginsDialog}
+    , m_pluginsEngine {pluginsEngine}
+    , m_storeDialogSize {SETTINGS_KEY(u"Size"_s)}
+    , m_storeHeaderState {SETTINGS_KEY(u"HeaderState"_s)}
+    , m_storeLastPath {SETTINGS_KEY(u"LastUsedPath"_s)}
+{
+    m_ui->setupUi(this);
+
+    m_ui->pluginsTree->setRootIsDecorated(false);
+    m_ui->pluginsTree->header()->setFirstSectionMovable(true);
+    m_ui->pluginsTree->header()->setSortIndicator(0, Qt::AscendingOrder);
+
+    m_ui->actionUninstall->setIcon(UIThemeManager::instance()->getIcon(u"list-remove"_s));
+
+    connect(m_ui->actionEnable, &QAction::toggled, this, &PluginsDialog::enableSelection);
+    connect(m_ui->pluginsTree, &QTreeWidget::customContextMenuRequested, this, &PluginsDialog::displayContextMenu);
+    connect(m_ui->pluginsTree, &QTreeWidget::itemDoubleClicked, this, &PluginsDialog::togglePluginState);
+
+    connect(m_ui->closeButton, &QAbstractButton::clicked, this, &QDialog::close);
+    connect(m_ui->installButton, &QAbstractButton::clicked, this, &PluginsDialog::onActionInstallTriggered);
+    connect(m_ui->actionUninstall, &QAction::triggered, this, &PluginsDialog::onActionUninstallTriggered);
+
+    loadPlugins();
+
+    connect(m_pluginsEngine, &PluginsEngine::pluginInstalled, this, &PluginsDialog::pluginInstalled);
+    connect(m_pluginsEngine, &PluginsEngine::pluginInstallationFailed, this, &PluginsDialog::pluginInstallationFailed);
+    connect(m_pluginsEngine, &PluginsEngine::pluginUpdated, this, &PluginsDialog::pluginUpdated);
+    connect(m_pluginsEngine, &PluginsEngine::pluginUpdateFailed, this, &PluginsDialog::pluginUpdateFailed);
+    connect(m_pluginsEngine, &PluginsEngine::pluginUninstalled, this, &PluginsDialog::pluginUninstalled);
+    connect(m_pluginsEngine, &PluginsEngine::pluginUninstallationFailed, this, &PluginsDialog::pluginUninstallationFailed);
+    connect(m_pluginsEngine, &PluginsEngine::pluginEnabledChanged, this, &PluginsDialog::pluginEnabledChanged);
+
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
+
+    if (const QByteArray state = m_storeHeaderState; !state.isEmpty())
+        m_ui->pluginsTree->header()->restoreState(state);
+}
+
+PluginsDialog::~PluginsDialog()
+{
+    m_storeDialogSize = size();
+    m_storeHeaderState = m_ui->pluginsTree->header()->saveState();
+    delete m_ui;
+}
+
+void PluginsDialog::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (event->mimeData()->hasText() || event->mimeData()->hasUrls())
+    {
+        event->setDropAction(Qt::CopyAction);
+        event->accept();
+    }
+}
+
+void PluginsDialog::dragMoveEvent(QDragMoveEvent *event)
+{
+    event->acceptProposedAction();
+}
+
+void PluginsDialog::dropEvent(QDropEvent *event)
+{
+    event->acceptProposedAction();
+
+    const QMimeData *mimeData = event->mimeData();
+    if (mimeData->hasUrls())
+    {
+        for (const QUrl &url : asConst(mimeData->urls()))
+        {
+            if (url.isLocalFile())
+                installPlugin(Path(url.toLocalFile()));
+        }
+    }
+    else
+    {
+        for (const QString &pathStr : asConst(mimeData->text().split(u'\n')))
+            installPlugin(Path(pathStr));
+    }
+}
+
+void PluginsDialog::onActionInstallTriggered()
+{
+    const QStringList pathsList = QFileDialog::getOpenFileNames(
+            nullptr, tr("Select plugins"), m_storeLastPath.get(QDir::homePath())
+            , (tr("qBittorrent plugin") + u" (*.lua)"));
+
+    for (const QString &pathStr : pathsList)
+        installPlugin(Path(pathStr));
+
+    if (!pathsList.isEmpty())
+        m_storeLastPath = Path(pathsList.at(0)).parentPath().data();
+}
+
+void PluginsDialog::onActionUninstallTriggered()
+{
+    for (QTreeWidgetItem *item : asConst(m_ui->pluginsTree->selectedItems()))
+    {
+        const int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
+        Q_ASSERT(index != -1);
+        if (index == -1) [[unlikely]]
+            continue;
+
+        const QString pluginID = item->text(PLUGIN_ID);
+        if (m_pluginsEngine->uninstallPlugin(pluginID))
+        {
+            startAsyncOp();
+            m_uninstallingPlugins.insert(pluginID);
+        }
+    }
+}
+
+void PluginsDialog::togglePluginState(QTreeWidgetItem *item)
+{
+    const QString pluginID = item->text(PLUGIN_ID);
+    const bool isEnabled = item->data(PLUGIN_STATE, Qt::UserRole).toBool();
+    m_pluginsEngine->setPluginEnabled(pluginID, !isEnabled);
+}
+
+void PluginsDialog::displayContextMenu()
+{
+    const QList<QTreeWidgetItem *> items = m_ui->pluginsTree->selectedItems();
+    if (items.isEmpty())
+        return;
+
+    QMenu *myContextMenu = new QMenu(this);
+    myContextMenu->setAttribute(Qt::WA_DeleteOnClose);
+
+    const QTreeWidgetItem *firstItem = items.first();
+    const bool isEnabled = firstItem->data(PLUGIN_STATE, Qt::UserRole).toBool();
+
+    myContextMenu->addAction(m_ui->actionEnable);
+    myContextMenu->addSeparator();
+    myContextMenu->addAction(m_ui->actionUninstall);
+
+    [[maybe_unused]] const QSignalBlocker actionEnableSignalBlocker {*m_ui->actionEnable};
+    m_ui->actionEnable->setChecked(isEnabled);
+
+    myContextMenu->popup(QCursor::pos());
+}
+
+void PluginsDialog::enableSelection(const bool enable)
+{
+    for (QTreeWidgetItem *item : asConst(m_ui->pluginsTree->selectedItems()))
+    {
+        const int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
+        Q_ASSERT(index != -1);
+        if (index == -1) [[unlikely]]
+            continue;
+
+        QString id = item->text(PLUGIN_ID);
+        m_pluginsEngine->setPluginEnabled(id, enable);
+        if (enable)
+        {
+            item->setText(PLUGIN_STATE, tr("Yes"));
+            setRowColor(index, u"green"_s);
+        }
+        else
+        {
+            item->setText(PLUGIN_STATE, tr("No"));
+            setRowColor(index, u"red"_s);
+        }
+    }
+}
+
+void PluginsDialog::setRowColor(const int row, const QString &color)
+{
+    QTreeWidgetItem *item = m_ui->pluginsTree->topLevelItem(row);
+    for (int i = 0; i < m_ui->pluginsTree->columnCount(); ++i)
+    {
+        item->setData(i, Qt::ForegroundRole, QColor(color));
+    }
+}
+
+QTreeWidgetItem *PluginsDialog::findItem(const QString &pluginID)
+{
+    for (int i = 0; i < m_ui->pluginsTree->topLevelItemCount(); ++i)
+    {
+        QTreeWidgetItem *item = m_ui->pluginsTree->topLevelItem(i);
+        if (pluginID == item->text(PLUGIN_ID))
+            return item;
+    }
+
+    return nullptr;
+}
+
+void PluginsDialog::loadPlugins()
+{
+    // Some clean up first
+    m_ui->pluginsTree->clear();
+    for (const PluginInfo &pluginInfo : asConst(m_pluginsEngine->allPlugins()))
+        addNewPlugin(pluginInfo);
+}
+
+void PluginsDialog::addNewPlugin(const PluginInfo &pluginInfo)
+{
+    auto *item = new QTreeWidgetItem(m_ui->pluginsTree);
+    item->setText(PLUGIN_ID, pluginInfo.id);
+    item->setText(PLUGIN_NAME, pluginInfo.name);
+    item->setText(PLUGIN_INVOCABLE, (pluginInfo.invocable ? tr("Yes") : tr("No")));
+    item->setData(PLUGIN_STATE, Qt::UserRole, pluginInfo.enabled);
+    if (pluginInfo.enabled)
+    {
+        item->setText(PLUGIN_STATE, tr("Yes"));
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), u"green"_s);
+    }
+    else
+    {
+        item->setText(PLUGIN_STATE, tr("No"));
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), u"red"_s);
+    }
+
+    item->setText(PLUGIN_VERSION, pluginInfo.version.toString());
+}
+
+void PluginsDialog::updatePlugin(const PluginInfo &pluginInfo)
+{
+    QTreeWidgetItem *item = findItem(pluginInfo.id);
+    if (!item)
+        return;
+
+    item->setText(PLUGIN_NAME, pluginInfo.name);
+    item->setText(PLUGIN_INVOCABLE, (pluginInfo.invocable ? tr("Yes") : tr("No")));
+    item->setText(PLUGIN_VERSION, pluginInfo.version.toString());
+}
+
+void PluginsDialog::installPlugin(const Path &pluginPath)
+{
+    if (m_pluginsEngine->installPlugin(pluginPath))
+    {
+        startAsyncOp();
+        m_installingPlugins.insert(pluginPath);
+    }
+}
+
+void PluginsDialog::startAsyncOp()
+{
+    ++m_asyncOps;
+    if (m_asyncOps == 1)
+        setCursor(QCursor(Qt::WaitCursor));
+}
+
+void PluginsDialog::finishAsyncOp()
+{
+    --m_asyncOps;
+    if (m_asyncOps == 0)
+        setCursor(QCursor(Qt::ArrowCursor));
+}
+
+void PluginsDialog::pluginInstalled(const Path &pluginPath, const PluginInfo &pluginInfo)
+{
+    addNewPlugin(pluginInfo);
+    if (m_installingPlugins.remove(pluginPath))
+    {
+        finishAsyncOp();
+        QMessageBox::information(this, tr("Plugin install"), tr("Plugin '%1' installed.").arg(pluginInfo.id));
+    }
+}
+
+void PluginsDialog::pluginInstallationFailed(const Path &pluginPath, const QString &reason)
+{
+    if (m_installingPlugins.remove(pluginPath))
+    {
+        finishAsyncOp();
+        QMessageBox::information(this, tr("Plugin install")
+                , tr("Couldn't install plugin from file '%1'.\n%2").arg(pluginPath.toString(), reason));
+    }
+}
+
+void PluginsDialog::pluginUpdated(const Path &pluginPath
+        , const PluginInfo &, const PluginInfo &newPluginInfo)
+{
+    updatePlugin(newPluginInfo);
+    if (m_installingPlugins.remove(pluginPath))
+    {
+        finishAsyncOp();
+        QMessageBox::information(this, tr("Plugin update"), tr("Plugin '%1' updated to version %2.")
+                .arg(newPluginInfo.id, newPluginInfo.version.toString()));
+    }
+}
+
+void PluginsDialog::pluginUpdateFailed(const Path &pluginPath, const PluginInfo &currentPluginInfo
+        , const PluginInfo &, const QString &reason)
+{
+    if (m_installingPlugins.remove(pluginPath))
+    {
+        finishAsyncOp();
+        QMessageBox::information(this, tr("Plugin update")
+                , tr("Couldn't update plugin '%1' from file '%2'.\n%3")
+                        .arg(currentPluginInfo.id, pluginPath.toString(), reason));
+    }
+}
+
+void PluginsDialog::pluginUninstalled(const QString &pluginID)
+{
+    const QTreeWidgetItem *item = findItem(pluginID);
+    if (!item)
+        return;
+
+    if (m_uninstallingPlugins.remove(pluginID))
+    {
+        delete item;
+        finishAsyncOp();
+        QMessageBox::information(this, tr("Plugin uninstall"), tr("Plugin '%1' uninstalled.").arg(pluginID));
+    }
+}
+
+void PluginsDialog::pluginUninstallationFailed(const QString &pluginID, const QString &reason)
+{
+    const QTreeWidgetItem *item = findItem(pluginID);
+    if (!item)
+        return;
+
+    if (m_uninstallingPlugins.remove(pluginID))
+    {
+        // Disable it instead
+        m_pluginsEngine->setPluginEnabled(pluginID, false);
+        finishAsyncOp();
+        QMessageBox::warning(this, tr("Plugin uninstall")
+                , tr("Failed to uninstall plugin '%1'.\n%2").arg(pluginID, reason));
+    }
+}
+
+void PluginsDialog::pluginEnabledChanged(const QString &pluginID, bool isEnabled)
+{
+    QTreeWidgetItem *item = findItem(pluginID);
+    if (!item)
+        return;
+
+    item->setData(PLUGIN_STATE, Qt::UserRole, isEnabled);
+    if (isEnabled)
+    {
+        item->setText(PLUGIN_STATE, tr("Yes"));
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), u"green"_s);
+    }
+    else
+    {
+        item->setText(PLUGIN_STATE, tr("No"));
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), u"red"_s);
+    }
+}

--- a/src/gui/plugins/pluginsdialog.h
+++ b/src/gui/plugins/pluginsdialog.h
@@ -28,60 +28,49 @@
 
 #pragma once
 
-#include <memory>
-#include <optional>
+#include <QDialog>
+#include <QSet>
 
-#include <QHash>
-#include <QObject>
-#include <QQueue>
+#include "base/plugins/pluginsengine.h"
+#include "base/settingvalue.h"
 
-#include "base/3rdparty/expected.hpp"
-#include "base/pathfwd.h"
-#include "base/utils/version.h"
-#include "pluginversion.h"
+class QDropEvent;
+class QTreeWidgetItem;
 
-using LuaVersion = Utils::Version<3>;
-using LuaBridgeVersion = Utils::Version<2>;
-
-class Plugin;
-
-namespace BitTorrent
+namespace Net
 {
-    class Torrent;
+    struct DownloadResult;
 }
 
-struct PluginInfo
+namespace Ui
 {
-    QString id;
-    QString name;
-    PluginVersion version;
-    bool invocable = false;
-    bool enabled = false;
-};
+    class PluginsDialog;
+}
 
-class PluginsEngine final : public QObject
+class PluginsDialog final : public QDialog
 {
     Q_OBJECT
-    Q_DISABLE_COPY_MOVE(PluginsEngine)
+    Q_DISABLE_COPY_MOVE(PluginsDialog)
 
 public:
-    static void initInstance();
-    static void freeInstance();
-    static PluginsEngine *instance();
+    explicit PluginsDialog(PluginsEngine *pluginsEngine, QWidget *parent = nullptr);
+    ~PluginsDialog() override;
 
-    static LuaVersion luaVersion();
-    static LuaBridgeVersion luaBridgeVersion();
+    QTreeWidgetItem *findItem(const QString &pluginID);
 
-    QHash<QString, PluginInfo> allPlugins() const;
-    std::optional<PluginInfo> pluginInfo(const QString &pluginID) const;
+protected:
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragMoveEvent(QDragMoveEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 
-    bool installPlugin(const Path &pluginPath);
-    bool uninstallPlugin(const QString &pluginID);
-    void setPluginEnabled(const QString &pluginID, bool enabled);
+private slots:
+    void onActionInstallTriggered();
+    void onActionUninstallTriggered();
+    void togglePluginState(QTreeWidgetItem*);
+    void setRowColor(int row, const QString &color);
+    void displayContextMenu();
+    void enableSelection(bool enable);
 
-    void invokePlugin(const QString &pluginID);
-
-signals:
     void pluginInstalled(const Path &pluginPath, const PluginInfo &pluginInfo);
     void pluginInstallationFailed(const Path &pluginPath, const QString &reason);
     void pluginUpdated(const Path &pluginPath, const PluginInfo &oldPluginInfo
@@ -93,40 +82,21 @@ signals:
     void pluginEnabledChanged(const QString &pluginID, bool isEnabled);
 
 private:
-    struct PluginEntry
-    {
-        std::shared_ptr<Plugin> plugin;
-        QString id;
-        bool enabled = false;
-    };
-
-    static Path pluginsPath();
-
-    explicit PluginsEngine(QObject *parent = nullptr);
-    ~PluginsEngine() override;
-
-    nonstd::expected<PluginEntry, QString> loadPlugin(const Path &path);
-    void installPluginDeferred();
-    void installPluginImpl();
-    void uninstallPluginDeferred();
-    void uninstallPluginImpl();
-
-    void loadConfig();
     void loadPlugins();
-    void connectEventHandlers();
-    void storeConfig() const;
-    PluginInfo getPluginInfo(const PluginEntry &pluginEntry) const;
+    void addNewPlugin(const PluginInfo &pluginInfo);
+    void updatePlugin(const PluginInfo &pluginInfo);
+    void installPlugin(const Path &pluginPath);
+    void startAsyncOp();
+    void finishAsyncOp();
 
-    template <typename Signal>
-    void connectEventHandler(Signal &&signal, const char *eventHandlerName);
+    Ui::PluginsDialog *m_ui = nullptr;
+    PluginsEngine *m_pluginsEngine = nullptr;
 
-    template <typename... Args>
-    void callEventHandlers(const char *eventHandlerName, Args&&... args);
+    SettingValue<QSize> m_storeDialogSize;
+    SettingValue<QByteArray> m_storeHeaderState;
+    SettingValue<QString> m_storeLastPath;
 
-    QHash<QString, PluginEntry> m_plugins;
-    QQueue<Path> m_pluginsToInstall;
-    QQueue<QString> m_pluginsToUninstall;
-    mutable bool m_configIsDirty = false;
-
-    inline static PluginsEngine *m_instance = nullptr;
+    int m_asyncOps = 0;
+    QSet<Path> m_installingPlugins;
+    QSet<QString> m_uninstallingPlugins;
 };

--- a/src/gui/plugins/pluginsdialog.ui
+++ b/src/gui/plugins/pluginsdialog.ui
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PluginsDialog</class>
+ <widget class="QDialog" name="PluginsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>345</height>
+   </rect>
+  </property>
+  <property name="acceptDrops">
+   <bool>true</bool>
+  </property>
+  <property name="windowTitle">
+   <string>Plugins</string>
+  </property>
+  <layout class="QVBoxLayout" name="pluginSelectLayout">
+   <item>
+    <widget class="QLabel" name="pluginsLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+       <underline>true</underline>
+      </font>
+     </property>
+     <property name="text">
+      <string>Installed plugins:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTreeWidget" name="pluginsTree">
+     <property name="contextMenuPolicy">
+      <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+     </property>
+     <property name="uniformRowHeights">
+      <bool>true</bool>
+     </property>
+     <property name="itemsExpandable">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <column>
+      <property name="text">
+       <string>ID</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Version</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Invocable</string>
+      </property>
+      <property name="toolTip">
+       <string>Plugin provides 'invoke' function that is called when user triggers corresponding plugin action from 'Plugins' menu.</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Enabled</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonsLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="installButton">
+       <property name="text">
+        <string>Install/Update plugins</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+  <action name="actionEnable">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enabled</string>
+   </property>
+  </action>
+  <action name="actionUninstall">
+   <property name="text">
+    <string>Uninstall</string>
+   </property>
+  </action>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This adds an experimental feature to support Lua plugins.
This is not a replacement/alternative to Search Plugins and has nothing to do with them. These are general purpose plugins.

### Motivation
The idea of adding plugin support has been on my mind for a very long time, but I still haven't had time to take it seriously. It consists in providing users with the opportunity to integrate into their qBittorrent some additional functions that are useful to them, which are unlikely to be added to the core of qBittorrent (for example, due to the reluctance to overload it with features that have a very limited user audience. Users occasionally request some features that seem to be relevant only to themselves, so we usually reject them).
We also have some functions in qBittorrent that have limited integration with the main code, so they can easily be implemented by plugins, and can later be removed from the core. I mean, something like sending email notifications and launching external programs. These are all functions that do not have deep integration with the main logic of the application, they just obtain some data and transmit it to the outside world. In addition, they are unlikely to be used by most users. But at the same time, some individuals request their extension from time to time, for example, by executing at other events. I consider it highly undesirable to overload the core with such functions.
Note that it is not initially intended to provide any official plugins (except as plugin examples). However, this is quite possible in the future, if anyone wants to maintain them.

### Interface
The main interface of plug-ins with the application core is "event handling". Event handlers are called for all installed plugins (provided, of course, that the plugin has a corresponding handler defined). At the same time, plug-ins (deliberately) live permanently during the lifetime of the application (well, either until they are uninstalled or updated), so they can store some data and track their changes.
Plugins can also be "user invocable" by providing the `invoke()` function. In this case, they can also be invoked by the user (for example, through the Plugins menu).

### Implementation notes
The feature is based on the core Lua library (of the version 5.5 ATTOW) and LuaBridge3.
I deliberately chose to integrate their source code into the qBittorrent source tree in order to facilitate its building and distribution on different target platforms, and this should ensure more controlled compatibility with the plugins code, since we will always have a specific version of Lua and update it, if necessary, only in major qBittorrent updates.

### Current state
Currently, all management functions are ready, such as installing, updating, and removing plug-ins, as well as enabling/disabling them. They are supported by GUI.
I have added support for most torrent-related events and their basic properties, so the rest can be added incrementally later.
"Invocable" plugins are listed under "Plugins" menu and can be invoked from there.
I have added several examples of plugins that demonstrate their main features and can serve as a basis for developing custom plug-ins.

### Note for reviewers
Please refrain from suggesting any improvements that are not mandatory at the initial stage. Quite a lot of work has already been done to provide this PR, so I would prefer to focus on fixing the obvious bugs and merging it into the qBittorrent code. This would make it easier for me to maintain and improve it further.

<img width="447" height="147" alt="000" src="https://github.com/user-attachments/assets/9ab270d7-9645-43cc-8b62-f19ababb2064" />

<img width="696" height="388" alt="001" src="https://github.com/user-attachments/assets/af986ecc-2c79-4d5c-b5ab-952d6323f275" />

<img width="560" height="414" alt="002" src="https://github.com/user-attachments/assets/eb1990af-4853-47fb-b262-ab30c5fad4ad" />

<img width="995" height="245" alt="003" src="https://github.com/user-attachments/assets/f9d6740f-9c74-406c-858b-cf5c6cb752a2" />
