### PR TITLE
Pre-fill rename dialog with cleaned torrent name

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -32,6 +32,7 @@
 #include <QApplication>
 #include <QDateTime>
 #include <QDebug>
+#include <QRegularExpression>
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
@@ -86,9 +87,46 @@ namespace
         }
         return colors;
     }
+
+    QString cleanTorrentName(const QString &rawName)
+    {
+        QString name = rawName;
+        static const QRegularExpression leadingBracket(u"^\\s*\\[[^\\]]*\\]\\s*"_s);
+        name.remove(leadingBracket);
+        static const QRegularExpression dotSep(u"(?<=[\\w)])\\."
+                                               "(?=[\\w(])"_s);
+        name.replace(dotSep, u" "_s);
+        name.replace(u'_', u' ');
+        static const QRegularExpression bracketTech(
+            u"\\s*\\[[^\\]]*(?:\\d{3,4}[pi]|x26[45]|HEVC|AVC|Hi10|Hi8|"
+            u"AAC|AC3|FLAC|DTS|MP3|Opus|[0-9A-Fa-f]{8})[^\\]]*\\]"_s,
+            QRegularExpression::CaseInsensitiveOption
+        );
+        name.remove(bracketTech);
+        static const QRegularExpression techToken(
+            u"(?:^|\\s)(?:2160[pi]?|1080[pi]?|720[pi]?|480[pi]?|4[Kk](?:[Hh][Dd][Rr])?|8[Kk]|"
+            u"Blu-?Ray|BDRip|BRRip|WEB-?(?:DL|Rip)?|HDTV|PDTV|DVDRip|DVD|"
+            u"CAM(?:Rip)?|HDCAM|R5|SCR|DVDSCR|"
+            u"x26[45]|[Hh]\\.?26[45]|HEVC|AVC|XviD|DivX|VP9|AV1|"
+            u"DD[P+]?(?:\\s*5\\.1)?|DTS(?:-HD|-X|-MA)?|TrueHD|Atmos|AC-?3|AAC|FLAC|MP3|Opus|"
+            u"HDR(?:10\\+?)?|SDR|DV|DoVi|Dolby(?:\\s+Vision)?|"
+            u"REMUX|REPACK|PROPER|EXTENDED|THEATRICAL|UNRATED|DC|COMPLETE|INTERNAL|"
+            u"(?:10|8)[Bb]it)(?=\\b|\\s|-|$).*$"_s,
+            QRegularExpression::CaseInsensitiveOption
+        );
+        name.remove(techToken);
+        static const QRegularExpression trailingGroup(u"\\s+-\\w+\\s*$"_s);
+        name.remove(trailingGroup);
+        return name.simplified();
+    }
 }
 
 // TransferListModel
+
+QString TransferListModel::cleanName(const QString &rawName)
+{
+    return cleanTorrentName(rawName);
+}
 
 TransferListModel::TransferListModel(QObject *parent)
     : QAbstractListModel {parent}

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -105,6 +105,8 @@ public:
 
     explicit TransferListModel(QObject *parent = nullptr);
 
+    static QString cleanName(const QString &rawName);
+
     int rowCount(const QModelIndex &parent = {}) const override;
     int columnCount(const QModelIndex &parent = {}) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -958,7 +958,9 @@ void TransferListWidget::renameSelectedTorrent()
 
     // Ask for a new Name
     bool ok = false;
-    QString name = AutoExpandableDialog::getText(this, tr("Rename"), tr("New name:"), QLineEdit::Normal, torrent->name(), &ok);
+    const QString suggested = TransferListModel::cleanName(torrent->name());
+    QString name = AutoExpandableDialog::getText(this, tr("Rename"), tr("New name:"), QLineEdit::Normal,
+        suggested.isEmpty() ? torrent->name() : suggested, &ok);
     if (ok && !name.isEmpty())
     {
         name.replace(QRegularExpression(u"\r?\n|\r"_s), u" "_s);


### PR DESCRIPTION
## Summary

When the user renames a torrent (right-click → **Rename**), the input dialog is now pre-populated with a cleaned version of the name rather than the raw scene/release string:

| Raw name | Pre-filled suggestion |
|---|---|
| `The.Dark.Knight.2008.1080p.BluRay.x264-GROUP` | `The Dark Knight 2008` |
| `[SubsPlease] Anime - 01 [1080p][AAC]` | `Anime - 01` |
| `Show_Name_S01E01_WEBRip_x265` | `Show Name S01E01` |

The original name is unchanged until the user confirms; if the cleaner returns an empty string (rare edge case) the raw name is used as the fallback.

## Implementation

A `cleanTorrentName()` helper in the anonymous namespace of `transferlistmodel.cpp` applies four sequential regex passes (strip leading `[Tag]`, dot/underscore → space, remove bracket-enclosed tech tags, strip from first resolution/codec/source token). Exposed publicly as `TransferListModel::cleanName()` so `transferlistwidget.cpp` can call it without duplicating the logic.

## Test plan

- [ ] Right-click a scene-named torrent → Rename
- [ ] Verify the input is pre-filled with the cleaned name (dots replaced, tags stripped)
- [ ] Verify editing and confirming renames correctly
- [ ] Verify cancelling leaves the original name unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)