### PR TITLE
WebUI: Migrate lint rule to new name

### DIFF
--- a/src/webui/www/eslint.config.mjs
+++ b/src/webui/www/eslint.config.mjs
@@ -71,7 +71,7 @@ export default [
             "Stylistic/quote-props": ["error", "consistent-as-needed"],
             "Stylistic/semi": "error",
             "Stylistic/spaced-comment": ["error", "always", { exceptions: ["*"] }],
-            "Unicorn/no-array-for-each": "error",
+            "Unicorn/no-for-each": "error",
             "Unicorn/no-for-loop": "error",
             "Unicorn/no-zero-fractions": "error",
             "Unicorn/prefer-classlist-toggle": "error",


### PR DESCRIPTION
The rule was renamed from `no-array-for-each` to `no-for-each`.
https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v66.0.0

This addresses the recent CI failure.