### PR TITLE
Recover from stale local peer lockfiles

### DIFF
--- a/src/app/localpeer.cpp
+++ b/src/app/localpeer.cpp
@@ -152,7 +152,8 @@ bool LocalPeer::isClient()
             if ((lockInfo->hostid == QSysInfo::machineUniqueId())
                     && (lockInfo->hostname == QSysInfo::machineHostName()))
             {
-                return true;
+                if (hasActiveServer(100ms))
+                    return true;
             }
 
             if (!m_lockFile.removeStaleLockFile() || !m_lockFile.tryLock())
@@ -230,6 +231,13 @@ bool LocalPeer::sendMessage(const QString &message, const std::chrono::milliseco
     }
 
     return true;
+}
+
+bool LocalPeer::hasActiveServer(const std::chrono::milliseconds timeout) const
+{
+    QLocalSocket socket;
+    socket.connectToServer(m_socketName);
+    return socket.waitForConnected(timeout.count());
 }
 
 void LocalPeer::receivedConnection()

--- a/src/app/localpeer.h
+++ b/src/app/localpeer.h
@@ -105,6 +105,7 @@ private:
         QByteArray bootid;
     };
 
+    bool hasActiveServer(std::chrono::milliseconds timeout) const;
     std::optional<LockInfo> getLockInfo() const;
 
     const QString m_socketName;


### PR DESCRIPTION
Closes #24552.

This checks whether the local peer IPC server is actually reachable before treating a same-host lockfile as an active qBittorrent instance.

If no server is listening, qBittorrent can remove the stale lockfile and continue startup instead of silently exiting.