### PR TITLE
Double SpeedMonitor buffer for smoother ETA (30 → 60 samples)

### DIFF
--- a/src/base/bittorrent/speedmonitor.h
+++ b/src/base/bittorrent/speedmonitor.h
@@ -77,7 +77,7 @@ public:
     void reset();
 
 private:
-    static const int MAX_SAMPLES = 30;
+    static const int MAX_SAMPLES = 60;
     boost::circular_buffer<SpeedSample> m_speedSamples;
     SpeedSample m_sum;
 };


### PR DESCRIPTION
## Summary

Increases `SpeedMonitor::MAX_SAMPLES` from **30** to **60**.

ETA is computed as `remaining_bytes / average_download_speed` where the average uses a circular buffer in `SpeedMonitor`. With 30 samples (one per second) the smoothing window is ~30 s, which causes visible ETA jumps when connection speed fluctuates briefly. Doubling the buffer to 60 samples gives a **~1-minute smoothing window**, keeping ETA stable during brief speed variations while still reacting to sustained changes within a minute.

This is a single-line change with no API or behaviour change beyond the smoother displayed value.

## Test plan

- [ ] Add a torrent on a variable-speed connection
- [ ] Verify ETA changes less frequently than before and doesn't jump every few seconds
