### PR TITLE
Resolve relative UI theme paths

### DIFF
--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -60,7 +60,7 @@ namespace
 
     Path resolveThemePath(const Path &themePath)
     {
-        return Profile::instance()->fromPortablePath(themePath);
+        return (themePath.isAbsolute() ? themePath : (Profile::instance()->rootPath() / themePath));
     }
 }
 

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -56,6 +56,14 @@ namespace
         const QColor &color = palette.color(QPalette::Active, QPalette::Base);
         return (color.lightness() < 127);
     }
+
+    Path resolveThemePath(const Path &themePath)
+    {
+        if (themePath.isAbsolute())
+            return themePath;
+
+        return (Path(QCoreApplication::applicationDirPath()) / themePath);
+    }
 }
 
 UIThemeManager *UIThemeManager::m_instance = nullptr;
@@ -100,7 +108,7 @@ UIThemeManager::UIThemeManager()
 
     if (m_useCustomTheme)
     {
-        const Path themePath = Preferences::instance()->customUIThemePath();
+        const Path themePath = resolveThemePath(Preferences::instance()->customUIThemePath());
 
         if (themePath.hasExtension(u".qbtheme"_s))
         {

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -39,6 +39,7 @@
 
 #include "base/logger.h"
 #include "base/path.h"
+#include "base/profile.h"
 #include "base/preferences.h"
 #include "uithemecommon.h"
 
@@ -59,10 +60,7 @@ namespace
 
     Path resolveThemePath(const Path &themePath)
     {
-        if (themePath.isAbsolute())
-            return themePath;
-
-        return (Path(QCoreApplication::applicationDirPath()) / themePath);
+        return Profile::instance()->fromPortablePath(themePath);
     }
 }
 


### PR DESCRIPTION
Closes #24489.

Resolves relative custom UI theme paths against the profile root when the theme manager loads them, while preserving the stored preference and Options field exactly as entered.