### PR TITLE
Fix ETA for match-all share limits

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -296,6 +296,30 @@ namespace
     {
         return ((value < 0) || (value == std::numeric_limits<int>::max())) ? 0 : value;
     }
+
+    qlonglong finishedTorrentShareLimitsEta(const ShareLimits &shareLimits, const qlonglong ratioEta
+            , const qlonglong seedingTimeEta, const qlonglong inactiveSeedingTimeEta)
+    {
+        const bool matchAll = (shareLimits.mode == ShareLimitsMode::MatchAll);
+        qlonglong result = (matchAll ? 0 : MAX_ETA);
+        bool hasLimit = false;
+
+        const auto applyEta = [&](const bool enabled, const qlonglong eta)
+        {
+            if (!enabled)
+                return;
+
+            hasLimit = true;
+            const qlonglong normalizedEta = std::max<qlonglong>(eta, 0);
+            result = (matchAll ? std::max(result, normalizedEta) : std::min(result, normalizedEta));
+        };
+
+        applyEta((shareLimits.ratioLimit >= 0), ratioEta);
+        applyEta((shareLimits.seedingTimeLimit >= 0), seedingTimeEta);
+        applyEta((shareLimits.inactiveSeedingTimeLimit >= 0), inactiveSeedingTimeEta);
+
+        return (hasLimit ? result : MAX_ETA);
+    }
 }
 
 // TorrentImpl
@@ -1422,7 +1446,7 @@ qlonglong TorrentImpl::eta() const
             inactiveSeedingTimeEta = std::max<qlonglong>(inactiveSeedingTimeEta, 0);
         }
 
-        return std::min({ratioEta, seedingTimeEta, inactiveSeedingTimeEta});
+        return finishedTorrentShareLimitsEta(shareLimits, ratioEta, seedingTimeEta, inactiveSeedingTimeEta);
     }
 
     if (!speedAverage.download) return MAX_ETA;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -296,30 +296,6 @@ namespace
     {
         return ((value < 0) || (value == std::numeric_limits<int>::max())) ? 0 : value;
     }
-
-    qlonglong finishedTorrentShareLimitsEta(const ShareLimits &shareLimits, const qlonglong ratioEta
-            , const qlonglong seedingTimeEta, const qlonglong inactiveSeedingTimeEta)
-    {
-        const bool matchAll = (shareLimits.mode == ShareLimitsMode::MatchAll);
-        qlonglong result = (matchAll ? 0 : MAX_ETA);
-        bool hasLimit = false;
-
-        const auto applyEta = [&](const bool enabled, const qlonglong eta)
-        {
-            if (!enabled)
-                return;
-
-            hasLimit = true;
-            const qlonglong normalizedEta = std::max<qlonglong>(eta, 0);
-            result = (matchAll ? std::max(result, normalizedEta) : std::min(result, normalizedEta));
-        };
-
-        applyEta((shareLimits.ratioLimit >= 0), ratioEta);
-        applyEta((shareLimits.seedingTimeLimit >= 0), seedingTimeEta);
-        applyEta((shareLimits.inactiveSeedingTimeLimit >= 0), inactiveSeedingTimeEta);
-
-        return (hasLimit ? result : MAX_ETA);
-    }
 }
 
 // TorrentImpl
@@ -1408,48 +1384,60 @@ qlonglong TorrentImpl::totalUpload() const
 
 qlonglong TorrentImpl::eta() const
 {
-    if (isStopped()) return MAX_ETA;
+    if (isStopped())
+        return MAX_ETA;
 
     const SpeedSampleAvg speedAverage = m_payloadRateMonitor.average();
 
     if (isFinished())
     {
+        const qint64 ZERO_ETA = 0;
+
         const ShareLimits shareLimits = effectiveShareLimits();
-        if ((shareLimits.ratioLimit < 0) && (shareLimits.seedingTimeLimit < 0) && (shareLimits.inactiveSeedingTimeLimit < 0))
-            return MAX_ETA;
+        QList<qint64> etaList;
 
-        qlonglong ratioEta = MAX_ETA;
-
-        if ((speedAverage.upload > 0) && (shareLimits.ratioLimit >= 0))
+        if (shareLimits.ratioLimit >= 0)
         {
-            qlonglong realDL = totalDownload();
+            qint64 realDL = totalDownload();
             if (realDL <= 0)
                 realDL = wantedSize();
 
-            ratioEta = ((realDL * shareLimits.ratioLimit) - totalUpload()) / speedAverage.upload;
+            const qreal uploadLimit = realDL * shareLimits.ratioLimit;
+            const qint64 uploaded = totalUpload();
+            qint64 ratioEta = ZERO_ETA;
+            if (uploadLimit > uploaded)
+            {
+                ratioEta = (speedAverage.upload > 0)
+                        ? (uploadLimit - uploaded) / speedAverage.upload
+                        : MAX_ETA;
+            }
+            etaList.append(ratioEta);
         }
-
-        qlonglong seedingTimeEta = MAX_ETA;
 
         if (shareLimits.seedingTimeLimit >= 0)
         {
-            seedingTimeEta = (shareLimits.seedingTimeLimit * 60) - finishedTime();
-            if (seedingTimeEta < 0)
-                seedingTimeEta = 0;
+            const qint64 seedingTimeEta = std::max(
+                    ((shareLimits.seedingTimeLimit * 60) - finishedTime()), ZERO_ETA);
+            etaList.append(seedingTimeEta);
         }
-
-        qlonglong inactiveSeedingTimeEta = MAX_ETA;
 
         if (shareLimits.inactiveSeedingTimeLimit >= 0)
         {
-            inactiveSeedingTimeEta = (shareLimits.inactiveSeedingTimeLimit * 60) - timeSinceActivity();
-            inactiveSeedingTimeEta = std::max<qlonglong>(inactiveSeedingTimeEta, 0);
+            const qint64 inactiveSeedingTimeEta = std::max(
+                    ((shareLimits.inactiveSeedingTimeLimit * 60) - timeSinceActivity()), ZERO_ETA);
+            etaList.append(inactiveSeedingTimeEta);
         }
 
-        return finishedTorrentShareLimitsEta(shareLimits, ratioEta, seedingTimeEta, inactiveSeedingTimeEta);
+        if (etaList.isEmpty())
+            return MAX_ETA;
+
+        return (shareLimits.mode == ShareLimitsMode::MatchAny)
+                ? std::ranges::min(etaList)
+                : std::ranges::max(etaList);
     }
 
-    if (!speedAverage.download) return MAX_ETA;
+    if (!speedAverage.download)
+        return MAX_ETA;
 
     return (wantedSize() - completedSize()) / speedAverage.download;
 }


### PR DESCRIPTION
Closes #24490.

Makes finished-torrent ETA respect the configured share-limit mode: Match Any reports the first enabled limit that can be reached, while Match All reports the time until the last enabled limit is satisfied.