### PR TITLE
Clear transfer filters when sections collapse

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -65,9 +65,12 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     mainWidgetLayout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
 
     {
-        auto *item = new TransferListFiltersWidgetItem(tr("Status"), new StatusFilterWidget(this, transferList), this);
+        auto *statusFilterWidget = new StatusFilterWidget(this, transferList);
+        auto *item = new TransferListFiltersWidgetItem(tr("Status"), statusFilterWidget, this);
         item->setChecked(pref->getStatusFilterState());
+        connect(item, &TransferListFiltersWidgetItem::toggled, statusFilterWidget, &StatusFilterWidget::toggleFilter);
         connect(item, &TransferListFiltersWidgetItem::toggled, pref, &Preferences::setStatusFilterState);
+        statusFilterWidget->toggleFilter(item->isChecked());
         mainWidgetLayout->addWidget(item);
     }
 
@@ -124,7 +127,9 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
 
         auto *item = new TransferListFiltersWidgetItem(tr("Trackers"), m_trackersFilterWidget, this);
         item->setChecked(pref->getTrackerFilterState());
+        connect(item, &TransferListFiltersWidgetItem::toggled, m_trackersFilterWidget, &TrackersFilterWidget::toggleFilter);
         connect(item, &TransferListFiltersWidgetItem::toggled, pref, &Preferences::setTrackerFilterState);
+        m_trackersFilterWidget->toggleFilter(item->isChecked());
         mainWidgetLayout->addWidget(item);
     }
 
@@ -140,9 +145,12 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
 
     const auto createTrackerStatusItem = [this, mainWidgetLayout, trackerStatusItemPos, pref]
     {
-        auto *item = new TransferListFiltersWidgetItem(tr("Tracker status"), new TrackerStatusFilterWidget(this, m_transferList), this);
+        auto *trackerStatusFilterWidget = new TrackerStatusFilterWidget(this, m_transferList);
+        auto *item = new TransferListFiltersWidgetItem(tr("Tracker status"), trackerStatusFilterWidget, this);
         item->setChecked(pref->getTrackerStatusFilterState());
+        connect(item, &TransferListFiltersWidgetItem::toggled, trackerStatusFilterWidget, &TrackerStatusFilterWidget::toggleFilter);
         connect(item, &TransferListFiltersWidgetItem::toggled, pref, &Preferences::setTrackerStatusFilterState);
+        trackerStatusFilterWidget->toggleFilter(item->isChecked());
         mainWidgetLayout->insertWidget(trackerStatusItemPos, item);
     };
 


### PR DESCRIPTION
Closes #24153.

Collapsing the Status, Trackers, and Tracker status sidebar sections now clears their active filters through the existing filter toggle path, matching the category and tag section behavior.

Manual UI validation:
- macOS 27.0 (26A5353q), arm64, qBittorrent v5.3.0alpha1 Debug build, Qt 6.11.1.
- Added a test magnet in an isolated profile.
- Verified selecting `Stopped (0)` hides the active torrent, then collapsing `Status` restores the torrent list.
- Verified selecting `Trackerless (0)` hides the torrent, then collapsing `Trackers` restores the torrent list.
- Enabled the separate tracker status filter and verified selecting `Warning (0)` hides the torrent, then collapsing `Tracker status` restores the torrent list.
- Local Debug GUI build completed successfully.
