### PR TITLE
Support libtorrent filename deduplication

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(qbt_base STATIC
     bittorrent/loadtorrentparams.h
     bittorrent/ltqbitarray.h
     bittorrent/lttypecast.h
+    bittorrent/managededupedfilenames.h
     bittorrent/nativesessionextension.h
     bittorrent/nativetorrentextension.h
     bittorrent/peeraddress.h
@@ -146,6 +147,7 @@ add_library(qbt_base STATIC
     bittorrent/filterparserthread.cpp
     bittorrent/infohash.cpp
     bittorrent/ltqbitarray.cpp
+    bittorrent/managededupedfilenames.cpp
     bittorrent/nativesessionextension.cpp
     bittorrent/nativetorrentextension.cpp
     bittorrent/peeraddress.cpp

--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -56,6 +56,7 @@
 #include "base/utils/string.h"
 #include "infohash.h"
 #include "loadtorrentparams.h"
+#include "managededupedfilenames.h"
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -350,6 +351,8 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
         {
             return nonstd::make_unexpected(tr("Mismatching info-hash detected in resume data"));
         }
+        if (pref->isFixMutatedFilenamesEnabled())
+            manageDedupedFilenames(p, DedupeAction::Revert);
     }
 
     p.save_path = Profile::instance()->fromPortablePath(

--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -64,6 +64,7 @@
 #include "base/utils/string.h"
 #include "infohash.h"
 #include "loadtorrentparams.h"
+#include "managededupedfilenames.h"
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -713,6 +714,8 @@ LoadResumeDataResult DBResumeDataStorage::parseQueryResultRow(const QSqlQuery &q
         if (ec)
             return nonstd::make_unexpected(tr("Cannot parse torrent info: %1").arg(QString::fromStdString(ec.message())));
 #endif
+        if (pref->isFixMutatedFilenamesEnabled())
+            manageDedupedFilenames(p, DedupeAction::Revert);
     }
 
     p.save_path = Profile::instance()->fromPortablePath(Path(fromLTString(p.save_path)))

--- a/src/base/bittorrent/managededupedfilenames.cpp
+++ b/src/base/bittorrent/managededupedfilenames.cpp
@@ -1,0 +1,97 @@
+#include "managededupedfilenames.h"
+
+#include <libtorrent/torrent_info.hpp>
+#include <libtorrent/write_resume_data.hpp>
+
+#include <QCoreApplication>
+#include <QDebug>
+
+#include "base/logger.h"
+#include "infohash.h"
+
+namespace BitTorrent
+{
+    // Makes sure renamed_files properly accounts for libtorrent filename deduplication based on DedupeAction value.
+    //
+    // Revert:
+    // Compares orig_files() to files() and packs divergent orig_files() into renamed_files if not covered.
+    // (Fixes "Missing Files" errors caused by libtorrent filename mutations.)
+    //
+    // Insert:
+    // Compares orig_files() to files() and packs divergent files() into renamed_files if not covered.
+    // (Allows use of libtorrent deduplicated filenames when adding a new torrent from a .torrent file.)
+    //
+    // MagnetInsert:
+    // Creates a temp .ti to force duplication check, then packs divergent files() into renamed_files if not covered.
+    // (Allows use of libtorrent deduplicated filenames when adding a new torrent from a magnet link.)
+    int manageDedupedFilenames(lt::add_torrent_params &atp, const DedupeAction action)
+    {
+        int mutation_counter = 0;
+        if (!atp.ti || !atp.ti->is_valid())
+            return mutation_counter;
+
+        std::shared_ptr<const lt::torrent_info> deduped_ti;
+        const lt::file_storage *original = nullptr;
+        const lt::file_storage *deduped = nullptr;
+        if (action == DedupeAction::MagnetInsert)
+        {
+            const lt::span<char const> buffer = lt::write_torrent_file_buf(atp, lt::write_flags::allow_missing_piece_layer);
+            if (buffer.empty())
+                return mutation_counter;
+
+            lt::error_code ec;
+            deduped_ti = std::make_shared<lt::torrent_info>(buffer.data(), static_cast<int>(buffer.size()), ec);
+            if (ec)
+                return mutation_counter;
+
+#if LIBTORRENT_VERSION_NUM >= 20100
+            original = &deduped_ti->layout();
+            deduped = &deduped_ti->files_impl();
+#else
+            original = &deduped_ti->orig_files();
+            deduped = &deduped_ti->files();
+#endif
+        }
+        else
+        {
+#if LIBTORRENT_VERSION_NUM >= 20100
+            original = &atp.ti->layout();
+            deduped = &atp.ti->files_impl();
+#else
+            original = &atp.ti->orig_files();
+            deduped = &atp.ti->files();
+#endif
+        }
+
+        if (original == deduped)
+            return mutation_counter;
+
+        for (const lt::file_index_t file_index : original->file_range())
+        {
+            if (original->pad_file_at(file_index))
+                continue;
+            if (original->file_name(file_index) == deduped->file_name(file_index))
+                continue;
+
+            const auto it = atp.renamed_files.lower_bound(file_index);
+            if (it == atp.renamed_files.end() || file_index < it->first)
+            {
+                ++mutation_counter;
+                std::string correction = (action == DedupeAction::Revert) ? original->file_path(file_index) : deduped->file_path(file_index);
+                const auto result = atp.renamed_files.emplace_hint(it, file_index, std::move(correction));
+                qDebug() << "Adding" << atp.ti->name() << "index" << int(file_index) << "to renamed_files:" << result->second;
+            }
+        }
+
+        if (mutation_counter)
+        {
+#ifdef QBT_USES_LIBTORRENT2
+            const QString info_hash = BitTorrent::InfoHash(atp.ti->info_hashes()).toString();
+#else
+            const QString info_hash = BitTorrent::InfoHash(atp.ti->info_hash()).toString();
+#endif
+            LogMsg(QCoreApplication::translate("manageDedupedFilenames", "%1 mutated filenames detected loading torrent: %2 {%3}").arg(mutation_counter).arg(atp.ti->name()).arg(info_hash), Log::WARNING);
+        }
+        return mutation_counter;
+    }
+}

--- a/src/base/bittorrent/managededupedfilenames.h
+++ b/src/base/bittorrent/managededupedfilenames.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <libtorrent/add_torrent_params.hpp>
+
+namespace BitTorrent
+{
+    enum class DedupeAction
+    {
+        Revert,
+        Insert,
+        MagnetInsert
+    };
+
+    int manageDedupedFilenames(lt::add_torrent_params &atp, const DedupeAction action);
+}

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2833,6 +2833,17 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         if (filePaths.isEmpty())
         {
             filePaths = torrentInfo.filePaths();
+            if (Preferences::instance()->isUseDedupedFilenamesEnabled() && !p.renamed_files.empty())
+            {
+                const auto nativeIndexes = torrentInfo.nativeIndexes();
+                for (const auto &[renamedIndex, renamedFile] : p.renamed_files)
+                {
+                    const qsizetype fileIndex = nativeIndexes.indexOf(renamedIndex);
+                    if (fileIndex >= 0)
+                        filePaths[fileIndex] = Path(renamedFile);
+                }
+            }
+
             if (loadTorrentParams.contentLayout != TorrentContentLayout::Original)
             {
                 const Path originalRootFolder = Path::findRootFolder(filePaths);

--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -42,6 +42,7 @@
 #include "base/preferences.h"
 #include "base/utils/io.h"
 #include "infohash.h"
+#include "managededupedfilenames.h"
 #include "trackerentry.h"
 
 namespace
@@ -175,6 +176,8 @@ BitTorrent::TorrentDescriptor::TorrentDescriptor(lt::add_torrent_params ltAddTor
         m_creator = QString::fromStdString(m_ltAddTorrentParams.ti->creator());
         m_comment = QString::fromStdString(m_ltAddTorrentParams.ti->comment());
 #endif
+        if (Preferences::instance()->isUseDedupedFilenamesEnabled())
+            manageDedupedFilenames(m_ltAddTorrentParams, DedupeAction::Insert);
     }
 }
 
@@ -228,6 +231,8 @@ void BitTorrent::TorrentDescriptor::setTorrentInfo(TorrentInfo torrentInfo)
 #else
         m_ltAddTorrentParams.info_hash = m_ltAddTorrentParams.ti->info_hash();
 #endif
+        if (Preferences::instance()->isUseDedupedFilenamesEnabled())
+            manageDedupedFilenames(m_ltAddTorrentParams, DedupeAction::MagnetInsert);
     }
 }
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -73,6 +73,7 @@
 #include "loadtorrentparams.h"
 #include "ltqbitarray.h"
 #include "lttypecast.h"
+#include "managededupedfilenames.h"
 #include "peeraddress.h"
 #include "peerinfo.h"
 #include "sessionimpl.h"
@@ -2199,6 +2200,10 @@ void TorrentImpl::handleSaveResumeData(lt::add_torrent_params params)
     {
         Q_ASSERT(m_indexMap.isEmpty());
 
+        const bool useDedupedFilenames = Preferences::instance()->isUseDedupedFilenamesEnabled();
+        if (useDedupedFilenames)
+            manageDedupedFilenames(params, DedupeAction::MagnetInsert);
+
         const auto isSeedMode = static_cast<bool>(m_ltAddTorrentParams.flags & lt::torrent_flags::seed_mode);
         m_ltAddTorrentParams = std::move(params);
         if (isSeedMode)
@@ -2214,7 +2219,25 @@ void TorrentImpl::handleSaveResumeData(lt::add_torrent_params params)
 
         const auto &renamedFiles = m_ltAddTorrentParams.renamed_files;
         PathList filePaths = metadata.filePaths();
-        if (renamedFiles.empty() && (m_contentLayout != TorrentContentLayout::Original))
+
+        // we are behind the HandleMetadata check here
+        // so i don't understand where renamed_files could come from other than filename deduplication
+        // or why content layout should not be applied if there are renamed_files
+        const auto nativeIndexes = metadata.nativeIndexes();
+        m_indexMap.reserve(filePaths.size());
+        for (qsizetype i = 0; i < filePaths.size(); ++i)
+        {
+            const auto nativeIndex = nativeIndexes.at(i);
+            m_indexMap[nativeIndex] = i;
+
+            if (useDedupedFilenames)
+            {
+                if (const auto it = renamedFiles.find(nativeIndex); it != renamedFiles.cend())
+                    filePaths[i] = Path(it->second);
+            }
+        }
+
+        if (m_contentLayout != TorrentContentLayout::Original)
         {
             const Path originalRootFolder = Path::findRootFolder(filePaths);
             const auto originalContentLayout = (originalRootFolder.isEmpty()
@@ -2226,17 +2249,6 @@ void TorrentImpl::handleSaveResumeData(lt::add_torrent_params params)
                 else
                     Path::addRootFolder(filePaths, filePaths.at(0).removedExtension());
             }
-        }
-
-        const auto nativeIndexes = metadata.nativeIndexes();
-        m_indexMap.reserve(filePaths.size());
-        for (qsizetype i = 0; i < filePaths.size(); ++i)
-        {
-            const auto nativeIndex = nativeIndexes.at(i);
-            m_indexMap[nativeIndex] = i;
-
-            if (const auto it = renamedFiles.find(nativeIndex); it != renamedFiles.cend())
-                filePaths[i] = Path(it->second);
         }
 
         m_session->findIncompleteFiles(savePath(), downloadPath(), filePaths).then(this

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -2176,6 +2176,32 @@ void Preferences::setAddNewTorrentDialogAttached(const bool attached)
     setValue(u"AddNewTorrentDialog/Attached"_s, attached);
 }
 
+bool Preferences::isFixMutatedFilenamesEnabled() const
+{
+    return value(u"Preferences/Advanced/FixMutatedFilenames"_s, true);
+}
+
+void Preferences::setFixMutatedFilenamesEnabled(const bool enabled)
+{
+    if (enabled == isFixMutatedFilenamesEnabled())
+        return;
+
+    setValue(u"Preferences/Advanced/FixMutatedFilenames"_s, enabled);
+}
+
+bool Preferences::isUseDedupedFilenamesEnabled() const
+{
+    return value(u"Preferences/Advanced/UseDedupedFilenames"_s, false);
+}
+
+void Preferences::setUseDedupedFilenamesEnabled(const bool enabled)
+{
+    if (enabled == isUseDedupedFilenamesEnabled())
+        return;
+
+    setValue(u"Preferences/Advanced/UseDedupedFilenames"_s, enabled);
+}
+
 void Preferences::apply()
 {
     if (SettingsStorage::instance()->save())

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -348,6 +348,12 @@ public:
     int getBdecodeTokenLimit() const;
     void setBdecodeTokenLimit(int value);
 
+    // libtorrent filename deduplication
+    bool isFixMutatedFilenamesEnabled() const;
+    void setFixMutatedFilenamesEnabled(bool enabled);
+    bool isUseDedupedFilenamesEnabled() const;
+    void setUseDedupedFilenamesEnabled(bool enabled);
+
     // Stuff that don't appear in the Options GUI but are saved
     // in the same file.
     QDateTime getDNSLastUpd() const;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -820,7 +820,23 @@ void AddNewTorrentDialog::setupTreeview()
 
     BitTorrent::AddTorrentParams &addTorrentParams = m_currentContext->torrentParams;
     if (addTorrentParams.filePaths.isEmpty())
+    {
         addTorrentParams.filePaths = torrentInfo.filePaths();
+        if (Preferences::instance()->isUseDedupedFilenamesEnabled())
+        {
+            const lt::add_torrent_params &p = torrentDescr.ltAddTorrentParams();
+            if (!p.renamed_files.empty())
+            {
+                const auto nativeIndexes = torrentInfo.nativeIndexes();
+                for (const auto &[renamedIndex, renamedFile] : p.renamed_files)
+                {
+                    const qsizetype fileIndex = nativeIndexes.indexOf(renamedIndex);
+                    if (fileIndex >= 0)
+                        addTorrentParams.filePaths[fileIndex] = Path(renamedFile);
+                }
+            }
+        }
+    }
 
     if (addTorrentParams.filePriorities.isEmpty())
     {

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -113,6 +113,9 @@ namespace
         PYTHON_EXECUTABLE_PATH,
         START_SESSION_PAUSED,
         SESSION_SHUTDOWN_TIMEOUT,
+        // libtorrent filename deduplication
+        FIX_MUTATED_FILENAMES,
+        USE_DEDUPED_FILENAMES,
 
         // libtorrent section
         LIBTORRENT_HEADER,
@@ -386,6 +389,10 @@ void AdvancedSettings::saveAdvancedSettings() const
 #endif
 
     session->setTorrentContentRemoveOption(m_comboBoxTorrentContentRemoveOption.currentData().value<BitTorrent::TorrentContentRemoveOption>());
+
+    // libtorrent filename deduplication
+    pref->setFixMutatedFilenamesEnabled(m_checkBoxFixMutatedFilenames.isChecked());
+    pref->setUseDedupedFilenamesEnabled(m_checkBoxUseDedupedFilenames.isChecked());
 }
 
 #ifndef QBT_USES_LIBTORRENT2
@@ -1013,6 +1020,13 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(I2P_OUTBOUND_LENGTH, (tr("I2P outbound length") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#i2p_outbound_length", u"(?)"))
         , &m_spinBoxI2POutboundLength);
 #endif
+    // libtorrent filename deduplication
+    m_checkBoxFixMutatedFilenames.setChecked(pref->isFixMutatedFilenamesEnabled());
+    addRow(FIX_MUTATED_FILENAMES, (tr("Fix libtorrent filename mutations on startup."))
+        , &m_checkBoxFixMutatedFilenames);
+    m_checkBoxUseDedupedFilenames.setChecked(pref->isUseDedupedFilenamesEnabled());
+    addRow(USE_DEDUPED_FILENAMES, (tr("Use libtorrent filename deduplication."))
+        , &m_checkBoxUseDedupedFilenames);
 }
 
 template <typename T>

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -80,7 +80,7 @@ private:
               m_checkBoxTrackerPortForwarding, m_checkBoxIgnoreSSLErrors, m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers,
               m_checkBoxAnnounceAllTiers, m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxSSRFMitigation, m_checkBoxBlockPeersOnPrivilegedPorts,
               m_checkBoxPieceExtentAffinity, m_checkBoxSuggestMode, m_checkBoxSeedingOutgoingConnections, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport,
-              m_checkBoxConfirmRemoveTrackerFromAllTorrents, m_checkBoxStartSessionPaused;
+              m_checkBoxConfirmRemoveTrackerFromAllTorrents, m_checkBoxStartSessionPaused, m_checkBoxFixMutatedFilenames, m_checkBoxUseDedupedFilenames;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxDiskIOReadMode, m_comboBoxDiskIOWriteMode, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage, m_comboBoxTorrentContentRemoveOption;
     QLineEdit m_lineEditAppInstanceName, m_pythonExecutablePath, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes;


### PR DESCRIPTION
This patch fixes #24292 and adds support for filename deduplication.

It adds a function to scan a torrent_info for divergences between files() and orig_files() and add the differences to renamed_files, calls that function wherever metadata is loaded, patches the renamed_files into the user-facing filelist wherever it is generated, and adds a couple advanced settings preferences to turn this behavior on and off.

I am somewhat concerned with handleSaveResumeData() -- I do not understand the purpose of some of its logic so I expect my changes must have broken something somewhere and I just haven't noticed it yet.