### PR TITLE
Use ASCII digits for technical numbers

### DIFF
--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -46,7 +46,7 @@ QString Utils::String::fromDouble(const double n, const int precision)
     ** precision we add an extra 0 behind 1 in the below algorithm. */
 
     const double prec = std::pow(10.0, precision);
-    return QLocale::system().toString(std::floor(n * prec) / prec, 'f', precision);
+    return QLocale::c().toString(std::floor(n * prec) / prec, 'f', precision);
 }
 
 QString Utils::String::fromLatin1(const std::string_view string)

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -31,7 +31,6 @@
 
 #include <cmath>
 
-#include <QLocale>
 #include <QPainter>
 #include <QPen>
 
@@ -39,6 +38,7 @@
 #include "base/global.h"
 #include "base/unicodestrings.h"
 #include "base/utils/misc.h"
+#include "base/utils/string.h"
 
 namespace
 {
@@ -93,7 +93,7 @@ namespace
     {
         // check is there need for digits after decimal separator
         const int precision = (argValue < 10) ? friendlyUnitPrecision(unit) : 0;
-        return QLocale::system().toString(argValue, 'f', precision)
+        return Utils::String::fromDouble(argValue, precision)
                + QChar::Nbsp + unitString(unit, true);
     }
 }

--- a/test/testutilsstring.cpp
+++ b/test/testutilsstring.cpp
@@ -62,6 +62,14 @@ public:
     TestUtilsString() = default;
 
 private slots:
+    void testFromDouble() const
+    {
+        QCOMPARE(Utils::String::fromDouble(0, 0), u"0"_s);
+        QCOMPARE(Utils::String::fromDouble(0.999, 1), u"0.9"_s);
+        QCOMPARE(Utils::String::fromDouble(150.49, 1), u"150.4"_s);
+        QCOMPARE(Utils::String::fromDouble(2.879, 2), u"2.87"_s);
+    }
+
     void testJoinIntoString() const
     {
         const QList<QString> list1;


### PR DESCRIPTION
## Summary

- Format technical decimal values with the C locale so they always use ASCII digits.
- Reuse the shared technical-number formatter for speed graph labels.
- Add coverage for `Utils::String::fromDouble()` output.

## Root Cause

`Utils::String::fromDouble()` used `QLocale::system().toString()`. On Windows, this respects the user's configured native digits. If the user sets native digits to Chinese numerals, qBittorrent renders technical values such as file sizes and speeds as digit-substituted text, for example `150.4 MiB` becomes `〡〥〇.〤 MiB`.

Technical measurements such as file sizes, speeds, percentages and ratios are easier to read and more conventional when they keep ASCII digits regardless of localized native-digit settings.

## Validation

- Configured a Windows MSVC/vcpkg build with `TESTING=ON`.
- Built `testutilsstring`.
- Ran `ctest --test-dir D:\build\qBittorrent-test\test -R testutilsstring --output-on-failure`.
- Built `qbittorrent.exe` successfully, covering the GUI speed plot change.
