### PR TITLE
Fix RSS feed doesn't follow the specified interval

### DIFF
--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -639,6 +639,13 @@ void Session::refresh()
         const auto interval = std::chrono::duration_cast<std::chrono::seconds>(timepoint - currentTimepoint);
         if ((interval < nextRefreshInterval) || (nextRefreshInterval == 0s))
             nextRefreshInterval = interval;
+
+        if (nextRefreshInterval == 0s)
+        {
+            const std::chrono::seconds feedRefreshInterval = feed->refreshInterval();
+            const std::chrono::seconds effectiveRefreshInterval = (feedRefreshInterval > 0s) ? feedRefreshInterval : std::chrono::minutes(refreshInterval());
+            nextRefreshInterval = effectiveRefreshInterval;
+        }
     }
 
     m_refreshTimer.start(nextRefreshInterval);

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -633,19 +633,14 @@ void Session::refresh()
         Feed *feed = it.key();
         std::chrono::system_clock::time_point &timepoint = it.value();
 
-        if (timepoint <= currentTimepoint)
+        // Subtract 1 second from feed refresh timepoint to get more wiggle room and not end up with 0 "interval" below
+        // because currentTimepoint and timepoint have a difference of nanoseconds (~0 seconds)
+        if (currentTimepoint > (timepoint - 1s))
             timepoint = refreshFeed(feed, currentTimepoint);
 
         const auto interval = std::chrono::duration_cast<std::chrono::seconds>(timepoint - currentTimepoint);
         if ((interval < nextRefreshInterval) || (nextRefreshInterval == 0s))
             nextRefreshInterval = interval;
-
-        if (nextRefreshInterval == 0s)
-        {
-            const std::chrono::seconds feedRefreshInterval = feed->refreshInterval();
-            const std::chrono::seconds effectiveRefreshInterval = (feedRefreshInterval > 0s) ? feedRefreshInterval : std::chrono::minutes(refreshInterval());
-            nextRefreshInterval = effectiveRefreshInterval;
-        }
     }
 
     m_refreshTimer.start(nextRefreshInterval);


### PR DESCRIPTION
Closes #24550

In the RSS refresh logic, there is chance that `interval` and `nextRefreshInterval` will both have `0`. 

https://github.com/qbittorrent/qBittorrent/blob/fe7baea4ce22f32cc5161aed63c09353928f601e/src/base/rss/rss_session.cpp#L639-L641

Resulting to  `nextRefreshInterval` have a value of `0`

If there is only one RSS feed, the refresh trigger immediately (again) since we are calling `m_refreshTimer.start(0)`

If there is more than one RSS feed, `nextRefreshInterval` would get the `interval` from the other feeds even though it has a higher interval rate.

Here's what my debug output using `master` looks like:

```
********* interval  0s  nextRefreshInterval  0s <-- feed 1
********* interval  35996s  nextRefreshInterval  0s <-- feed 2
nextRefreshInterval  35996s
```

~We just need to handle the case where both `interval` and `nextRefreshInterval` are `0` and correctly set the  `nextRefreshInterval` to the current feed interval setting~

Let's just subtract 1 second from the feed refresh timepoint, to force a refresh and prevent getting an `interval = 0`