### PR TITLE
Fix potential invalid migration procedure

### DIFF
--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -55,7 +55,10 @@ namespace
     {
         const auto migrate = [](const QString &oldKey, const QString &newKey, const Path &savePath)
         {
-            SettingsStorage *settingsStorage {SettingsStorage::instance()};
+            auto *settingsStorage = SettingsStorage::instance();
+            if (!settingsStorage->hasKey(oldKey))
+                return;
+
             const auto oldData {settingsStorage->loadValue<QByteArray>(oldKey)};
             const auto newData {settingsStorage->loadValue<QString>(newKey)};
             const QString errorMsgFormat {QCoreApplication::translate("Upgrade", "Migrate preferences failed: WebUI https, file: \"%1\", error: \"%2\"")};
@@ -88,10 +91,13 @@ namespace
 
     void upgradeTorrentContentLayout()
     {
+        auto *settingsStorage = SettingsStorage::instance();
         const QString oldKey = u"BitTorrent/Session/CreateTorrentSubfolder"_s;
+        if (!settingsStorage->hasKey(oldKey))
+            return;
+
         const QString newKey = u"BitTorrent/Session/TorrentContentLayout"_s;
 
-        SettingsStorage *settingsStorage {SettingsStorage::instance()};
         const auto oldData {settingsStorage->loadValue<QVariant>(oldKey)};
         const auto newData {settingsStorage->loadValue<QString>(newKey)};
 
@@ -125,8 +131,10 @@ namespace
     {
         auto *settingsStorage = SettingsStorage::instance();
         const auto key = u"Preferences/Scheduler/days"_s;
-        const auto value = settingsStorage->loadValue<QString>(key);
+        if (!settingsStorage->hasKey(key))
+            return;
 
+        const auto value = settingsStorage->loadValue<QString>(key);
         bool ok = false;
         const auto number = value.toInt(&ok);
 
@@ -178,6 +186,8 @@ namespace
         auto *settingsStorage = SettingsStorage::instance();
         const auto key = u"Preferences/DynDNS/Service"_s;
         const auto value = settingsStorage->loadValue<QString>(key);
+        if (!settingsStorage->hasKey(key))
+            return;
 
         bool ok = false;
         const auto number = value.toInt(&ok);
@@ -208,8 +218,10 @@ namespace
     {
         auto *settingsStorage = SettingsStorage::instance();
         const auto key = u"Preferences/Advanced/TrayIconStyle"_s;
-        const auto value = settingsStorage->loadValue<QString>(key);
+        if (!settingsStorage->hasKey(key))
+            return;
 
+        const auto value = settingsStorage->loadValue<QString>(key);
         bool ok = false;
         const auto number = value.toInt(&ok);
 
@@ -239,6 +251,9 @@ namespace
     {
         auto *settingsStorage = SettingsStorage::instance();
         const auto oldKey = u"Preferences/Advanced/TrayIconStyle"_s;
+        if (!settingsStorage->hasKey(oldKey))
+            return;
+
         const auto newKey = u"Appearance/TrayIconStyle"_s;
         const auto value = settingsStorage->loadValue<QString>(oldKey);
 
@@ -365,8 +380,10 @@ namespace
     {
         auto *settingsStorage = SettingsStorage::instance();
         const auto key = u"Network/Proxy/Type"_s;
-        const auto value = settingsStorage->loadValue<QString>(key);
+        if (!settingsStorage->hasKey(key))
+            return;
 
+        const auto value = settingsStorage->loadValue<QString>(key);
         bool ok = false;
         const auto number = value.toInt(&ok);
 
@@ -473,6 +490,9 @@ namespace
     {
         auto *settingsStorage = SettingsStorage::instance();
         const auto oldKey = u"BitTorrent/Session/MaxRatioAction"_s;
+        if (!settingsStorage->hasKey(oldKey))
+            return;
+
         const auto newKey = u"BitTorrent/Session/ShareLimitAction"_s;
         const auto value = settingsStorage->loadValue<int>(oldKey);
 
@@ -503,8 +523,10 @@ namespace
     {
         auto *settingsStorage = SettingsStorage::instance();
         const auto oldKey = u"BitTorrent/Session/AddTorrentPaused"_s;
-        const auto newKey = u"BitTorrent/Session/AddTorrentStopped"_s;
+        if (!settingsStorage->hasKey(oldKey))
+            return;
 
+        const auto newKey = u"BitTorrent/Session/AddTorrentStopped"_s;
         settingsStorage->storeValue(newKey, settingsStorage->loadValue<bool>(oldKey));
         settingsStorage->removeValue(oldKey);
     }


### PR DESCRIPTION
Without actually checking the old keys existence, the migration procedures might write new keys while wrongly assuming the old value is valid (it is not, it may be some default constructed value).
