### PR TITLE
WebAPI: Accept requests with JSON-encoded body

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,5 +1,10 @@
 # WebAPI Changelog
 
+## 2.16.1
+* [#XXXXX](https://github.com/qbittorrent/qBittorrent/pull/XXXXX)
+  * All WebAPI endpoints now accept request bodies in `application/json` format
+    * List parameters must be sent as JSON arrays (not delimited strings) and scalar parameters as their natural type (string/number/boolean). URL values are sent without percent-encoding
+
 ## 2.16.0
 * [#23989](https://github.com/qbittorrent/qBittorrent/pull/23989)
   * `sync/torrentPeers` endpoint now includes calculated `contribution` to a peer's progress

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(qbt_base STATIC
     utils/fs.h
     utils/gzip.h
     utils/io.h
+    utils/json.h
     utils/misc.h
     utils/net.h
     utils/number.h
@@ -214,6 +215,7 @@ add_library(qbt_base STATIC
     utils/fs.cpp
     utils/gzip.cpp
     utils/io.cpp
+    utils/json.cpp
     utils/misc.cpp
     utils/net.cpp
     utils/number.cpp

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -38,11 +38,16 @@
 #include <QByteArrayList>
 #include <QByteArrayView>
 #include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
 #include <QUrl>
 #include <QUrlQuery>
 
 #include "base/global.h"
 #include "base/utils/bytearray.h"
+#include "base/utils/json.h"
 #include "base/utils/string.h"
 #include "constants.h"
 
@@ -154,6 +159,10 @@ RequestParser::ParseResult RequestParser::doParse(const QByteArrayView data)
                 qWarning() << Q_FUNC_INFO << "message body parsing error";
                 return {ParseStatus::BadRequest, Request(), 0};
             }
+        }
+        else if (m_request.headers.value(HEADER_CONTENT_TYPE).toLower().startsWith(CONTENT_TYPE_JSON))
+        {
+            m_request.isJson = true;
         }
 
         return {ParseStatus::OK, m_request, (headerLength + contentLength)};
@@ -321,6 +330,39 @@ bool RequestParser::parsePostMessage(const QByteArrayView data)
         {
             return this->parseFormData(part);
         });
+    }
+
+    // application/json
+    if (contentTypeLower.startsWith(CONTENT_TYPE_JSON))
+    {
+        QJsonParseError parseError;
+        const QJsonDocument doc = QJsonDocument::fromJson(QByteArray::fromRawData(data.constData(), data.size()), &parseError);
+        if (parseError.error != QJsonParseError::NoError)
+        {
+            qWarning() << Q_FUNC_INFO << "invalid JSON body:" << parseError.errorString();
+            return false;
+        }
+        if (!doc.isObject())
+        {
+            // params are name/value pairs, so the top-level JSON value must be an object
+            qWarning() << Q_FUNC_INFO << "JSON body must be an object";
+            return false;
+        }
+
+        m_request.isJson = true;
+
+        const QJsonObject object = doc.object();
+        m_request.jsonBody = object;
+        m_request.posts.reserve(object.size());
+        for (auto it = object.constBegin(); it != object.constEnd(); ++it)
+        {
+            // treat a JSON null as an omitted field
+            if (it.value().isNull())
+                continue;
+            m_request.posts[it.key()] = Utils::Json::flattenValue(it.value());
+        }
+
+        return true;
     }
 
     qWarning() << Q_FUNC_INFO << "unknown content type:" << contentType;

--- a/src/base/utils/json.cpp
+++ b/src/base/utils/json.cpp
@@ -1,7 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2014-2026  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2018  Mike Tzou (Chocobo1)
+ * Copyright (C) 2026  Thomas Piccirello <thomas@piccirello.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,35 +26,36 @@
  * exception statement from your version.
  */
 
-#pragma once
+#include "json.h"
 
-#include <QByteArray>
-#include <QHash>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <QJsonObject>
-#include <QList>
-#include <QString>
+#include <QVariant>
 
-#include "headermap.h"
+#include "base/global.h"
 
-namespace Http
+QString Utils::Json::flattenValue(const QJsonValue &value)
 {
-    struct UploadedFile
+    switch (value.type())
     {
-        QString filename;
-        QString type;  // MIME type
-        QByteArray data;
-    };
-
-    struct Request
-    {
-        QString version;
-        QString method;
-        QString path;
-        HeaderMap headers;
-        QHash<QString, QByteArray> query;
-        QHash<QString, QString> posts;
-        QList<UploadedFile> files;
-        bool isJson = false;  // whether content type was application/json
-        QJsonObject jsonBody;  // the parsed JSON body
-    };
+    case QJsonValue::String:
+        return value.toString();
+    case QJsonValue::Bool:
+        return value.toBool() ? u"true"_s : u"false"_s;
+    case QJsonValue::Double:
+        {
+            // use `toInteger()` because `toVariant()` can emit scientific notation
+            const double number = value.toDouble();
+            if (const qint64 integer = value.toInteger(); static_cast<double>(integer) == number)
+                return QString::number(integer);
+            return value.toVariant().toString();
+        }
+    case QJsonValue::Array:
+        return QString::fromUtf8(QJsonDocument(value.toArray()).toJson(QJsonDocument::Compact));
+    case QJsonValue::Object:
+        return QString::fromUtf8(QJsonDocument(value.toObject()).toJson(QJsonDocument::Compact));
+    default:
+        return {};
+    }
 }

--- a/src/base/utils/json.h
+++ b/src/base/utils/json.h
@@ -1,7 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2014-2026  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2018  Mike Tzou (Chocobo1)
+ * Copyright (C) 2026  Thomas Piccirello <thomas@piccirello.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,33 +28,10 @@
 
 #pragma once
 
-#include <QByteArray>
-#include <QHash>
-#include <QJsonObject>
-#include <QList>
+#include <QJsonValue>
 #include <QString>
 
-#include "headermap.h"
-
-namespace Http
+namespace Utils::Json
 {
-    struct UploadedFile
-    {
-        QString filename;
-        QString type;  // MIME type
-        QByteArray data;
-    };
-
-    struct Request
-    {
-        QString version;
-        QString method;
-        QString path;
-        HeaderMap headers;
-        QHash<QString, QByteArray> query;
-        QHash<QString, QString> posts;
-        QList<UploadedFile> files;
-        bool isJson = false;  // whether content type was application/json
-        QJsonObject jsonBody;  // the parsed JSON body
-    };
+    QString flattenValue(const QJsonValue &value);
 }

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -31,11 +31,17 @@
 #include <utility>
 
 #include <QHash>
+#include <QJsonArray>
 #include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
 #include <QList>
 #include <QMetaObject>
 #include <QScopeGuard>
+#include <QStringList>
+#include <QUrl>
 
+#include "base/utils/json.h"
 #include "apierror.h"
 
 using namespace Qt::Literals::StringLiterals;
@@ -45,14 +51,18 @@ APIController::APIController(IApplication *app, QObject *parent)
 {
 }
 
-APIResult APIController::run(const QString &action, const StringMap &params, const DataMap &data)
+APIResult APIController::run(const QString &action, const APIRequest &request)
 {
-    m_params = params;
-    m_data = data;
+    m_params = request.params;
+    m_data = request.data;
+    m_isJson = request.isJson;
+    m_jsonBody = request.jsonBody;
     [[maybe_unused]] const auto inputsGuard = qScopeGuard([this]
     {
         m_params = {};
         m_data = {};
+        m_isJson = false;
+        m_jsonBody = {};
     });
 
     const QByteArray methodName = action.toLatin1() + "Action";
@@ -72,6 +82,17 @@ const DataMap &APIController::data() const
     return m_data;
 }
 
