### PR TITLE
GHA CI: Sync `NSIS` third party action with upstream

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -224,7 +224,7 @@ jobs:
           path: upload
 
       - name: Install NSIS
-        uses: repolevedavaj/install-nsis@c14d0ea1b829818b4e9313d8e009b43f0a65fddd # v1.2.0
+        uses: repolevedavaj/install-nsis@1ab2f7ba2fe9408db612029be0bb3c0088b0d3e9 # v1.2.1
         with:
           nsis-version: '3.12'
 


### PR DESCRIPTION
* Bump `repolevedavaj/install-nsis` action `1.2.0` -> `1.2.1`
https://github.com/repolevedavaj/install-nsis/releases/tag/v1.2.1

Our `dependabot` would've updated this at some stage, but updating now (oob) to address current CI failures on windows.