### PR TITLE
Add "File Types" column to transfer list

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -86,6 +86,38 @@ namespace
         }
         return colors;
     }
+
+    QString fileTypesString(const BitTorrent::Torrent *torrent)
+    {
+        if (!torrent->hasMetadata())
+            return {};
+
+        static const QHash<QString, QString> extMap = {
+            {u"mkv"_s, u"Video"_s}, {u"mp4"_s, u"Video"_s}, {u"avi"_s, u"Video"_s},
+            {u"mov"_s, u"Video"_s}, {u"wmv"_s, u"Video"_s}, {u"m4v"_s, u"Video"_s},
+            {u"ts"_s,  u"Video"_s}, {u"flv"_s, u"Video"_s}, {u"webm"_s, u"Video"_s},
+            {u"mp3"_s, u"Audio"_s}, {u"flac"_s, u"Audio"_s}, {u"aac"_s, u"Audio"_s},
+            {u"ogg"_s, u"Audio"_s}, {u"m4a"_s, u"Audio"_s}, {u"wav"_s, u"Audio"_s},
+            {u"zip"_s, u"Archive"_s}, {u"rar"_s, u"Archive"_s}, {u"7z"_s, u"Archive"_s},
+            {u"tar"_s, u"Archive"_s}, {u"gz"_s, u"Archive"_s}, {u"iso"_s, u"Archive"_s},
+            {u"srt"_s, u"Subtitles"_s}, {u"ass"_s, u"Subtitles"_s}, {u"sub"_s, u"Subtitles"_s},
+            {u"pdf"_s, u"Document"_s}, {u"epub"_s, u"Document"_s}, {u"cbz"_s, u"Document"_s},
+            {u"exe"_s, u"Software"_s}, {u"dmg"_s, u"Software"_s}, {u"pkg"_s, u"Software"_s},
+        };
+
+        QSet<QString> seen;
+        for (const Path &p : torrent->filePaths())
+        {
+            const QString ext = p.filename().section(u'.', -1).toLower();
+            seen.insert(extMap.value(ext, u"Other"_s));
+        }
+
+        QStringList ordered;
+        for (const QString &cat : {u"Video"_s, u"Audio"_s, u"Archive"_s, u"Subtitles"_s, u"Document"_s, u"Software"_s, u"Other"_s})
+            if (seen.contains(cat))
+                ordered << cat;
+        return ordered.join(u", "_s);
+    }
 }
 
 // TransferListModel
@@ -173,6 +205,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_CATEGORY: return tr("Category");
             case TR_TAGS: return tr("Tags");
             case TR_CREATE_DATE: return tr("Created On", "Torrent was initially created on 01/01/2010 08:00");
+            case TR_FILE_TYPES: return tr("File Types", "Categories of files inside the torrent, e.g. Video, Audio");
             case TR_ADD_DATE: return tr("Added On", "Torrent was added to transfer list on 01/01/2010 08:00");
             case TR_SEED_DATE: return tr("Completed On", "Torrent was completed on 01/01/2010 08:00");
             case TR_TRACKER: return tr("Tracker");
@@ -447,6 +480,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return reannounceString(torrent->nextAnnounce());
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
+    case TR_FILE_TYPES:
+        return fileTypesString(torrent);
     }
 
     return {};
@@ -532,6 +567,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->nextAnnounce();
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
+    case TR_FILE_TYPES:
+        return fileTypesString(torrent);
     }
 
     return {};

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -93,6 +93,7 @@ public:
         TR_REANNOUNCE,
         TR_PRIVATE,
         TR_CREATE_DATE,
+        TR_FILE_TYPES,
 
         NB_COLUMNS
     };


### PR DESCRIPTION
## Summary

Adds a new optional **File Types** column that categorises the content inside a torrent by file extension and displays a comma-separated summary (e.g. *"Video"*, *"Audio, Subtitles"*, *"Archive"*).

Categories: **Video**, **Audio**, **Archive**, **Subtitles**, **Document**, **Software**, **Other** — listed in that fixed order when multiple apply.

The column is blank for magnet links until metadata has been received. Enable via right-click on the column header.

## Implementation

A `fileTypesString()` helper in the anonymous namespace iterates `torrent->filePaths()`, maps the lowercase file extension to a category via a `static const QHash`, collects unique categories into a `QSet`, then outputs them in the fixed display order.

## Test plan

- [ ] Enable the **File Types** column
- [ ] Verify a video torrent shows "Video"
- [ ] Verify a torrent with video + subtitle files shows "Video, Subtitles"
- [ ] Verify a magnet link shows blank until metadata is fetched
- [ ] Verify an archive torrent shows "Archive"

🤖 Generated with [Claude Code](https://claude.com/claude-code)