### PR TITLE
Normalize Python executable path for search

### DIFF
--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -58,7 +58,7 @@ using namespace Utils::ForeignApps;
 
 namespace
 {
-    Path normalizedPythonPath(const Path &path)
+    Path unquotePath(const Path &path)
     {
         QString pathStr = path.toString().trimmed();
         if (((pathStr.startsWith(u'"') && pathStr.endsWith(u'"'))
@@ -204,7 +204,7 @@ PythonInfo Utils::ForeignApps::pythonInfo()
 {
     static PythonInfo pyInfo;
 
-    const Path preferredPythonPath = normalizedPythonPath(Preferences::instance()->getPythonExecutablePath());
+    const Path preferredPythonPath = unquotePath(Preferences::instance()->getPythonExecutablePath());
     if (pyInfo.isValid() && (preferredPythonPath == pyInfo.executablePath))
         return pyInfo;
 

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -58,6 +58,19 @@ using namespace Utils::ForeignApps;
 
 namespace
 {
+    Path normalizedPythonPath(const Path &path)
+    {
+        QString pathStr = path.toString().trimmed();
+        if (((pathStr.startsWith(u'"') && pathStr.endsWith(u'"'))
+                || (pathStr.startsWith(u'\'') && pathStr.endsWith(u'\'')))
+                && (pathStr.size() >= 2))
+        {
+            pathStr = pathStr.mid(1, (pathStr.size() - 2)).trimmed();
+        }
+
+        return Path(pathStr);
+    }
+
     bool testPythonInstallation(const Path &exePath, PythonInfo &info)
     {
         info = {};
@@ -191,7 +204,7 @@ PythonInfo Utils::ForeignApps::pythonInfo()
 {
     static PythonInfo pyInfo;
 
-    const Path preferredPythonPath = Preferences::instance()->getPythonExecutablePath();
+    const Path preferredPythonPath = normalizedPythonPath(Preferences::instance()->getPythonExecutablePath());
     if (pyInfo.isValid() && (preferredPythonPath == pyInfo.executablePath))
         return pyInfo;
 


### PR DESCRIPTION
Closes #24169.

This strips accidental surrounding quotes from the configured Python executable path before probing it.

That lets the search tab handle paths copied from shells or dialogs with quotes around them.

Manual UI validation:
- macOS 27.0 (26A5353q), qBittorrent v5.3.0alpha1.
- Set `Python executable path (may require restart)` to `"/opt/homebrew/bin/python3"` and opened Search. Search loaded normally and showed the no-plugins state instead of the missing Python runtime warning.
- Quit and relaunched with the same isolated profile; the quoted path persisted and Search still loaded normally.