### PR TITLE
WebUI: use CSS.escape when generating CSS query selector

### DIFF
--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -454,7 +454,7 @@ window.qBittorrent.ContextMenu ??= (() => {
 
             const contextTagList = document.getElementById("contextTagList");
             for (const tag of window.qBittorrent.Client.tagMap.keys()) {
-                const checkbox = contextTagList.querySelector(`a[href="#Tag/${tag}"] input[type="checkbox"]`);
+                const checkbox = contextTagList.querySelector(`a[href="#Tag/${CSS.escape(tag)}"] input[type="checkbox"]`);
                 const count = tagCount.get(tag);
                 const hasCount = (count !== undefined);
                 const isLesser = (count < selectedRows.length);

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -464,7 +464,7 @@ window.qBittorrent.ContextMenu ??= (() => {
 
             const contextCategoryList = document.getElementById("contextCategoryList");
             for (const category of window.qBittorrent.Client.categoryMap.keys()) {
-                const categoryIcon = contextCategoryList.querySelector(`a[href$="#Category/${category}"] img`);
+                const categoryIcon = contextCategoryList.querySelector(`a[href$="#Category/${CSS.escape(category)}"] img`);
                 const count = categoryCount.get(category);
                 const isEqual = ((count !== undefined) && (count === selectedRows.length));
                 categoryIcon.classList.toggle("highlightedCategoryIcon", isEqual);


### PR DESCRIPTION
Closes #24536 

A category with double quote breaks the CSS selector:

<img width="929" height="155" alt="Screenshot 2026-06-19 at 3 34 41 PM" src="https://github.com/user-attachments/assets/f59d0dfa-e26f-4865-a9ac-96f82d25c11e" />

Use `CSS.escape` to properly generate a correct css selector.