### PR TITLE
Highlight rows amber when save path is low on disk space

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -32,6 +32,7 @@
 #include <QApplication>
 #include <QDateTime>
 #include <QDebug>
+#include <QStorageInfo>
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
@@ -549,9 +550,18 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
     switch (role)
     {
     case Qt::ForegroundRole:
+    {
+        const qint64 remaining = torrent->remainingSize();
+        if (remaining > 0)
+        {
+            const QStorageInfo storage(torrent->savePath().toString());
+            if (storage.isValid() && storage.bytesAvailable() < remaining)
+                return QColor(0xFF, 0xA5, 0x00); // amber warning
+        }
         if (m_useTorrentStatesColors)
             return m_stateThemeColors.value(torrent->state());
         break;
+    }
     case Qt::DisplayRole:
         return displayValue(torrent, index.column());
     case UnderlyingDataRole:


### PR DESCRIPTION
## Summary

When a torrent is still downloading and `QStorageInfo` reports fewer free bytes on its save-path volume than the torrent still needs to download, the row text is coloured **amber** (`#FFA500`). This gives an at-a-glance warning before the download fails with a write error, without requiring a separate column or status flag.

The check is performed in the `Qt::ForegroundRole` branch of `TransferListModel::data()`. It takes priority over the torrent-state colours setting. `QStorageInfo` is inexpensive for cached filesystem queries and is already used elsewhere in the codebase.

## Test plan

- [ ] Add a torrent larger than available disk space on the save path
- [ ] Verify the row turns amber
- [ ] Verify a torrent with sufficient disk space is not affected
- [ ] Verify completed torrents (remainingSize == 0) are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)