### PR TITLE
Add announce port command line option

### DIFF
--- a/doc/en/qbittorrent-nox.1
+++ b/doc/en/qbittorrent-nox.1
@@ -42,6 +42,8 @@ notice.
 \f[B]\f[CB]\-\-torrenting\-port=<port>\f[B]\f[R] Change the torrenting
 port.
 .PP
+\f[B]\f[CB]\-\-announce\-port=<port>\f[B]\f[R] Change the announce port.
+.PP
 \f[B]\f[CB]\-d | \-\-daemon\f[B]\f[R] Run in daemon\-mode (background).
 .PP
 \f[B]\f[CB]\-\-profile=<dir>\f[B]\f[R] Store configuration files in

--- a/doc/en/qbittorrent-nox.1.md
+++ b/doc/en/qbittorrent-nox.1.md
@@ -42,6 +42,8 @@ password in the program preferences.
 
 **`--torrenting-port=<port>`** Change the torrenting port.
 
+**`--announce-port=<port>`** Change the announce port.
+
 **`-d | --daemon`** Run in daemon-mode (background).
 
 **`--profile=<dir>`** Store configuration files in `<dir>`.

--- a/doc/en/qbittorrent.1
+++ b/doc/en/qbittorrent.1
@@ -31,6 +31,8 @@ notice.
 \f[B]\f[CB]\-\-torrenting\-port=<port>\f[B]\f[R] Change the torrenting
 port.
 .PP
+\f[B]\f[CB]\-\-announce\-port=<port>\f[B]\f[R] Change the announce port.
+.PP
 \f[B]\f[CB]\-\-no\-splash\f[B]\f[R] Disable splash screen.
 .PP
 \f[B]\f[CB]\-\-profile=<dir>\f[B]\f[R] Store configuration files in

--- a/doc/en/qbittorrent.1.md
+++ b/doc/en/qbittorrent.1.md
@@ -33,6 +33,8 @@ FAST extension (mainline) and PeX support (utorrent compatible).
 
 **`--torrenting-port=<port>`** Change the torrenting port.
 
+**`--announce-port=<port>`** Change the announce port.
+
 **`--no-splash`** Disable splash screen.
 
 **`--profile=<dir>`** Store configuration files in `<dir>`.

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -382,6 +382,12 @@ Application::Application(int &argc, char **argv)
         SettingValue<int> port {u"BitTorrent/Session/Port"_s};
         port = m_commandLineArgs.torrentingPort;
     }
+
+    if (m_commandLineArgs.announcePort > 0) // it will be -1 when user did not set any value
+    {
+        SettingValue<int> port {u"BitTorrent/Session/AnnouncePort"_s};
+        port = m_commandLineArgs.announcePort;
+    }
 }
 
 Application::~Application()

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -377,6 +377,12 @@ Application::Application(int &argc, char **argv)
         SettingValue<int> port {u"BitTorrent/Session/Port"_s};
         port = m_commandLineArgs.torrentingPort;
     }
+
+    if (m_commandLineArgs.announcePort > 0) // it will be -1 when user did not set any value
+    {
+        SettingValue<int> port {u"BitTorrent/Session/AnnouncePort"_s};
+        port = m_commandLineArgs.announcePort;
+    }
 }
 
 Application::~Application()

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -317,6 +317,7 @@ namespace
 #endif
     constexpr const IntOption WEBUI_PORT_OPTION {u"webui-port"};
     constexpr const IntOption TORRENTING_PORT_OPTION {u"torrenting-port"};
+    constexpr const IntOption ANNOUNCE_PORT_OPTION {u"announce-port"};
     constexpr const StringOption PROFILE_OPTION {u"profile"};
     constexpr const StringOption CONFIGURATION_OPTION {u"configuration"};
     constexpr const BoolOption RELATIVE_FASTRESUME {u"relative-fastresume"};
@@ -378,6 +379,9 @@ namespace
             + TORRENTING_PORT_OPTION.usage(QCoreApplication::translate("CMD Options", "port"))
             + wrapText(QCoreApplication::translate("CMD Options", "Change the torrenting port"))
             + u'\n'
+            + ANNOUNCE_PORT_OPTION.usage(QCoreApplication::translate("CMD Options", "port"))
+            + wrapText(QCoreApplication::translate("CMD Options", "Change the announce port"))
+            + u'\n'
 #ifndef DISABLE_GUI
             + NO_SPLASH_OPTION.usage() + wrapText(QCoreApplication::translate("CMD Options", "Disable splash screen")) + u'\n'
 #elif !defined(Q_OS_WIN)
@@ -431,6 +435,7 @@ QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &en
 #endif
     , webUIPort(WEBUI_PORT_OPTION.value(env, -1))
     , torrentingPort(TORRENTING_PORT_OPTION.value(env, -1))
+    , announcePort(ANNOUNCE_PORT_OPTION.value(env, -1))
     , skipDialog(SKIP_DIALOG_OPTION.value(env))
     , profileDir(Utils::Fs::toAbsolutePath(Path(PROFILE_OPTION.value(env))))
     , configurationName(CONFIGURATION_OPTION.value(env))
@@ -481,6 +486,15 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
                 {
                     throw CommandLineParameterError(QCoreApplication::translate("CMD Options", "%1 must specify a valid port (1 to 65535).")
                                                     .arg(u"--torrenting-port"_s));
+                }
+            }
+            else if (arg == ANNOUNCE_PORT_OPTION)
+            {
+                result.announcePort = ANNOUNCE_PORT_OPTION.value(arg);
+                if ((result.announcePort < 1) || (result.announcePort > 65535))
+                {
+                    throw CommandLineParameterError(QCoreApplication::translate("CMD Options", "%1 must specify a valid port (1 to 65535).")
+                                                    .arg(u"--announce-port"_s));
                 }
             }
 #ifndef DISABLE_GUI

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -56,6 +56,7 @@ struct QBtCommandLineParameters
 #endif
     int webUIPort = -1;
     int torrentingPort = -1;
+    int announcePort = -1;
     std::optional<bool> skipDialog;
     Path profileDir;
     QString configurationName;


### PR DESCRIPTION
Similar to #17862, this adds an option to start the program with a specific announce port; this is useful when the announce port is not static (for example, when using VPN providers that do not provide a static port for port forwarding).

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