+bool APIController::isJsonRequest() const
+{
+    return m_isJson;
+}
+
+void APIController::rejectArrayParam(const QString &key) const
+{
+    if (m_jsonBody.value(key).isArray())
+        throw APIError(APIErrorType::BadParams, tr("Parameter '%1' must not be a JSON array").arg(key));
+}
+
 void APIController::requireParams(const QList<QString> &requiredParams) const
 {
     QStringList missingParams;
@@ -85,6 +106,47 @@ void APIController::requireParams(const QList<QString> &requiredParams) const
 
     if (!missingParams.isEmpty())
         throw APIError(APIErrorType::BadParams, tr("Missing required parameters: %1").arg(missingParams.join(u", ")));
+}
+
+QStringList APIController::parseList(const QString &key, const QChar separator, const Qt::SplitBehavior behavior) const
+{
+    if (isJsonRequest())
+    {
+        const QJsonValue value = m_jsonBody.value(key);
+        // undefined/null = not provided
+        if (value.isUndefined() || value.isNull())
+            return {};
+        if (!value.isArray())
+            throw APIError(APIErrorType::BadParams, tr("Parameter '%1' must be a JSON array").arg(key));
+
+        const QJsonArray array = value.toArray();
+        QStringList result;
+        result.reserve(array.size());
+        for (const QJsonValue &item : array)
+        {
+            if (!item.isString() && !item.isBool() && !item.isDouble())
+                throw APIError(APIErrorType::BadParams, tr("List parameters must only contain strings, numbers or booleans"));
+            result.append(Utils::Json::flattenValue(item));
+        }
+        if (behavior == Qt::SkipEmptyParts)
+            result.removeIf([](const QString &element) { return element.isEmpty(); });
+        return result;
+    }
+
+    return params().value(key).split(separator, behavior);
+}
+
+QStringList APIController::parseUrlList(const QString &key, const QChar separator, const Qt::SplitBehavior behavior) const
+{
+    QStringList urls = parseList(key, separator, behavior);
+    for (QString &url : urls)
+        url = decodeUrl(url);
+    return urls;
+}
+
+QString APIController::decodeUrl(const QString &value) const
+{
+    return isJsonRequest() ? value : QUrl::fromPercentEncoding(value.toLatin1());
 }
 
 void APIController::setResult(const QString &result)

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -31,6 +31,7 @@
 #include <variant>
 
 #include <QtContainerFwd>
+#include <QJsonObject>
 #include <QObject>
 #include <QString>
 #include <QVariant>
@@ -41,6 +42,14 @@
 
 using DataMap = QHash<QString, QByteArray>;
 using StringMap = QHash<QString, QString>;
+
+struct APIRequest
+{
+    StringMap params {};
+    DataMap data {};
+    bool isJson = false;
+    QJsonObject jsonBody {};
+};
 
 struct RegularAPIResult
 {
@@ -65,12 +74,18 @@ class APIController : public ApplicationComponent<QObject>
 public:
     explicit APIController(IApplication *app, QObject *parent = nullptr);
 
-    APIResult run(const QString &action, const StringMap &params, const DataMap &data = {});
+    APIResult run(const QString &action, const APIRequest &request);
 
 protected:
     const StringMap &params() const;
     const DataMap &data() const;
+    bool isJsonRequest() const;
     void requireParams(const QList<QString> &requiredParams) const;
+    void rejectArrayParam(const QString &key) const;
+
+    QStringList parseList(const QString &key, QChar separator, Qt::SplitBehavior behavior = Qt::KeepEmptyParts) const;
+    QStringList parseUrlList(const QString &key, QChar separator, Qt::SplitBehavior behavior = Qt::SkipEmptyParts) const;
+    QString decodeUrl(const QString &value) const;
 
     void setResult(const QString &result);
     void setResult(const QJsonArray &result);
@@ -83,5 +98,7 @@ protected:
 private:
     StringMap m_params;
     DataMap m_data;
+    bool m_isJson = false;
+    QJsonObject m_jsonBody;
     APIResult m_result;
 };

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -85,6 +85,29 @@ const QString KEY_FILE_METADATA_CREATION_DATE = u"creation_date"_s;
 const QString KEY_FILE_METADATA_LAST_ACCESS_DATE = u"last_access_date"_s;
 const QString KEY_FILE_METADATA_LAST_MODIFICATION_DATE = u"last_modification_date"_s;
 
