### PR TITLE
Fix MatchAll share limit mode when all limits are disabled

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2402,23 +2402,34 @@ void SessionImpl::processTorrentShareLimits(TorrentImpl *torrent)
     }
     else
     {
-        reached = true;
-        description = tr("Torrent reached the share limit(s).");
+        // In MatchAll mode, all configured limits must be reached.
+        // If no limits are configured (all disabled), the torrent should not be considered as reached.
+        if ((shareLimits.ratioLimit < 0)
+                && (shareLimits.seedingTimeLimit < 0)
+                && (shareLimits.inactiveSeedingTimeLimit < 0))
+        {
+            reached = false;
+        }
+        else
+        {
+            reached = true;
+            description = tr("Torrent reached the share limit(s).");
 
-        if (const qreal ratio = torrent->realRatio();
-            (shareLimits.ratioLimit >= 0) && (ratio < shareLimits.ratioLimit))
-        {
-            reached = false;
-        }
-        else if (const qlonglong seedingTimeInMinutes = torrent->finishedTime() / 60;
-            (shareLimits.seedingTimeLimit >= 0) && (seedingTimeInMinutes < shareLimits.seedingTimeLimit))
-        {
-            reached = false;
-        }
-        else if (const qlonglong inactiveSeedingTimeInMinutes = torrent->timeSinceActivity() / 60;
-            (shareLimits.inactiveSeedingTimeLimit >= 0) && (inactiveSeedingTimeInMinutes < shareLimits.inactiveSeedingTimeLimit))
-        {
-            reached = false;
+            if (const qreal ratio = torrent->realRatio();
+                (shareLimits.ratioLimit >= 0) && (ratio < shareLimits.ratioLimit))
+            {
+                reached = false;
+            }
+            else if (const qlonglong seedingTimeInMinutes = torrent->finishedTime() / 60;
+                (shareLimits.seedingTimeLimit >= 0) && (seedingTimeInMinutes < shareLimits.seedingTimeLimit))
+            {
+                reached = false;
+            }
+            else if (const qlonglong inactiveSeedingTimeInMinutes = torrent->timeSinceActivity() / 60;
+                (shareLimits.inactiveSeedingTimeLimit >= 0) && (inactiveSeedingTimeInMinutes < shareLimits.inactiveSeedingTimeLimit))
+            {
+                reached = false;
+            }
         }
     }
 

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2376,6 +2376,14 @@ void SessionImpl::processTorrentShareLimits(TorrentImpl *torrent)
 
     const ShareLimits shareLimits = torrent->effectiveShareLimits();
 
+    // If all share limits are disabled, there is nothing to check
+    if ((shareLimits.ratioLimit < 0)
+            && (shareLimits.seedingTimeLimit < 0)
+            && (shareLimits.inactiveSeedingTimeLimit < 0))
+    {
+        return;
+    }
+
     bool reached = false;
     QString description;
 
@@ -2402,34 +2410,23 @@ void SessionImpl::processTorrentShareLimits(TorrentImpl *torrent)
     }
     else
     {
-        // In MatchAll mode, all configured limits must be reached.
-        // If no limits are configured (all disabled), the torrent should not be considered as reached.
-        if ((shareLimits.ratioLimit < 0)
-                && (shareLimits.seedingTimeLimit < 0)
-                && (shareLimits.inactiveSeedingTimeLimit < 0))
+        reached = true;
+        description = tr("Torrent reached the share limit(s).");
+
+        if (const qreal ratio = torrent->realRatio();
+            (shareLimits.ratioLimit >= 0) && (ratio < shareLimits.ratioLimit))
         {
             reached = false;
         }
-        else
+        else if (const qlonglong seedingTimeInMinutes = torrent->finishedTime() / 60;
+            (shareLimits.seedingTimeLimit >= 0) && (seedingTimeInMinutes < shareLimits.seedingTimeLimit))
         {
-            reached = true;
-            description = tr("Torrent reached the share limit(s).");
-
-            if (const qreal ratio = torrent->realRatio();
-                (shareLimits.ratioLimit >= 0) && (ratio < shareLimits.ratioLimit))
-            {
-                reached = false;
-            }
-            else if (const qlonglong seedingTimeInMinutes = torrent->finishedTime() / 60;
-                (shareLimits.seedingTimeLimit >= 0) && (seedingTimeInMinutes < shareLimits.seedingTimeLimit))
-            {
-                reached = false;
-            }
-            else if (const qlonglong inactiveSeedingTimeInMinutes = torrent->timeSinceActivity() / 60;
-                (shareLimits.inactiveSeedingTimeLimit >= 0) && (inactiveSeedingTimeInMinutes < shareLimits.inactiveSeedingTimeLimit))
-            {
-                reached = false;
-            }
+            reached = false;
+        }
+        else if (const qlonglong inactiveSeedingTimeInMinutes = torrent->timeSinceActivity() / 60;
+            (shareLimits.inactiveSeedingTimeLimit >= 0) && (inactiveSeedingTimeInMinutes < shareLimits.inactiveSeedingTimeLimit))
+        {
+            reached = false;
         }
     }
 


### PR DESCRIPTION
## Bug

In `MatchAll` share limit mode, if all limits (ratio, seeding time, inactive seeding time) are disabled (set to "no limit"), finished torrents are incorrectly treated as having reached all share limits, causing them to be stopped or removed.

### Cause

`SessionImpl::processTorrentShareLimits()` starts with `reached = true` in `MatchAll` mode, then sets it to `false` if any configured limit is **not** reached. However, when all limits are disabled (`< 0`), none of the conditions evaluate to `true`, so `reached` remains `true` — a vacuous truth bug.

### Fix

Add an early check in the `MatchAll` branch: if all three limits are disabled, set `reached = false` directly instead of falling through to the (vacuously true) limit comparison logic.