### PR TITLE
Update example email addresses in SMTP recipients tooltips

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -670,9 +670,9 @@ void OptionsDialog::loadDownloadsTabOptions()
         + u"\n\n"
         + tr("Example:")
         + u"\n"
-        + tr("a@a.com;b@b.com,c@c.com - send two emails: the first to just a@a.com, the second to both b@b.com and c@c.com")
+        + tr("a@x.com;b@y.com,c@z.com - send two emails: the first to just a@x.com, the second to both b@y.com and c@z.com")
         + u"\n\n"
-        + tr("Note: b&b.com & c@c.com will both see each other's email addresses, whereas a&a.com will not see them nor be seen."));
+        + tr("Note: b@y.com & c@z.com will both see each other's email addresses, whereas a@x.com will not see them nor be seen."));
     m_ui->lineEditSMTPServer->setText(pref->getMailNotificationSMTP());
     m_ui->lineEditSMTPServer->setToolTip(tr("Provide the SMTP server address for sending email notifications.")
         + u"\n\n"

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -353,9 +353,9 @@ QBT_TR(Separate multiple emails with a semicolon.)QBT_TR[CONTEXT=OptionsDialog]
 QBT_TR(Separate multiple email addresses within each email with a comma.)QBT_TR[CONTEXT=OptionsDialog]
 
 QBT_TR(Example:)QBT_TR[CONTEXT=OptionsDialog]
-QBT_TR(a@a.com;b@b.com,c@c.com - send two emails: the first to just a@a.com, the second to both b@b.com and c@c.com)QBT_TR[CONTEXT=OptionsDialog]
+QBT_TR(a@x.com;b@y.com,c@z.com - send two emails: the first to just a@x.com, the second to both b@y.com and c@z.com)QBT_TR[CONTEXT=OptionsDialog]
 
-QBT_TR(Note: b&b.com & c@c.com will both see each other's email addresses, whereas a&a.com will not see them nor be seen.)QBT_TR[CONTEXT=OptionsDialog]">
+QBT_TR(Note: b@y.com & c@z.com will both see each other's email addresses, whereas a@x.com will not see them nor be seen.)QBT_TR[CONTEXT=OptionsDialog]">
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Corrected silly typos and replaced example addresses with better ones.