### PR TITLE
Fix wrong torrent tracker conversion

### DIFF
--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -233,11 +233,22 @@ void BitTorrent::TorrentDescriptor::setTorrentInfo(TorrentInfo torrentInfo)
 
 QList<BitTorrent::TrackerEntry> BitTorrent::TorrentDescriptor::trackers() const
 {
+    // libtorrent does not guarantee `add_torrent_params.trackers.size() == add_torrent_params.tracker_tiers.size()`
+
+    const qsizetype trackerCount = m_ltAddTorrentParams.trackers.size();
+    const qsizetype tierCount = m_ltAddTorrentParams.tracker_tiers.size();
+
     QList<TrackerEntry> ret;
-    ret.reserve(static_cast<decltype(ret)::size_type>(m_ltAddTorrentParams.trackers.size()));
-    std::size_t i = 0;
-    for (const std::string &tracker : m_ltAddTorrentParams.trackers)
-        ret.append({QString::fromStdString(tracker), m_ltAddTorrentParams.tracker_tiers[i++]});
+    ret.reserve(trackerCount);
+
+    int tier = 0;
+    for (qsizetype i = 0; i < trackerCount; ++i)
+    {
+        const auto tracker = QString::fromStdString(m_ltAddTorrentParams.trackers[i]);
+        if (i < tierCount)
+            tier = m_ltAddTorrentParams.tracker_tiers[i];
+        ret.append({.url = tracker, .tier = tier});
+    }
 
     return ret;
 }


### PR DESCRIPTION
From http://libtorrent.org/reference-Add_Torrent.html#add_torrent_params
> This is optional, if not specified trackers are assumed to be part of tier 0, or whichever the
> last tier was as iterating over the trackers.
