### PR TITLE
Update helpers.py

### DIFF
--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -45,6 +45,18 @@ from typing import Any, Optional, cast
 import socks
 
 
+def _create_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    # Python.org builds ship a bundled OpenSSL that ignores the macOS system
+    # keychain. Load from the system CA bundle directly as a fallback.
+    if sys.platform == 'darwin' and os.path.exists('/etc/ssl/cert.pem'):
+        ctx.load_verify_locations('/etc/ssl/cert.pem')
+    return ctx
+
+
+_ssl_context: ssl.SSLContext = _create_ssl_context()
+
+
 def _getBrowserUserAgent() -> str:
     """
     Disguise as browser to circumvent website blocking
@@ -87,7 +99,7 @@ def enable_socks_proxy(enable: bool) -> None:
 htmlentitydecode = html.unescape
 
 
-def retrieve_url(url: str, custom_headers: Mapping[str, str] = {}, request_data: Optional[Any] = None, ssl_context: Optional[ssl.SSLContext] = None, unescape_html_entities: bool = True) -> str:
+def retrieve_url(url: str, custom_headers: Mapping[str, str] = {}, request_data: Optional[Any] = None, ssl_context: ssl.SSLContext = _ssl_context, unescape_html_entities: bool = True) -> str:
     """
     Return the content of the url page as a string
     """
@@ -120,7 +132,7 @@ def retrieve_url(url: str, custom_headers: Mapping[str, str] = {}, request_data:
     return dataStr
 
 
-def download_file(url: str, referer: Optional[str] = None, ssl_context: Optional[ssl.SSLContext] = None) -> str:
+def download_file(url: str, referer: Optional[str] = None, ssl_context: ssl.SSLContext = _ssl_context) -> str:
     """
     Download file at url and write it to a file, return both the path to the file and the url
     """


### PR DESCRIPTION
## Summary
- add `_create_ssl_context()` to `src/searchengine/nova3/helpers.py` that loads Apple's system CA bundle on macOS
- use the resulting context as the default for `retrieve_url` and `download_file` instead of `None`
- leave non-macOS behavior unchanged

Closes #23312

## Root cause
Python.org builds ship a bundled OpenSSL that does not read the macOS system keychain. When search plugins call `retrieve_url()` against HTTPS endpoints, SSL certificate verification fails and raises `urllib.error.URLError`, which `retrieve_url` catches and returns `""`. The plugin emits no results and qBittorrent shows an empty search result with no visible error.

`/etc/ssl/cert.pem` is Apple's maintained root CA bundle (the same one used by Safari and curl). Loading it via `ctx.load_verify_locations()` supplements the incomplete Python.org CA store and allows certificate chains to verify successfully.

## Validation
`cmake --build build --target qbittorrent`
- Open Search tab → search for any term → confirm results appear
- Confirm non-macOS builds unaffected (platform branch only runs on `darwin`)