+namespace
+{
+    // A list preference may arrive as a native JSON array (elements returned directly) or a delimited
+    // string (split by `separator`). A JSON request must use an array; a delimited string is rejected.
+    template <typename Separator>
+    QStringList parseListPreference(const QVariant &value, const Separator &separator
+            , const bool jsonRequest, const Qt::SplitBehavior behavior = Qt::KeepEmptyParts)
+    {
+        if (value.typeId() == QMetaType::QVariantList)
+        {
+            QStringList result = value.toStringList();
+            if (behavior == Qt::SkipEmptyParts)
+                result.removeIf([](const QString &element) { return element.isEmpty(); });
+            return result;
+        }
+
+        if (jsonRequest)
+            throw APIError(APIErrorType::BadParams, QCoreApplication::translate("AppController", "List preferences must be sent as JSON arrays"));
+
+        return value.toString().split(separator, behavior);
+    }
+}
+
 void AppController::webapiVersionAction()
 {
     setResult(API_VERSION.toString());
@@ -663,7 +686,7 @@ void AppController::setPreferencesAction()
     if (hasKey(u"excluded_file_names_enabled"_s))
         session->setExcludedFileNamesEnabled(it.value().toBool());
     if (hasKey(u"excluded_file_names"_s))
-        session->setExcludedFileNames(it.value().toString().split(u'\n'));
+        session->setExcludedFileNames(parseListPreference(it.value(), u'\n', isJsonRequest()));
 
     // Email notification upon download completion
     if (hasKey(u"mail_notification_enabled"_s))
@@ -774,7 +797,7 @@ void AppController::setPreferencesAction()
     if (hasKey(u"ip_filter_trackers"_s))
         session->setTrackerFilteringEnabled(it.value().toBool());
     if (hasKey(u"banned_IPs"_s))
-        session->setBannedIPs(it.value().toString().split(u'\n', Qt::SkipEmptyParts));
+        session->setBannedIPs(parseListPreference(it.value(), u'\n', isJsonRequest(), Qt::SkipEmptyParts));
 
     // Speed
     // Global Rate Limits
@@ -924,7 +947,7 @@ void AppController::setPreferencesAction()
     if (hasKey(u"bypass_auth_subnet_whitelist"_s))
     {
         // recognize new lines and commas as delimiters
-        pref->setWebUIAuthSubnetWhitelist(it.value().toString().split(QRegularExpression(u"\n|,"_s), Qt::SkipEmptyParts));
+        pref->setWebUIAuthSubnetWhitelist(parseListPreference(it.value(), QRegularExpression(u"\n|,"_s), isJsonRequest(), Qt::SkipEmptyParts));
     }
     if (hasKey(u"web_ui_max_auth_fail_count"_s))
         pref->setWebUIMaxAuthFailCount(it.value().toInt());
@@ -981,7 +1004,7 @@ void AppController::setPreferencesAction()
     if (hasKey(u"rss_download_repack_proper_episodes"_s))
         RSS::AutoDownloader::instance()->setDownloadRepacks(it.value().toBool());
     if (hasKey(u"rss_smart_episode_filters"_s))
-        RSS::AutoDownloader::instance()->setSmartEpisodeFilters(it.value().toString().split(u'\n'));
+        RSS::AutoDownloader::instance()->setSmartEpisodeFilters(parseListPreference(it.value(), u'\n', isJsonRequest()));
 
     // Advanced settings
     // qBittorrent preferences

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -91,7 +91,7 @@ void SearchController::startAction()
 
     const QString pattern = params()[u"pattern"_s].trimmed();
     const QString category = params()[u"category"_s].trimmed();
-    const QStringList plugins = params()[u"plugins"_s].split(u'|');
+    const QStringList plugins = parseList(u"plugins"_s, u'|');
 
     QStringList pluginsToUse;
     if (plugins.size() == 1)
@@ -256,7 +256,7 @@ void SearchController::installPluginAction()
 {
     requireParams({u"sources"_s});
 
-    const QStringList sources = params()[u"sources"_s].split(u'|');
+    const QStringList sources = parseList(u"sources"_s, u'|');
     for (const QString &source : sources)
         SearchPluginManager::instance()->installPlugin(source);
 
@@ -267,7 +267,7 @@ void SearchController::uninstallPluginAction()
 {
     requireParams({u"names"_s});
 
-    const QStringList names = params()[u"names"_s].split(u'|');
+    const QStringList names = parseList(u"names"_s, u'|');
     for (const QString &name : names)
         SearchPluginManager::instance()->uninstallPlugin(name.trimmed());
 
@@ -278,7 +278,7 @@ void SearchController::enablePluginAction()
 {
     requireParams({u"names"_s, u"enable"_s});
 
-    const QStringList names = params()[u"names"_s].split(u'|');
+    const QStringList names = parseList(u"names"_s, u'|');
     const bool enable = Utils::String::parseBool(params()[u"enable"_s].trimmed()).value_or(false);
 
     for (const QString &name : names)

--- a/src/webui/api/torrentcreatorcontroller.cpp
+++ b/src/webui/api/torrentcreatorcontroller.cpp
@@ -32,7 +32,6 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QStringList>
-#include <QUrl>
 
 #include "base/global.h"
 #include "base/bittorrent/torrentcreationmanager.h"
@@ -91,17 +90,6 @@ namespace
     }
 #endif
 
-    QStringList parseUrls(const QString &urlsParam)
-    {
-        // Empty lines are preserved because they indicate new tracker tier and will be ignored in url seeds.
-        const QStringList encodedUrls = urlsParam.split(u'|');
-        QStringList urls;
-        urls.reserve(encodedUrls.size());
-        for (const QString &urlStr : encodedUrls)
-            urls << QUrl::fromPercentEncoding(urlStr.toLatin1());
-        return urls;
-    }
-
     QString taskStatusString(const std::shared_ptr<BitTorrent::TorrentCreationTask> task)
     {
         if (task->isFailed())
@@ -145,8 +133,9 @@ void TorrentCreatorController::addTaskAction()
         .torrentFilePath = Path(params()[KEY_TORRENT_FILE_PATH]),
         .comment = params()[KEY_COMMENT],
         .source = params()[KEY_SOURCE],
-        .trackers = parseUrls(params()[KEY_TRACKERS]),
-        .urlSeeds = parseUrls(params()[KEY_URL_SEEDS])
+        // keep empty `|`-segments: they mark tracker tiers (ignored for url seeds)
+        .trackers = parseUrlList(KEY_TRACKERS, u'|', Qt::KeepEmptyParts),
+        .urlSeeds = parseUrlList(KEY_URL_SEEDS, u'|', Qt::KeepEmptyParts)
     };
 
     const bool startSeeding = parseBool(params()[u"startSeeding"_s]).value_or(createTorrentParams.torrentFilePath.isEmpty());

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -383,11 +383,9 @@ namespace
 
     nonstd::expected<QUrl, QString> validateWebSeedUrl(const QString &urlStr)
     {
-        const QString normalizedUrlStr = QUrl::fromPercentEncoding(urlStr.toLatin1());
-
-        const QUrl url {normalizedUrlStr, QUrl::StrictMode};
+        const QUrl url {urlStr, QUrl::StrictMode};
         if (!url.isValid())
-            return nonstd::make_unexpected(TorrentsController::tr("\"%1\" is not a valid URL").arg(normalizedUrlStr));
+            return nonstd::make_unexpected(TorrentsController::tr("\"%1\" is not a valid URL").arg(urlStr));
 
         if (!SUPPORTED_WEB_SEED_SCHEMES.contains(url.scheme()))
             return nonstd::make_unexpected(TorrentsController::tr("URL scheme must be one of [%1]").arg(SUPPORTED_WEB_SEED_SCHEMES.values().join(u", ")));
@@ -613,7 +611,7 @@ void TorrentsController::infoAction()
     const bool reverse {parseBool(params()[u"reverse"_s]).value_or(false)};
     int limit {params()[u"limit"_s].toInt()};
     int offset {params()[u"offset"_s].toInt()};
-    const QStringList hashes {params()[u"hashes"_s].split(u'|', Qt::SkipEmptyParts)};
+    const QStringList hashes {parseList(u"hashes"_s, u'|', Qt::SkipEmptyParts)};
     const std::optional<bool> isPrivate = parseBool(params()[u"private"_s]);
     const bool includeFiles = parseBool(params()[u"includeFiles"_s]).value_or(false);
     const bool includeTrackers = parseBool(params()[u"includeTrackers"_s]).value_or(false);
@@ -875,7 +873,7 @@ void TorrentsController::webseedsAction()
 void TorrentsController::addWebSeedsAction()
 {
     requireParams({u"hash"_s, u"urls"_s});
-    const QStringList paramUrls = params()[u"urls"_s].split(u'|', Qt::SkipEmptyParts);
+    const QStringList paramUrls = parseUrlList(u"urls"_s, u'|');
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
     BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
@@ -902,8 +900,8 @@ void TorrentsController::editWebSeedAction()
     requireParams({u"hash"_s, u"origUrl"_s, u"newUrl"_s});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
-    const QString origUrlStr = params()[u"origUrl"_s];
-    const QString newUrlStr = params()[u"newUrl"_s];
+    const QString origUrlStr = decodeUrl(params()[u"origUrl"_s]);
+    const QString newUrlStr = decodeUrl(params()[u"newUrl"_s]);
 
     BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
@@ -934,7 +932,7 @@ void TorrentsController::editWebSeedAction()
 void TorrentsController::removeWebSeedsAction()
 {
     requireParams({u"hash"_s, u"urls"_s});
-    const QStringList paramUrls = params()[u"urls"_s].split(u'|', Qt::SkipEmptyParts);
+    const QStringList paramUrls = parseUrlList(u"urls"_s, u'|');
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
     BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
@@ -983,7 +981,7 @@ void TorrentsController::filesAction()
     if (idxIt != params().cend())
     {
         const int filesCount = torrent->filesCount();
-        const QStringList indexStrings = idxIt.value().split(u'|');
+        const QStringList indexStrings = parseList(u"indexes"_s, u'|');
         fileIndexes.reserve(indexStrings.size());
         for (const QString &indexString : indexStrings)
         {
@@ -1080,7 +1078,7 @@ void TorrentsController::pieceAvailabilityAction()
 
 void TorrentsController::addAction()
 {
-    const QStringList urls = params()[u"urls"_s].split(u'\n', Qt::SkipEmptyParts);
+    const QStringList urls = parseList(u"urls"_s, u'\n', Qt::SkipEmptyParts);
 
     const bool skipChecking = parseBool(params()[u"skip_checking"_s]).value_or(false);
     const bool seqDownload = parseBool(params()[u"sequentialDownload"_s]).value_or(false);
@@ -1092,7 +1090,7 @@ void TorrentsController::addAction()
     const QString downloadPath = params()[u"downloadPath"_s].trimmed();
     const std::optional<bool> useDownloadPath = parseBool(params()[u"useDownloadPath"_s]);
     const QString category = params()[u"category"_s];
-    const QStringList tags = params()[u"tags"_s].split(u',', Qt::SkipEmptyParts);
+    const QStringList tags = parseList(u"tags"_s, u',', Qt::SkipEmptyParts);
     const QString torrentName = params()[u"rename"_s].trimmed();
     const int upLimit = parseInt(params()[u"upLimit"_s]).value_or(-1);
     const int dlLimit = parseInt(params()[u"dlLimit"_s]).value_or(-1);
@@ -1116,7 +1114,7 @@ void TorrentsController::addAction()
     const DataMap &torrents = data();
 
     QList<BitTorrent::DownloadPriority> filePriorities;
-    const QStringList filePrioritiesParam = params()[u"filePriorities"_s].split(u',', Qt::SkipEmptyParts);
+    const QStringList filePrioritiesParam = parseList(u"filePriorities"_s, u',', Qt::SkipEmptyParts);
     if (!filePrioritiesParam.isEmpty())
     {
         if (urls.size() > 1)
@@ -1298,8 +1296,12 @@ void TorrentsController::addAction()
 void TorrentsController::addTrackersAction()
 {
     requireParams({u"hash"_s, u"urls"_s});
+
+    // `urls` is a newline-separated tracker list (blank line = new tier); that tier structure can't be a
+    // flat array, so a JSON array is rejected — send `urls` as a newline-separated string.
+    rejectArrayParam(u"urls"_s);
     const QList<BitTorrent::TrackerEntry> trackers = BitTorrent::parseTrackerEntries(params()[u"urls"_s]);
-    const QStringList idStrings = params()[u"hash"_s].split(u'|');
+    const QStringList idStrings = parseList(u"hash"_s, u'|');
 
     applyToTorrents(idStrings, [&trackers](BitTorrent::Torrent *const torrent) { torrent->addTrackers(trackers); });
 }
@@ -1388,16 +1390,9 @@ void TorrentsController::removeTrackersAction()
 {
     requireParams({u"hash"_s, u"urls"_s});
 
-    QString hash = params()[u"hash"_s];
-    if (hash == u"*"_s)
-        hash = u"all"_s;
-    const QStringList idStrings = hash.split(u'|', Qt::SkipEmptyParts);
-    const QStringList urlsParam = params()[u"urls"_s].split(u'|', Qt::SkipEmptyParts);
-
-    QStringList urls;
-    urls.reserve(urlsParam.size());
-    for (const QString &urlStr : urlsParam)
-        urls << QUrl::fromPercentEncoding(urlStr.toLatin1());
+    const QStringList rawIds = parseList(u"hash"_s, u'|', Qt::SkipEmptyParts);
+    const QStringList idStrings = (rawIds == QStringList {u"*"_s}) ? QStringList {u"all"_s} : rawIds;
+    const QStringList urls = parseUrlList(u"urls"_s, u'|');
 
     applyToTorrents(idStrings, [&urls](BitTorrent::Torrent *const torrent) { torrent->removeTrackers(urls); });
 }
@@ -1406,8 +1401,8 @@ void TorrentsController::addPeersAction()
 {
     requireParams({u"hashes"_s, u"peers"_s});
 
-    const QStringList hashes = params()[u"hashes"_s].split(u'|');
-    const QStringList peers = params()[u"peers"_s].split(u'|');
+    const QStringList hashes = parseList(u"hashes"_s, u'|');
+    const QStringList peers = parseList(u"peers"_s, u'|');
 
     QList<BitTorrent::PeerAddress> peerList;
     peerList.reserve(peers.size());
@@ -1444,7 +1439,7 @@ void TorrentsController::stopAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList hashes = params()[u"hashes"_s].split(u'|');
+    const QStringList hashes = parseList(u"hashes"_s, u'|');
     applyToTorrents(hashes, [](BitTorrent::Torrent *const torrent) { torrent->stop(); });
 
     setResult(QString());
@@ -1454,7 +1449,7 @@ void TorrentsController::startAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList idStrings = params()[u"hashes"_s].split(u'|');
+    const QStringList idStrings = parseList(u"hashes"_s, u'|');
     applyToTorrents(idStrings, [](BitTorrent::Torrent *const torrent) { torrent->start(); });
 
     setResult(QString());
@@ -1480,7 +1475,7 @@ void TorrentsController::filePrioAction()
     const int filesCount = torrent->filesCount();
     QList<BitTorrent::DownloadPriority> priorities = torrent->filePriorities();
     bool priorityChanged = false;
-    for (const QString &fileID : params()[u"id"_s].split(u'|'))
+    for (const QString &fileID : parseList(u"id"_s, u'|'))
     {
         bool ok = false;
         const int id = fileID.toInt(&ok);
@@ -1506,7 +1501,7 @@ void TorrentsController::uploadLimitAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList idList {params()[u"hashes"_s].split(u'|')};
+    const QStringList idList {parseList(u"hashes"_s, u'|')};
     QJsonObject map;
     for (const QString &id : idList)
     {
@@ -1524,7 +1519,7 @@ void TorrentsController::downloadLimitAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList idList {params()[u"hashes"_s].split(u'|')};
+    const QStringList idList {parseList(u"hashes"_s, u'|')};
     QJsonObject map;
     for (const QString &id : idList)
     {
@@ -1546,7 +1541,7 @@ void TorrentsController::setUploadLimitAction()
     if (limit == 0)
         limit = -1;
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     applyToTorrents(hashes, [limit](BitTorrent::Torrent *const torrent) { torrent->setUploadLimit(limit); });
 
     setResult(QString());
@@ -1560,7 +1555,7 @@ void TorrentsController::setDownloadLimitAction()
     if (limit == 0)
         limit = -1;
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     applyToTorrents(hashes, [limit](BitTorrent::Torrent *const torrent) { torrent->setDownloadLimit(limit); });
 
     setResult(QString());
@@ -1578,7 +1573,7 @@ void TorrentsController::setShareLimitsAction()
         .action = Utils::String::toEnum(params()[u"shareLimitAction"_s], BitTorrent::ShareLimitAction::Default)
     };
 
-    const QStringList hashes = params()[u"hashes"_s].split(u'|');
+    const QStringList hashes = parseList(u"hashes"_s, u'|');
 
     applyToTorrents(hashes, [shareLimits](BitTorrent::Torrent *const torrent)
     {
@@ -1592,7 +1587,7 @@ void TorrentsController::toggleSequentialDownloadAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     applyToTorrents(hashes, [](BitTorrent::Torrent *const torrent) { torrent->toggleSequentialDownload(); });
 
     setResult(QString());
@@ -1602,7 +1597,7 @@ void TorrentsController::toggleFirstLastPiecePrioAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     applyToTorrents(hashes, [](BitTorrent::Torrent *const torrent) { torrent->toggleFirstLastPiecePriority(); });
 
     setResult(QString());
@@ -1613,7 +1608,7 @@ void TorrentsController::setSuperSeedingAction()
     requireParams({u"hashes"_s, u"value"_s});
 
     const bool value {parseBool(params()[u"value"_s]).value_or(false)};
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     applyToTorrents(hashes, [value](BitTorrent::Torrent *const torrent) { torrent->setSuperSeeding(value); });
 
     setResult(QString());
@@ -1624,7 +1619,7 @@ void TorrentsController::setForceStartAction()
     requireParams({u"hashes"_s, u"value"_s});
 
     const bool value {parseBool(params()[u"value"_s]).value_or(false)};
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     applyToTorrents(hashes, [value](BitTorrent::Torrent *const torrent)
     {
         torrent->start(value ? BitTorrent::TorrentOperatingMode::Forced : BitTorrent::TorrentOperatingMode::AutoManaged);
@@ -1637,7 +1632,7 @@ void TorrentsController::deleteAction()
 {
     requireParams({u"hashes"_s, u"deleteFiles"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     const BitTorrent::TorrentRemoveOption deleteOption = parseBool(params()[u"deleteFiles"_s]).value_or(false)
             ? BitTorrent::TorrentRemoveOption::RemoveContent : BitTorrent::TorrentRemoveOption::KeepContent;
     applyToTorrents(hashes, [deleteOption](const BitTorrent::Torrent *torrent)
@@ -1655,7 +1650,7 @@ void TorrentsController::increasePrioAction()
     if (!BitTorrent::Session::instance()->isQueueingSystemEnabled())
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     BitTorrent::Session::instance()->increaseTorrentsQueuePos(toTorrentIDs(hashes));
 
     setResult(QString());
@@ -1668,7 +1663,7 @@ void TorrentsController::decreasePrioAction()
     if (!BitTorrent::Session::instance()->isQueueingSystemEnabled())
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     BitTorrent::Session::instance()->decreaseTorrentsQueuePos(toTorrentIDs(hashes));
 
     setResult(QString());
@@ -1681,7 +1676,7 @@ void TorrentsController::topPrioAction()
     if (!BitTorrent::Session::instance()->isQueueingSystemEnabled())
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     BitTorrent::Session::instance()->topTorrentsQueuePos(toTorrentIDs(hashes));
 
     setResult(QString());
@@ -1694,7 +1689,7 @@ void TorrentsController::bottomPrioAction()
     if (!BitTorrent::Session::instance()->isQueueingSystemEnabled())
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     BitTorrent::Session::instance()->bottomTorrentsQueuePos(toTorrentIDs(hashes));
 
     setResult(QString());
@@ -1704,7 +1699,7 @@ void TorrentsController::setLocationAction()
 {
     requireParams({u"hashes"_s, u"location"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     const Path newLocation {params()[u"location"_s].trimmed()};
 
     if (newLocation.isEmpty())
@@ -1729,7 +1724,7 @@ void TorrentsController::setSavePathAction()
 {
     requireParams({u"id"_s, u"path"_s});
 
-    const QStringList ids {params()[u"id"_s].split(u'|')};
+    const QStringList ids {parseList(u"id"_s, u'|')};
     const Path newPath {params()[u"path"_s]};
 
     if (newPath.isEmpty())
@@ -1756,7 +1751,7 @@ void TorrentsController::setDownloadPathAction()
 {
     requireParams({u"id"_s, u"path"_s});
 
-    const QStringList ids {params()[u"id"_s].split(u'|')};
+    const QStringList ids {parseList(u"id"_s, u'|')};
     const Path newPath {params()[u"path"_s]};
 
     if (!newPath.isEmpty())
@@ -1803,7 +1798,7 @@ void TorrentsController::setCommentAction()
 {
     requireParams({u"hashes"_s, u"comment"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     const QString comment = params()[u"comment"_s].trimmed();
 
     applyToTorrents(hashes, [&comment](BitTorrent::Torrent *const torrent)
@@ -1816,7 +1811,7 @@ void TorrentsController::setAutoManagementAction()
 {
     requireParams({u"hashes"_s, u"enable"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     const bool isEnabled {parseBool(params()[u"enable"_s]).value_or(false)};
 
     applyToTorrents(hashes, [isEnabled](BitTorrent::Torrent *const torrent)
@@ -1831,7 +1826,7 @@ void TorrentsController::recheckAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     applyToTorrents(hashes, [](BitTorrent::Torrent *const torrent) { torrent->forceRecheck(); });
 
     setResult(QString());
@@ -1841,13 +1836,9 @@ void TorrentsController::reannounceAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
-    const QStringList urlsParam {params()[u"urls"_s].split(u'|', Qt::SkipEmptyParts)};
-
-    QSet<QString> urls;
-    urls.reserve(urlsParam.size());
-    for (const QString &urlStr : urlsParam)
-        urls << QUrl::fromPercentEncoding(urlStr.toLatin1());
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
+    const QStringList urlList {parseUrlList(u"urls"_s, u'|')};
+    const QSet<QString> urls {urlList.cbegin(), urlList.cend()};
 
     applyToTorrents(hashes, [&urls](BitTorrent::Torrent *const torrent)
     {
@@ -1875,7 +1866,7 @@ void TorrentsController::setCategoryAction()
 {
     requireParams({u"hashes"_s, u"category"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
     const QString category {params()[u"category"_s]};
 
     applyToTorrents(hashes, [category](BitTorrent::Torrent *const torrent)
@@ -1942,7 +1933,7 @@ void TorrentsController::removeCategoriesAction()
 {
     requireParams({u"categories"_s});
 
-    const QStringList categories {params()[u"categories"_s].split(u'\n')};
+    const QStringList categories {parseList(u"categories"_s, u'\n')};
     for (const QString &category : categories)
         BitTorrent::Session::instance()->removeCategory(category);
 
@@ -1972,8 +1963,8 @@ void TorrentsController::addTagsAction()
 {
     requireParams({u"hashes"_s, u"tags"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
-    const QStringList tags {params()[u"tags"_s].split(u',', Qt::SkipEmptyParts)};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
+    const QStringList tags {parseList(u"tags"_s, u',', Qt::SkipEmptyParts)};
 
     for (const QString &tagStr : tags)
     {
@@ -1990,8 +1981,8 @@ void TorrentsController::setTagsAction()
 {
     requireParams({u"hashes"_s, u"tags"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|', Qt::SkipEmptyParts)};
-    const QStringList tags {params()[u"tags"_s].split(u',', Qt::SkipEmptyParts)};
+    const QStringList hashes {parseList(u"hashes"_s, u'|', Qt::SkipEmptyParts)};
+    const QStringList tags {parseList(u"tags"_s, u',', Qt::SkipEmptyParts)};
 
     const TagSet newTags {tags.begin(), tags.end()};
     applyToTorrents(hashes, [&newTags](BitTorrent::Torrent *const torrent)
@@ -2011,8 +2002,8 @@ void TorrentsController::removeTagsAction()
 {
     requireParams({u"hashes"_s});
 
-    const QStringList hashes {params()[u"hashes"_s].split(u'|')};
-    const QStringList tags {params()[u"tags"_s].split(u',', Qt::SkipEmptyParts)};
+    const QStringList hashes {parseList(u"hashes"_s, u'|')};
+    const QStringList tags {parseList(u"tags"_s, u',', Qt::SkipEmptyParts)};
 
     for (const QString &tagStr : tags)
     {
@@ -2037,7 +2028,7 @@ void TorrentsController::createTagsAction()
 {
     requireParams({u"tags"_s});
 
-    const QStringList tags {params()[u"tags"_s].split(u',', Qt::SkipEmptyParts)};
+    const QStringList tags {parseList(u"tags"_s, u',', Qt::SkipEmptyParts)};
 
     for (const QString &tagStr : tags)
         BitTorrent::Session::instance()->addTag(Tag(tagStr));
@@ -2049,7 +2040,7 @@ void TorrentsController::deleteTagsAction()
 {
     requireParams({u"tags"_s});
 
-    const QStringList tags {params()[u"tags"_s].split(u',', Qt::SkipEmptyParts)};
+    const QStringList tags {parseList(u"tags"_s, u',', Qt::SkipEmptyParts)};
     for (const QString &tagStr : tags)
         BitTorrent::Session::instance()->removeTag(Tag(tagStr));
 
@@ -2191,7 +2182,7 @@ void TorrentsController::fetchMetadataAction()
     if (!downloaderParam.isEmpty() && !SearchPluginManager::instance()->allPlugins().contains(downloaderParam))
         throw APIError(APIErrorType::BadParams, tr("downloader must be a valid search plugin"));
 
-    const QString source = QUrl::fromPercentEncoding(sourceParam.toLatin1());
+    const QString source = decodeUrl(sourceParam);
     const auto sourceTorrentDescr = BitTorrent::TorrentDescriptor::parse(source);
 
     const BitTorrent::InfoHash infoHash = sourceTorrentDescr ? sourceTorrentDescr.value().infoHash() : m_torrentSourceCache.value(source);
@@ -2295,7 +2286,7 @@ void TorrentsController::saveMetadataAction()
     if (sourceParam.isEmpty())
         throw APIError(APIErrorType::BadParams, tr("Must specify URI or hash"));
 
-    const QString source = QUrl::fromPercentEncoding(sourceParam.toLatin1());
+    const QString source = decodeUrl(sourceParam);
 
     BitTorrent::InfoHash infoHash;
     if (const auto iter = m_torrentSourceCache.constFind(source); iter != m_torrentSourceCache.constEnd())

--- a/src/webui/api/transfercontroller.cpp
+++ b/src/webui/api/transfercontroller.cpp
@@ -180,7 +180,7 @@ void TransferController::banPeersAction()
 {
     requireParams({u"peers"_s});
 
-    const QStringList peers = params()[u"peers"_s].split(u'|');
+    const QStringList peers = parseList(u"peers"_s, u'|');
     for (const QString &peer : peers)
     {
         const BitTorrent::PeerAddress addr = BitTorrent::PeerAddress::parse(peer.trimmed());

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -377,7 +377,7 @@ void WebApplication::processAPIRequest(const QString &endpoint, const Http::Head
 
     try
     {
-        const APIResult apiResult = controller->run(action, params, data);
+        const APIResult apiResult = controller->run(action, {.params = params, .data = data, .isJson = m_request.isJson, .jsonBody = m_request.jsonBody});
         if (std::holds_alternative<StreamFileAPIResult>(apiResult))
         {
             const auto result = std::get<StreamFileAPIResult>(apiResult);

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -58,7 +58,7 @@
 using namespace std::chrono_literals;
 using namespace Qt::Literals::StringLiterals;
 
-inline const Utils::Version<3, 2> API_VERSION {2, 16, 0};
+inline const Utils::Version<3, 2> API_VERSION {2, 16, 1};
 
 class QNetworkCookie;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(testFiles
     testconceptsexplicitlyconvertibleto.cpp
     testconceptsstringable.cpp
     testglobal.cpp
+    testhttprequestparser.cpp
     testorderedset.cpp
     testpath.cpp
     testutilsbytearray.cpp
@@ -19,6 +20,7 @@ set(testFiles
     testutilsdatetime.cpp
     testutilsgzip.cpp
     testutilsio.cpp
+    testutilsjson.cpp
     testutilsmisc.cpp
     testutilsnumber.cpp
     testutilsstring.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,3 +36,12 @@ foreach(testFile ${testFiles})
 
     add_dependencies(check "${testFilename}")
 endforeach()
+
+# testapicontroller exercises APIController (parseList / JSON-array params), which lives in the
+# webui library, so unlike the other tests it must also link qbt_webui.
+if (TARGET qbt_webui)
+    add_executable(testapicontroller testapicontroller.cpp)
+    target_link_libraries(testapicontroller PRIVATE Qt::Test qbt_webui qbt_base)
+    add_test(NAME testapicontroller COMMAND testapicontroller)
+    add_dependencies(check testapicontroller)
+endif()

--- a/test/testapicontroller.cpp
+++ b/test/testapicontroller.cpp
@@ -1,0 +1,281 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Thomas Piccirello <thomas@piccirello.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QByteArray>
+#include <QChar>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QObject>
+#include <QStringList>
+#include <QTest>
+
+#include "base/global.h"
+#include "webui/api/apicontroller.h"
+#include "webui/api/apierror.h"
+
+// The parse helpers are protected and only valid during run(), so we drive them through Q_INVOKABLE
+// actions; app() is never touched, so a null IApplication is fine.
+class ParseListHarness final : public APIController
+{
+    Q_OBJECT
+
+public:
+    using APIController::APIController;
+
+    QStringList listResult;
+
+    Q_INVOKABLE void splitAction()
+    {
+        const QString sepStr = params().value(u"sep"_s);
+        const QChar separator = sepStr.isEmpty() ? u'|' : sepStr.front();
+        const Qt::SplitBehavior behavior = (params().value(u"skip"_s) == u"1"_s)
+            ? Qt::SkipEmptyParts : Qt::KeepEmptyParts;
+        listResult = parseList(u"value"_s, separator, behavior);
+    }
+
+    Q_INVOKABLE void urlListAction()
+    {
+        const QString sepStr = params().value(u"sep"_s);
+        const QChar separator = sepStr.isEmpty() ? u'|' : sepStr.front();
+        const Qt::SplitBehavior behavior = (params().value(u"keep"_s) == u"1"_s)
+            ? Qt::KeepEmptyParts : Qt::SkipEmptyParts;
+        listResult = parseUrlList(u"value"_s, separator, behavior);
+    }
+
+    Q_INVOKABLE void rejectArrayAction()
+    {
+        rejectArrayParam(u"value"_s);
+    }
+};
+
+namespace
+{
+    QString skipFlag(const Qt::SplitBehavior behavior)
+    {
+        return (behavior == Qt::SkipEmptyParts) ? u"1"_s : u"0"_s;
+    }
+
+    QString keepFlag(const Qt::SplitBehavior behavior)
+    {
+        return (behavior == Qt::KeepEmptyParts) ? u"1"_s : u"0"_s;
+    }
+
+    // parses `json` into a QJsonValue with its real type
+    QJsonValue toJsonValue(const QByteArray &json)
+    {
+        return QJsonDocument::fromJson("{\"v\":" + json + '}').object().value(u"v"_s);
+    }
+
+    QStringList parseListForm(const QString &value, const QChar separator, const Qt::SplitBehavior behavior)
+    {
+        ParseListHarness harness {nullptr};
+        harness.run(u"split"_s, {.params = {{u"value"_s, value}, {u"sep"_s, QString(separator)}
+            , {u"skip"_s, skipFlag(behavior)}}, .isJson = false});
+        return harness.listResult;
+    }
+
+    QStringList parseListJson(const QJsonValue &value, const QChar separator, const Qt::SplitBehavior behavior)
+    {
+        ParseListHarness harness {nullptr};
+        harness.run(u"split"_s, {.params = {{u"sep"_s, QString(separator)}, {u"skip"_s, skipFlag(behavior)}}
+            , .isJson = true, .jsonBody = QJsonObject {{u"value"_s, value}}});
+        return harness.listResult;
+    }
+
+    QStringList parseUrlListForm(const QString &value, const QChar separator
+            , const Qt::SplitBehavior behavior = Qt::SkipEmptyParts)
+    {
+        ParseListHarness harness {nullptr};
+        harness.run(u"urlList"_s, {.params = {{u"value"_s, value}, {u"sep"_s, QString(separator)}
+            , {u"keep"_s, keepFlag(behavior)}}, .isJson = false});
+        return harness.listResult;
+    }
+
+    QStringList parseUrlListJson(const QJsonValue &value, const QChar separator
+            , const Qt::SplitBehavior behavior = Qt::SkipEmptyParts)
+    {
+        ParseListHarness harness {nullptr};
+        harness.run(u"urlList"_s, {.params = {{u"sep"_s, QString(separator)}, {u"keep"_s, keepFlag(behavior)}}
+            , .isJson = true, .jsonBody = QJsonObject {{u"value"_s, value}}});
+        return harness.listResult;
+    }
+}
+
+class TestApiController final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestApiController)
+
+public:
+    TestApiController() = default;
+
+private slots:
+    // Core promise: a form delimited string and a JSON array produce the identical QStringList.
+    void testListEquivalence_data() const
+    {
+        QTest::addColumn<QString>("formValue");
+        QTest::addColumn<QByteArray>("jsonArray");
+        QTest::addColumn<QChar>("separator");
+        QTest::addColumn<bool>("skipEmpty");
+        QTest::addColumn<QStringList>("expected");
+
+        QTest::newRow("pipe")
+            << u"a|b|c"_s << R"(["a","b","c"])"_ba << QChar(u'|') << false << QStringList {u"a"_s, u"b"_s, u"c"_s};
+        // filePriorities: comma-delimited string vs JSON array of numbers
+        QTest::newRow("comma numbers")
+            << u"0,1,7"_s << "[0,1,7]"_ba << QChar(u',') << true << QStringList {u"0"_s, u"1"_s, u"7"_s};
+        QTest::newRow("skip empty parts")
+            << u"a||b"_s << R"(["a","","b"])"_ba << QChar(u'|') << true << QStringList {u"a"_s, u"b"_s};
+        QTest::newRow("keep empty parts")
+            << u"a||b"_s << R"(["a","","b"])"_ba << QChar(u'|') << false << QStringList {u"a"_s, u""_s, u"b"_s};
+        // torrents/add `urls` and torrents/removeCategories `categories` split on '\n'
+        QTest::newRow("newline")
+            << u"a\nb\nc"_s << R"(["a","b","c"])"_ba << QChar(u'\n') << true << QStringList {u"a"_s, u"b"_s, u"c"_s};
+    }
+
+    void testListEquivalence() const
+    {
+        QFETCH(QString, formValue);
+        QFETCH(QByteArray, jsonArray);
+        QFETCH(QChar, separator);
+        QFETCH(bool, skipEmpty);
+        QFETCH(QStringList, expected);
+
+        const Qt::SplitBehavior behavior = skipEmpty ? Qt::SkipEmptyParts : Qt::KeepEmptyParts;
+        QCOMPARE(parseListForm(formValue, separator, behavior), expected);
+        QCOMPARE(parseListJson(toJsonValue(jsonArray), separator, behavior), expected);
+    }
+
+    void testJsonArrayNumberAndBoolElements() const
+    {
+        QCOMPARE(parseListJson(toJsonValue("[1,true,false]"_ba), u'|', Qt::KeepEmptyParts)
+            , (QStringList {u"1"_s, u"true"_s, u"false"_s}));
+    }
+
+    void testJsonArrayElementMayContainSeparator() const
+    {
+        // unlike a delimited string, an array element keeps a literal separator character
+        QCOMPARE(parseListJson(toJsonValue(R"(["a|b","c"])"_ba), u'|', Qt::KeepEmptyParts)
+            , (QStringList {u"a|b"_s, u"c"_s}));
+    }
+
+    void testJsonSingleElementArray() const
+    {
+        QCOMPARE(parseListJson(toJsonValue(R"(["solo"])"_ba), u'|', Qt::KeepEmptyParts), (QStringList {u"solo"_s}));
+    }
+
+    // strict: a JSON list parameter must be an array; any scalar or object is rejected
+    void testJsonNonArrayRejected() const
+    {
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(QJsonValue(u"abc"_s), u'|', Qt::KeepEmptyParts));
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(QJsonValue(5), u'|', Qt::KeepEmptyParts));
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(QJsonValue(true), u'|', Qt::KeepEmptyParts));
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(toJsonValue("{}"_ba), u'|', Qt::KeepEmptyParts));
+    }
+
+    void testJsonArrayLikeStringNotReinterpreted() const
+    {
+        // a JSON string that looks like array syntax is still a scalar (detection is by type, not text)
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(QJsonValue(uR"(["a","b"])"_s), u'|', Qt::KeepEmptyParts));
+    }
+
+    void testJsonNonScalarElementRejected() const
+    {
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(toJsonValue(R"(["a",{}])"_ba), u'|', Qt::KeepEmptyParts));
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(toJsonValue(R"(["a",[1]])"_ba), u'|', Qt::KeepEmptyParts));
+        QVERIFY_THROWS_EXCEPTION(APIError, parseListJson(toJsonValue(R"(["a",null])"_ba), u'|', Qt::KeepEmptyParts));
+    }
+
+    void testJsonAbsentOrNullIsEmpty() const
+    {
+        // a null or omitted value is "not provided" -> empty list (requireParams enforces required-ness)
+        QCOMPARE(parseListJson(QJsonValue(QJsonValue::Null), u'|', Qt::KeepEmptyParts), QStringList {});
+
+        ParseListHarness harness {nullptr};  // omitted key
+        harness.run(u"split"_s, {.params = {{u"sep"_s, u"|"_s}}, .isJson = true, .jsonBody = QJsonObject {}});
+        QCOMPARE(harness.listResult, QStringList {});
+    }
+
+    void testFormSplitsLiterally() const
+    {
+        QCOMPARE(parseListForm(u"a|b"_s, u'|', Qt::KeepEmptyParts), (QStringList {u"a"_s, u"b"_s}));
+        // a form value that looks like JSON array text is split literally, never parsed as an array
+        QCOMPARE(parseListForm(uR"(["a","b"])"_s, u'|', Qt::KeepEmptyParts), (QStringList {uR"(["a","b"])"_s}));
+    }
+
+    // parseUrlList: form requests decode each URL; JSON arrays carry raw URLs verbatim.
+    void testUrlListFormIsPercentDecoded() const
+    {
+        QCOMPARE(parseUrlListForm(u"a%20b|c"_s, u'|'), (QStringList {u"a b"_s, u"c"_s}));
+    }
+
+    void testUrlListJsonArrayIsVerbatim() const
+    {
+        QCOMPARE(parseUrlListJson(toJsonValue(R"(["a%20b","c"])"_ba), u'|'), (QStringList {u"a%20b"_s, u"c"_s}));
+    }
+
+    void testUrlListJsonNonArrayRejected() const
+    {
+        // strict: a JSON URL list must be an array, not a delimited string
+        QVERIFY_THROWS_EXCEPTION(APIError, parseUrlListJson(QJsonValue(u"a|b"_s), u'|'));
+    }
+
+    void testUrlListSkipsEmpty() const
+    {
+        QCOMPARE(parseUrlListForm(u"a||c"_s, u'|'), (QStringList {u"a"_s, u"c"_s}));
+        QCOMPARE(parseUrlListJson(toJsonValue(R"(["a","","c"])"_ba), u'|'), (QStringList {u"a"_s, u"c"_s}));
+    }
+
+    void testRejectArrayParam() const
+    {
+        // a param an endpoint reads as a scalar/string (e.g. addTrackers `urls`) rejects a JSON array
+        ParseListHarness arrayHarness {nullptr};
+        QVERIFY_THROWS_EXCEPTION(APIError, arrayHarness.run(u"rejectArray"_s
+            , {.isJson = true, .jsonBody = QJsonObject {{u"value"_s, QJsonArray {u"a"_s}}}}));
+
+        // no-op for a JSON scalar, and for a form request (jsonBody empty)
+        ParseListHarness scalarHarness {nullptr};
+        QVERIFY_THROWS_NO_EXCEPTION(scalarHarness.run(u"rejectArray"_s
+            , {.isJson = true, .jsonBody = QJsonObject {{u"value"_s, u"a"_s}}}));
+        ParseListHarness formHarness {nullptr};
+        QVERIFY_THROWS_NO_EXCEPTION(formHarness.run(u"rejectArray"_s, {.params = {{u"value"_s, u"a"_s}}}));
+    }
+
+    void testUrlListKeepEmptyParts() const
+    {
+        // empty array elements mark tier boundaries (torrent creator); KeepEmptyParts preserves them
+        QCOMPARE(parseUrlListForm(u"a||c"_s, u'|', Qt::KeepEmptyParts), (QStringList {u"a"_s, u""_s, u"c"_s}));
+        QCOMPARE(parseUrlListJson(toJsonValue(R"(["a","","c"])"_ba), u'|', Qt::KeepEmptyParts)
+            , (QStringList {u"a"_s, u""_s, u"c"_s}));
+    }
+};
+
+QTEST_APPLESS_MAIN(TestApiController)
+#include "testapicontroller.moc"

--- a/test/testhttprequestparser.cpp
+++ b/test/testhttprequestparser.cpp
@@ -1,0 +1,188 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Thomas Piccirello <thomas@piccirello.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QByteArray>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QObject>
+#include <QTest>
+
+#include "base/global.h"
+#include "base/http/request.h"
+#include "base/http/requestparser.h"
+
+using namespace Http;
+
+namespace
+{
+    QByteArray makeRequest(const QByteArray &method, const QByteArray &target
+            , const QByteArray &contentType, const QByteArray &body)
+    {
+        QByteArray request = method + ' ' + target + " HTTP/1.1\r\n";
+        request += "Host: localhost\r\n";
+        if (!contentType.isEmpty())
+            request += "Content-Type: " + contentType + "\r\n";
+        request += "Content-Length: " + QByteArray::number(body.size()) + "\r\n";
+        request += "\r\n";
+        request += body;
+        return request;
+    }
+
+    RequestParser::ParseResult parsePost(const QByteArray &contentType, const QByteArray &body)
+    {
+        return RequestParser::parse(makeRequest("POST", "/api/v2/test", contentType, body));
+    }
+}
+
+class TestHttpRequestParser final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestHttpRequestParser)
+
+public:
+    TestHttpRequestParser() = default;
+
+private slots:
+    void testJsonScalars() const
+    {
+        const auto result = parsePost("application/json", R"({"a":"x","b":5,"c":true,"d":false})");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QVERIFY(result.request.isJson);
+        QCOMPARE(result.request.posts.value(u"a"_s), u"x"_s);
+        QCOMPARE(result.request.posts.value(u"b"_s), u"5"_s);
+        QCOMPARE(result.request.posts.value(u"c"_s), u"true"_s);
+        QCOMPARE(result.request.posts.value(u"d"_s), u"false"_s);
+    }
+
+    void testJsonBodyPreservesType() const
+    {
+        // the typed body is kept (so list params read as arrays); posts holds the flattened scalar forms
+        const auto result = parsePost("application/json", R"({"hashes":["a","b"],"name":"x"})");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QVERIFY(result.request.jsonBody.value(u"hashes"_s).isArray());
+        QCOMPARE(result.request.jsonBody.value(u"hashes"_s).toArray().size(), 2);
+        QVERIFY(result.request.jsonBody.value(u"name"_s).isString());
+        QCOMPARE(result.request.posts.value(u"name"_s), u"x"_s);
+    }
+
+    void testJsonNested() const
+    {
+        // nested arrays/objects become compact JSON
+        const auto result = parsePost("application/json", R"({"obj":{"k":1},"arr":[1,2]})");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QCOMPARE(result.request.posts.value(u"obj"_s), u"{\"k\":1}"_s);
+        QCOMPARE(result.request.posts.value(u"arr"_s), u"[1,2]"_s);
+    }
+
+    void testJsonNullSkipped() const
+    {
+        // a JSON null is treated as an omitted field
+        const auto result = parsePost("application/json", R"({"a":"x","b":null})");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QVERIFY(result.request.posts.contains(u"a"_s));
+        QVERIFY(!result.request.posts.contains(u"b"_s));
+    }
+
+    void testJsonEmptyObject() const
+    {
+        const auto result = parsePost("application/json", "{}");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QVERIFY(result.request.isJson);
+        QVERIFY(result.request.posts.isEmpty());
+    }
+
+    void testJsonEmptyBody() const
+    {
+        // an empty application/json body is treated as an empty object
+        const auto result = parsePost("application/json", "");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QVERIFY(result.request.isJson);
+        QVERIFY(result.request.posts.isEmpty());
+    }
+
+    void testInvalidJson() const
+    {
+        const auto result = parsePost("application/json", "{bad");
+        QCOMPARE(result.status, RequestParser::ParseStatus::BadRequest);
+    }
+
+    void testNonObjectJson() const
+    {
+        // a non-object top-level value is rejected
+        QCOMPARE(parsePost("application/json", "[1,2]").status, RequestParser::ParseStatus::BadRequest);
+        QCOMPARE(parsePost("application/json", "\"x\"").status, RequestParser::ParseStatus::BadRequest);
+        QCOMPARE(parsePost("application/json", "5").status, RequestParser::ParseStatus::BadRequest);
+    }
+
+    void testJsonContentTypeWithCharset() const
+    {
+        const auto result = parsePost("application/json; charset=utf-8", R"({"a":"x"})");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QCOMPARE(result.request.posts.value(u"a"_s), u"x"_s);
+    }
+
+    void testJsonUtf8Value() const
+    {
+        const auto result = parsePost("application/json", "{\"name\":\"caf\xC3\xA9\"}");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QCOMPARE(result.request.posts.value(u"name"_s), QString::fromUtf8("caf\xC3\xA9"));
+    }
+
+    void testFormRegression() const
+    {
+        const auto result = parsePost("application/x-www-form-urlencoded", "a=x&b=5&c=true");
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QVERIFY(!result.request.isJson);
+        QCOMPARE(result.request.posts.value(u"a"_s), u"x"_s);
+        QCOMPARE(result.request.posts.value(u"b"_s), u"5"_s);
+        QCOMPARE(result.request.posts.value(u"c"_s), u"true"_s);
+    }
+
+    void testFormAndJsonScalarsAreEquivalent() const
+    {
+        // form and equivalent JSON requests produce identical params
+        const auto formResult = parsePost("application/x-www-form-urlencoded", "a=x&b=5&c=true&d=false");
+        const auto jsonResult = parsePost("application/json", R"({"a":"x","b":5,"c":true,"d":false})");
+        QCOMPARE(formResult.status, RequestParser::ParseStatus::OK);
+        QCOMPARE(jsonResult.status, RequestParser::ParseStatus::OK);
+        QVERIFY(formResult.request.posts == jsonResult.request.posts);
+    }
+
+    void testGetQueryUnaffected() const
+    {
+        const auto result = RequestParser::parse(makeRequest("GET", "/api/v2/test?a=b&c=d", "", ""));
+        QCOMPARE(result.status, RequestParser::ParseStatus::OK);
+        QCOMPARE(result.request.query.value(u"a"_s), QByteArray("b"));
+        QCOMPARE(result.request.query.value(u"c"_s), QByteArray("d"));
+        QVERIFY(result.request.posts.isEmpty());
+    }
+};
+
+QTEST_APPLESS_MAIN(TestHttpRequestParser)
+#include "testhttprequestparser.moc"

--- a/test/testutilsjson.cpp
+++ b/test/testutilsjson.cpp
@@ -1,0 +1,103 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Thomas Piccirello <thomas@piccirello.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QByteArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QObject>
+#include <QTest>
+
+#include "base/global.h"
+#include "base/utils/json.h"
+
+namespace
+{
+    // Parses `{"x": <json>}` and returns x with the real type the parser sees (notably ints as Double).
+    QJsonValue jsonValue(const QByteArray &json)
+    {
+        return QJsonDocument::fromJson("{\"x\":" + json + "}").object().value(u"x"_s);
+    }
+}
+
+class TestUtilsJson final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestUtilsJson)
+
+public:
+    TestUtilsJson() = default;
+
+private slots:
+    void testFlattenString() const
+    {
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("\"hello\"")), u"hello"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("\"\"")), u""_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("\"caf\xC3\xA9\"")), QString::fromUtf8("caf\xC3\xA9"));
+    }
+
+    void testFlattenBool() const
+    {
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("true")), u"true"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("false")), u"false"_s);
+    }
+
+    void testFlattenNumber() const
+    {
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("100")), u"100"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("0")), u"0"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("-1")), u"-1"_s);
+        // large int64 value stays a plain decimal (no scientific notation)
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("10000000000")), u"10000000000"_s);
+        // integral doubles drop the fraction
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("2.0")), u"2"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("1.5")), u"1.5"_s);
+    }
+
+    void testFlattenNullAndUndefined() const
+    {
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("null")), u""_s);
+        QCOMPARE(Utils::Json::flattenValue(QJsonValue {QJsonValue::Undefined}), u""_s);
+    }
+
+    void testFlattenArray() const
+    {
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("[\"a\",\"b\"]")), u"[\"a\",\"b\"]"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("[1,2]")), u"[1,2]"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("[]")), u"[]"_s);
+    }
+
+    void testFlattenObject() const
+    {
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("{\"a\":1}")), u"{\"a\":1}"_s);
+        QCOMPARE(Utils::Json::flattenValue(jsonValue("{}")), u"{}"_s);
+    }
+};
+
+QTEST_APPLESS_MAIN(TestUtilsJson)
+#include "testutilsjson.moc"


### PR DESCRIPTION
This PR adds JSON request body support to all WebAPI endpoints. JSON is the modern standard for interacting with web APIs and a few of the WebAPI's more complicated endpoints already partially support it, but the vast majority still require form encoding.

JSON requests follow proper JSON paradigms and do away with some of the ugly form encoding hacks we've built: proper arrays are used instead of string delimited values, and URLs don't need to be percent encoded. With the assistance of AI, I've added a bunch of unit tests that help us ensure equivalence between the form encoding and JSON encoding logic.

This change is fully backwards compatible with existing form requests. This PR does not modify the WebUI at all, though we could switch over in the future.
