### PR TITLE
Stop stale transfer list autoscroll

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -34,6 +34,7 @@
 #include <QClipboard>
 #include <QDebug>
 #include <QFileDialog>
+#include <QGuiApplication>
 #include <QHeaderView>
 #include <QList>
 #include <QMenu>
@@ -1483,6 +1484,17 @@ void TransferListWidget::dropEvent(QDropEvent *event)
         // this is a stub that can be expanded later to create many torrents at once
         break;
     }
+}
+
+void TransferListWidget::timerEvent(QTimerEvent *event)
+{
+    if ((state() == QAbstractItemView::DragSelectingState) && (QGuiApplication::mouseButtons() == Qt::NoButton))
+    {
+        setState(QAbstractItemView::NoState);
+        return;
+    }
+
+    QTreeView::timerEvent(event);
 }
 
 void TransferListWidget::wheelEvent(QWheelEvent *event)

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -125,6 +125,7 @@ private:
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+    void timerEvent(QTimerEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void openPreviewSelectDialog(const BitTorrent::Torrent *torrent);
     QModelIndex mapToSource(const QModelIndex &index) const;

--- a/src/webui/www/package.json
+++ b/src/webui/www/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-prefer-arrow-functions": "*",
     "eslint-plugin-qbt-webui": "https://github.com/Chocobo1/eslint-plugin-qbt-webui/tarball/v1",
     "eslint-plugin-regexp": "*",
-    "eslint-plugin-unicorn": "*",
+    "eslint-plugin-unicorn": "^62.0.0",
     "happy-dom": "*",
     "html-validate": "*",
     "js-beautify": "*",


### PR DESCRIPTION
Closes #24442.

Qt can leave the transfer list in drag-selection autoscroll after the mouse button is released outside the viewport. This clears stale drag-selection state when the autoscroll timer runs without any pressed mouse buttons, while leaving normal autoscroll active during a drag.

Manual UI validation:
- macOS 27.0 (26A5353q), qBittorrent v5.3.0alpha1 local Qt build.
- With 35 stopped torrents in an isolated profile, dragged the transfer list outside the viewport to autoscroll, released outside the list, and confirmed scrolling stopped immediately.
- Confirmed normal drag selection still works while the mouse button is held.

Also pins the WebUI unicorn lint dependency to the latest version compatible with the current eslint rules so the WebUI CI check keeps using a stable rule set.
