### PR TITLE
Keep RSS matches with unknown smart episode

### DIFF
--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -371,7 +371,7 @@ bool AutoDownloadRule::matchesSmartEpisodeFilter(const QString &articleTitle) co
 
     const QString episodeStr = computeEpisodeName(articleTitle);
     if (episodeStr.isEmpty())
-        return false; // Don't accept articles with unrecognized episode number
+        return true; // No episode key to deduplicate; leave the regular rule match intact
 
     // See if this episode has been downloaded before
     const bool previouslyMatched = m_dataPtr->previouslyMatchedEpisodes.contains(episodeStr);


### PR DESCRIPTION
Closes #24397.

This keeps regular RSS rule matches when the smart episode filter cannot extract an episode or date key from the article title.

Duplicate suppression still applies when a smart episode key is found, but unrecognized titles are no longer hidden from matching or auto-download processing.

Manual UI validation:
- macOS 27.0 (26A5353q), qBittorrent v5.3.0alpha1.
- Added a local RSS feed containing `Naruto s01e01 1080p` and `Naruto Season 1 Complete 1080p`.
- Created a rule with `Must Contain: Naruto`, enabled Smart Episode Filter, and applied it to the feed. Both articles remained listed under Matching RSS Articles, including the title without a parseable episode key.