### PR TITLE
Add "Stalled For" column to transfer list

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -173,6 +173,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_CATEGORY: return tr("Category");
             case TR_TAGS: return tr("Tags");
             case TR_CREATE_DATE: return tr("Created On", "Torrent was initially created on 01/01/2010 08:00");
+            case TR_STALLED_FOR: return tr("Stalled For", "How long the torrent has been stuck with no transfer activity");
             case TR_ADD_DATE: return tr("Added On", "Torrent was added to transfer list on 01/01/2010 08:00");
             case TR_SEED_DATE: return tr("Completed On", "Torrent was completed on 01/01/2010 08:00");
             case TR_TRACKER: return tr("Tracker");
@@ -447,6 +448,15 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return reannounceString(torrent->nextAnnounce());
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
+    case TR_STALLED_FOR:
+    {
+        const auto state = torrent->state();
+        if (state != BitTorrent::TorrentState::StalledDownloading
+                && state != BitTorrent::TorrentState::StalledUploading)
+            return {};
+        const qint64 secs = torrent->timeSinceActivity();
+        return (secs > 0) ? Utils::Misc::userFriendlyDuration(secs) : QString {};
+    }
     }
 
     return {};
@@ -532,6 +542,15 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->nextAnnounce();
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
+    case TR_STALLED_FOR:
+    {
+        const auto state = torrent->state();
+        if (state != BitTorrent::TorrentState::StalledDownloading
+                && state != BitTorrent::TorrentState::StalledUploading)
+            return {};
+        const qint64 secs = torrent->timeSinceActivity();
+        return (secs > 0) ? QVariant(secs) : QVariant();
+    }
     }
 
     return {};

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -93,6 +93,7 @@ public:
         TR_REANNOUNCE,
         TR_PRIVATE,
         TR_CREATE_DATE,
+        TR_STALLED_FOR,
 
         NB_COLUMNS
     };


### PR DESCRIPTION
## Summary

Adds a new optional **Stalled For** column that shows how long a torrent has been stuck with no transfer activity. The cell is **blank** for torrents that are actively downloading, seeding, stopped, checking, or queued — it only shows a value when the state is `StalledDownloading` or `StalledUploading`.

This makes stuck torrents immediately visible without needing to cross-reference the **Last Activity** column (which shows for all torrents regardless of state).

## Implementation

Uses the existing `torrent->timeSinceActivity()` value and `Utils::Misc::userFriendlyDuration()` formatter, filtered by torrent state. The internal sort value is the raw seconds, so sorting by duration works correctly.

## Test plan

- [ ] Enable the **Stalled For** column
- [ ] Verify it is blank for actively-transferring, stopped, and queued torrents
- [ ] Verify it shows a duration for stalled torrents
- [ ] Verify the column sorts correctly by duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)