### PR TITLE
Auto-assign category based on tracker domain on torrent add

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -77,6 +77,7 @@
 #include <QString>
 #include <QThread>
 #include <QTimer>
+#include <QUrl>
 #include <QUuid>
 
 #include "base/algorithm.h"
@@ -2806,6 +2807,28 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         cancelDownloadMetadata(altID);
 
     LoadTorrentParams loadTorrentParams = initLoadTorrentParams(addTorrentParams);
+
+    // Auto-assign category from tracker domain when no category was explicitly set
+    if (loadTorrentParams.category.isEmpty())
+    {
+        const QMap<QString, QString> trackerCatMap = Preferences::instance()->getTrackerCategoryMap();
+        if (!trackerCatMap.isEmpty())
+        {
+            for (const TrackerEntry &entry : source.trackers())
+            {
+                const QString host = QUrl(entry.url).host();
+                if (const auto it = trackerCatMap.constFind(host); it != trackerCatMap.constEnd())
+                {
+                    const QString autoCategory = it.value();
+                    if (!m_categories.contains(autoCategory))
+                        addCategory(autoCategory);
+                    loadTorrentParams.category = autoCategory;
+                    break;
+                }
+            }
+        }
+    }
+
     lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;
     p = source.ltAddTorrentParams();
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1760,6 +1760,19 @@ void Preferences::setTrackerListState(const QByteArray &state)
     setValue(u"GUI/Qt6/TorrentProperties/TrackerListState"_s, state);
 }
 
+QMap<QString, QString> Preferences::getTrackerCategoryMap() const
+{
+    return value<QMap<QString, QString>>(u"BitTorrent/TrackerCategoryMap"_s);
+}
+
+void Preferences::setTrackerCategoryMap(const QMap<QString, QString> &map)
+{
+    if (map == getTrackerCategoryMap())
+        return;
+    setValue(u"BitTorrent/TrackerCategoryMap"_s, map);
+    emit changed();
+}
+
 QStringList Preferences::getRssOpenFolders() const
 {
     return value<QStringList>(u"GUI/RSSWidget/OpenedFolders"_s);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -374,6 +374,8 @@ public:
     void setPropVisible(bool visible);
     QByteArray getTrackerListState() const;
     void setTrackerListState(const QByteArray &state);
+    QMap<QString, QString> getTrackerCategoryMap() const;
+    void setTrackerCategoryMap(const QMap<QString, QString> &map);
     QStringList getRssOpenFolders() const;
     void setRssOpenFolders(const QStringList &folders);
     QByteArray getRssSideSplitterState() const;


### PR DESCRIPTION
## Summary

Reads a user-configurable **tracker-domain → category** map from `Preferences` and applies the matching category automatically when a torrent is added without an explicit one.

The map is stored under the key `BitTorrent/TrackerCategoryMap` as a `QMap<QString, QString>` (tracker hostname → category name). The first matching announce URL wins. If the mapped category does not yet exist it is created automatically (same behaviour as specifying a new category in the Add Torrent dialog).

A UI for editing the map in Options → Downloads can be added on top of this backend change.

## Implementation

- `Preferences::getTrackerCategoryMap()` / `setTrackerCategoryMap()` added
- Lookup injected in `SessionImpl::addTorrent_impl()` immediately after `initLoadTorrentParams()`, only when `loadTorrentParams.category` is empty

## Test plan

- [ ] Set `BitTorrent/TrackerCategoryMap` via the API or direct settings edit, e.g. `{ "tracker.example.com": "Movies" }`
- [ ] Add a torrent whose announce URL contains that hostname without selecting a category
- [ ] Verify the torrent is automatically assigned the mapped category
- [ ] Verify torrents with an explicit category set are not overridden
- [ ] Verify torrents with no matching tracker domain get no category

🤖 Generated with [Claude Code](https://claude.com/claude-code)