### PR TITLE
Align lock toolbar menu button on Windows

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -60,6 +60,8 @@
 #ifdef Q_OS_WIN
 #include <QCryptographicHash>
 #include <QScopeGuard>
+#include <QStyle>
+#include <QToolButton>
 #endif
 
 #include "base/bittorrent/session.h"
@@ -215,6 +217,14 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     lockMenu->addAction(tr("&Set Password"), this, &MainWindow::defineUILockPassword);
     lockMenu->addAction(tr("&Clear Password"), this, &MainWindow::clearUILockPassword);
     m_ui->actionLock->setMenu(lockMenu);
+#ifdef Q_OS_WIN
+    if (auto *lockButton = qobject_cast<QToolButton *>(m_ui->toolBar->widgetForAction(m_ui->actionLock)))
+    {
+        const int menuButtonWidth = lockButton->style()->pixelMetric(QStyle::PM_MenuButtonIndicator, nullptr, lockButton);
+        lockButton->setStyleSheet(u"QToolButton::menu-button { width: %1px; "
+            "subcontrol-origin: padding; subcontrol-position: center right; }"_s.arg(menuButtonWidth));
+    }
+#endif
 
     updateAltSpeedsBtn(BitTorrent::Session::instance()->isAltGlobalSpeedLimitEnabled());
 


### PR DESCRIPTION
Closes #24498.

Applies a Windows-only toolbar button style adjustment so the lock action menu indicator is positioned inside the lock button while keeping the existing lock and menu behavior unchanged.

### Screenshot

![Windows lock toolbar menu proof](https://cdn.discordapp.com/attachments/1503227011705999460/1515853174299168768/image.png?ex=6a3083c7&is=6a2f3247&hm=dc9ea82e6db194740965b29f99a652f96f7d3e270b4d4dbea5603396e7670451&)


