### PR TITLE
Add "Download Duration" column to transfer list

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -175,6 +175,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_CREATE_DATE: return tr("Created On", "Torrent was initially created on 01/01/2010 08:00");
             case TR_ADD_DATE: return tr("Added On", "Torrent was added to transfer list on 01/01/2010 08:00");
             case TR_SEED_DATE: return tr("Completed On", "Torrent was completed on 01/01/2010 08:00");
+            case TR_DOWNLOAD_DURATION: return tr("Download Duration", "Time elapsed between adding and completing the torrent download");
             case TR_TRACKER: return tr("Tracker");
             case TR_DLLIMIT: return tr("Down Limit", "i.e: Download limit");
             case TR_UPLIMIT: return tr("Up Limit", "i.e: Upload limit");
@@ -447,6 +448,17 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return reannounceString(torrent->nextAnnounce());
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
+    case TR_DOWNLOAD_DURATION:
+    {
+        const QDateTime added = torrent->addedTime();
+        const QDateTime completed = torrent->completedTime();
+        if (!added.isValid() || !completed.isValid())
+            return {};
+        const qint64 secs = added.secsTo(completed);
+        if (secs <= 0)
+            return {};
+        return Utils::Misc::userFriendlyDuration(secs);
+    }
     }
 
     return {};
@@ -532,6 +544,15 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->nextAnnounce();
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
+    case TR_DOWNLOAD_DURATION:
+    {
+        const QDateTime added = torrent->addedTime();
+        const QDateTime completed = torrent->completedTime();
+        if (!added.isValid() || !completed.isValid())
+            return {};
+        const qint64 secs = added.secsTo(completed);
+        return (secs > 0) ? QVariant(secs) : QVariant();
+    }
     }
 
     return {};

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -93,6 +93,7 @@ public:
         TR_REANNOUNCE,
         TR_PRIVATE,
         TR_CREATE_DATE,
+        TR_DOWNLOAD_DURATION,
 
         NB_COLUMNS
     };


### PR DESCRIPTION
## Summary

Adds a new optional column **Download Duration** to the main torrent transfer list. It shows the elapsed time between when a torrent was added and when it completed downloading, displayed using the existing `userFriendlyDuration` formatter (e.g. `1h 23m`, `45m`).

- Column is blank for torrents that have not yet completed or where either timestamp is unavailable
- Sortable (internal value is seconds as `qint64`)
- Follows the same pattern as the existing `TR_TIME_ELAPSED` / `TR_ADD_DATE` / `TR_SEED_DATE` columns
- No new dependencies

## Motivation

Users who want to review past download speeds at a glance currently have to mentally subtract "Added On" from "Completed On". This column surfaces that derived value directly without requiring changes to how timestamps are stored.

## Test plan

- [ ] Build and launch qBittorrent
- [ ] Right-click the column header and enable "Download Duration"
- [ ] Verify completed torrents show a human-readable duration
- [ ] Verify in-progress or never-completed torrents show a blank cell
- [ ] Verify the column sorts correctly (ascending/descending by seconds)