### PR TITLE
Render ratio column as a progress bar

### DIFF
--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -31,6 +31,7 @@
 
 #include <QModelIndex>
 
+#include "base/bittorrent/torrent.h"
 #include "base/preferences.h"
 #include "transferlistmodel.h"
 
@@ -89,6 +90,19 @@ void TransferListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
             const QColor color = Preferences::instance()->getProgressBarFollowsTextColor() ? index.data(Qt::ForegroundRole).value<QColor>() : QColor();
 
             m_progressBarPainter.paint(painter, customOption, index.data().toString(), progress, color);
+        }
+        break;
+    case TransferListModel::TR_RATIO:
+        {
+            const qreal ratio = index.data(TransferListModel::UnderlyingDataRole).toReal();
+            const qreal ratioLimit = index.siblingAtColumn(TransferListModel::TR_RATIO_LIMIT)
+                .data(TransferListModel::UnderlyingDataRole).toReal();
+            const qreal cap = (ratioLimit > 0 && ratioLimit < 100.0) ? ratioLimit : 2.0;
+            const int progress = static_cast<int>(std::min(ratio / cap, 1.0) * 100);
+
+            QStyleOptionViewItem customOption {option};
+            customOption.state.setFlag(QStyle::State_Enabled, ratio >= 0);
+            m_progressBarPainter.paint(painter, customOption, index.data().toString(), progress, QColor());
         }
         break;
     default:


### PR DESCRIPTION
## Summary

Replaces the plain ratio number in `TR_RATIO` with a visual **progress bar**, mirroring the existing treatment of `TR_PROGRESS`.

The bar fills relative to the effective ratio limit:
- If a per-torrent or session ratio limit is set (finite, < 100), that value is used as the cap.
- Otherwise the cap defaults to **2.0** (a common seeding target).

The numeric ratio string (e.g. `"1.23"`) continues to be rendered as the bar's label, so no information is lost.

## Test plan

- [ ] Verify the Ratio column renders as a progress bar, not plain text
- [ ] Verify the bar fills to ~50% at ratio 1.0 with default cap 2.0
- [ ] Set a per-torrent ratio limit of 1.5 and verify a torrent at ratio 1.5 shows a full bar
- [ ] Verify the numeric label is still visible inside the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)