### PR TITLE
Add 'Show in list' button to duplicate torrent dialog

### DIFF
--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -29,6 +29,9 @@
 
 #include "guiaddtorrentmanager.h"
 
+#include <QAbstractButton>
+#include <QMessageBox>
+#include <QPushButton>
 #include <QScreen>
 
 #include "base/bittorrent/session.h"
@@ -40,6 +43,7 @@
 #include "interfaces/iguiapplication.h"
 #include "mainwindow.h"
 #include "raisedmessagebox.h"
+#include "transferlistwidget.h"
 
 namespace
 {
@@ -215,13 +219,27 @@ bool GUIAddTorrentManager::processTorrent(const QString &source
             else
             {
                 const bool mergeTrackers = btSession()->isMergeTrackersEnabled();
-                const QMessageBox::StandardButton btn = RaisedMessageBox::question(app()->mainWindow(), dialogCaption
-                        , tr("Torrent '%1' is already in the transfer list. Do you want to merge trackers from new source?").arg(torrent->name())
-                        , (QMessageBox::Yes | QMessageBox::No), (mergeTrackers ? QMessageBox::Yes : QMessageBox::No));
-                if (btn == QMessageBox::Yes)
+                QMessageBox msgBox(app()->mainWindow());
+                msgBox.setWindowTitle(dialogCaption);
+                msgBox.setText(tr("Torrent <b>%1</b> is already in the transfer list.").arg(torrent->name()));
+                msgBox.setInformativeText(tr("Do you want to merge trackers from the new source?"));
+                msgBox.setIcon(QMessageBox::Question);
+                QPushButton *mergeBtn = msgBox.addButton(tr("Merge trackers"), QMessageBox::YesRole);
+                msgBox.addButton(tr("Skip"), QMessageBox::NoRole);
+                QPushButton *locateBtn = msgBox.addButton(tr("Show in list"), QMessageBox::ActionRole);
+                msgBox.setDefaultButton(mergeTrackers ? mergeBtn : locateBtn);
+                msgBox.exec();
+                QAbstractButton *const clicked = msgBox.clickedButton();
+                if (clicked == mergeBtn)
                 {
                     torrent->addTrackers(torrentDescr.trackers());
                     torrent->addUrlSeeds(torrentDescr.urlSeeds());
+                }
+                if (clicked == mergeBtn || clicked == locateBtn)
+                {
+                    app()->mainWindow()->transferListWidget()->scrollToAndSelect(torrent);
+                    app()->mainWindow()->raise();
+                    app()->mainWindow()->activateWindow();
                 }
             }
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -712,6 +712,12 @@ void TransferListModel::handleTorrentsUpdated(const QList<BitTorrent::Torrent *>
     }
 }
 
+QModelIndex TransferListModel::indexOfTorrent(const BitTorrent::Torrent *torrent) const
+{
+    const int row = getTorrentRow(const_cast<BitTorrent::Torrent *>(torrent));
+    return (row >= 0) ? index(row, TR_NAME) : QModelIndex {};
+}
+
 int TransferListModel::getTorrentRow(BitTorrent::Torrent *const torrent) const
 {
     const auto iter = m_torrents.get<ByHandle>().find(torrent);

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -105,6 +105,8 @@ public:
 
     explicit TransferListModel(QObject *parent = nullptr);
 
+    QModelIndex indexOfTorrent(const BitTorrent::Torrent *torrent) const;
+
     int rowCount(const QModelIndex &parent = {}) const override;
     int columnCount(const QModelIndex &parent = {}) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -242,6 +242,19 @@ TransferListModel *TransferListWidget::getSourceModel() const
     return m_listModel;
 }
 
+void TransferListWidget::scrollToAndSelect(const BitTorrent::Torrent *torrent)
+{
+    const QModelIndex sourceIdx = m_listModel->indexOfTorrent(torrent);
+    if (!sourceIdx.isValid())
+        return;
+    const QModelIndex proxyIdx = m_sortFilterModel->mapFromSource(sourceIdx);
+    if (!proxyIdx.isValid())
+        return;
+    selectionModel()->select(proxyIdx, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    scrollTo(proxyIdx, QAbstractItemView::EnsureVisible);
+    setFocus();
+}
+
 void TransferListWidget::previewFile(const Path &filePath)
 {
     Utils::Gui::openPath(filePath);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -61,6 +61,7 @@ public:
     TransferListWidget(IGUIApplication *app, QWidget *parent);
     ~TransferListWidget() override;
     TransferListModel *getSourceModel() const;
+    void scrollToAndSelect(const BitTorrent::Torrent *torrent);
 
 public slots:
     void setSelectionCategory(const QString &category);


### PR DESCRIPTION
## Summary

When a duplicate torrent is added and the confirmation dialog appears, a third **Show in list** button is added alongside *Merge trackers* and *Skip*. Clicking either *Merge trackers* or *Show in list* scrolls the transfer list to the existing torrent, selects it, and brings the main window to the foreground.

This makes it easy to locate the duplicate without manually scanning a long list.

### Before
> "Torrent 'X' is already in the transfer list. Do you want to merge trackers from new source?" → **Yes** / **No**

### After
> "Torrent **X** is already in the transfer list. Do you want to merge trackers from the new source?" → **Merge trackers** / **Skip** / **Show in list**

## Implementation

Two reusable helpers are added:
- `TransferListModel::indexOfTorrent(const Torrent *)` — returns the model index for a given torrent handle
- `TransferListWidget::scrollToAndSelect(const Torrent *)` — maps through the sort/filter proxy and scrolls + selects the row

`GUIAddTorrentManager` uses `app()->mainWindow()->transferListWidget()->scrollToAndSelect()` after the user's choice.

## Test plan

- [ ] Add a torrent already in the list
- [ ] Verify the dialog shows three buttons: Merge trackers, Skip, Show in list
- [ ] Click **Show in list** — verify the main window comes forward and the duplicate is selected
- [ ] Click **Merge trackers** — verify trackers are merged and the torrent is also selected
- [ ] Click **Skip** — verify nothing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)