### PR TITLE
Disable "Resolve peer countries" by default in new installations

### DIFF
--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -546,13 +546,22 @@ namespace
             settingsStorage->removeValue(oldKey);
         }
     }
+
+    void setResolvePeerCountriesSetting()
+    {
+        // User may not have touched this setting so it will stay at the default and its value is empty.
+        // Set it to the previous default value so existing installations are not affected by the new default
+
+        auto *settingsStorage = SettingsStorage::instance();
+        const QString key = u"Preferences/Connection/ResolvePeerCountries"_s;
+        if (!settingsStorage->hasKey(key))
+            SettingsStorage::instance()->storeValue(key, true);
+    }
 }
 
 bool upgrade()
 {
-    CachedSettingValue<int> version {MIGRATION_VERSION_KEY, 0};
-
-    if (version != MIGRATION_VERSION)
+    if (CachedSettingValue<int> version {MIGRATION_VERSION_KEY, 0}; version != MIGRATION_VERSION)
     {
         if (version < 1)
         {
@@ -597,6 +606,7 @@ bool upgrade()
         {
             upgradeTrayIconStyleSettings2();
             migrateSMTPEncryptionSetting();
+            setResolvePeerCountriesSetting();
         }
 
         version = MIGRATION_VERSION;

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1376,7 +1376,7 @@ void Preferences::recheckTorrentsOnCompletion(const bool recheck)
 
 bool Preferences::resolvePeerCountries() const
 {
-    return value(u"Preferences/Connection/ResolvePeerCountries"_s, true);
+    return value(u"Preferences/Connection/ResolvePeerCountries"_s, false);
 }
 
 void Preferences::resolvePeerCountries(const bool resolve)


### PR DESCRIPTION
The country of a connected peer is interesting, however it is not a crucial information that needs to be present for out-of-the box user experience. This also avoids contacting the GeoDB on the first qbt start up which acts like a ping signal for each qbt instance.

Note that this change only affects new/fresh qbt installations. Existing instances are not affected.

ps. I would like this change but I don't insist strongly.