### PR TITLE
WebUI: Fix table header misalignment when scrolling horizontally

### DIFF
--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -374,14 +374,14 @@
                         <input type="text" id="torrentFilesFilterInput" placeholder="QBT_TR(Filter files...)QBT_TR[CONTEXT=AddNewTorrentDialog]" aria-label="QBT_TR(Filter files...)QBT_TR[CONTEXT=AddNewTorrentDialog]" autocorrect="off" autocapitalize="none">
                     </div>
                     <div id="torrentFiles" style="overflow: auto;">
-                        <div id="torrentFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-                            <table class="dynamicTable" style="position:relative;">
-                                <thead>
-                                    <tr class="dynamicTableHeader"></tr>
-                                </thead>
-                            </table>
-                        </div>
                         <div id="addTorrentFilesTableDiv" class="dynamicTableDiv">
+                            <div id="torrentFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                                <table class="dynamicTable" style="position:relative;">
+                                    <thead>
+                                        <tr class="dynamicTableHeader"></tr>
+                                    </thead>
+                                </table>
+                            </div>
                             <table class="dynamicTable">
                                 <tbody></tbody>
                             </table>

--- a/src/webui/www/private/css/dynamicTable.css
+++ b/src/webui/www/private/css/dynamicTable.css
@@ -150,15 +150,21 @@
     padding-left: 25px;
 }
 
-div:has(> div.dynamicTableFixedHeaderDiv):not(.invisible) {
+div:has(> div.dynamicTableDiv):not(.invisible) {
     display: flex;
     flex-direction: column;
     height: 100%;
 }
 
 .dynamicTableFixedHeaderDiv {
-    flex-shrink: 0;
-    overflow: hidden;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+/* opaque background on the header table so body rows don't show through when scrolling under it */
+.dynamicTableFixedHeaderDiv table {
+    background-color: var(--color-background-primary);
 }
 
 #propertiesPanel .dynamicTableFixedHeaderDiv,

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -445,14 +445,14 @@
             <input id="closeButton" type="button" value="Close" style="float: right; width: 30%;">
         </div>
         <div id="torrentFiles" class="panel" style="position: absolute; top: 0; right: 0; bottom: 0; left: 228px; margin: 35px 10px 45px 20px; border-bottom: 0; height: initial;">
-            <div id="bulkRenameFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-                <table class="dynamicTable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
-                </table>
-            </div>
             <div id="bulkRenameFilesTableDiv" class="dynamicTableDiv">
+                <div id="bulkRenameFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                    <table class="dynamicTable">
+                        <thead>
+                            <tr class="dynamicTableHeader"></tr>
+                        </thead>
+                    </table>
+                </div>
                 <table class="dynamicTable">
                     <tbody></tbody>
                 </table>

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -81,10 +81,14 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.dynamicTableDiv = document.getElementById(dynamicTableDivId);
             this.useVirtualList = clientData.get("use_virtual_list") ?? true;
             this.fixedTableHeader = document.querySelector(`#${dynamicTableFixedHeaderDivId} thead tr`);
-            this.table = this.dynamicTableDiv.querySelector("table");
+            // the body table is the direct child; the fixed header table is nested in a child div
+            this.table = this.dynamicTableDiv.querySelector(":scope > table");
             this.colgroup = document.createElement("colgroup");
             this.table.prepend(this.colgroup);
-            this.tableBody = this.dynamicTableDiv.querySelector("tbody");
+            // the fixed header table needs its own colgroup so its columns size identically to the body
+            this.fixedTableHeaderColgroup = document.createElement("colgroup");
+            this.fixedTableHeader.closest("table").prepend(this.fixedTableHeaderColgroup);
+            this.tableBody = this.table.querySelector("tbody");
             this.rowHeight = (clientData.get("display_density") === "compact") ? 22 : 26;
             this.rows = new Map();
             this.cachedElements = [];
@@ -123,15 +127,14 @@ window.qBittorrent.DynamicTable ??= (() => {
         }
 
         setupCommonEvents() {
-            const tableFixedHeaderDiv = document.getElementById(this.dynamicTableFixedHeaderDivId);
-
-            const tableElement = tableFixedHeaderDiv.querySelector("table");
             this.dynamicTableDiv.addEventListener("scroll", (e) => {
-                tableElement.style.left = `${-this.dynamicTableDiv.scrollLeft}px`;
-                // rerender on scroll
+                // rerender on vertical scroll
                 if (this.useVirtualList) {
-                    this.renderedOffset = this.dynamicTableDiv.scrollTop;
-                    this.rerender();
+                    const scrollTop = this.dynamicTableDiv.scrollTop;
+                    if (scrollTop !== this.renderedOffset) {
+                        this.renderedOffset = scrollTop;
+                        this.rerender();
+                    }
                 }
             });
 
@@ -446,6 +449,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             const style = `width: ${column.width}px; ${column.style}`;
             this.getRowCells(this.fixedTableHeader)[pos].style.cssText = style;
             this.colgroup.children[pos].style.width = `${column.width}px`;
+            this.fixedTableHeaderColgroup.children[pos].style.width = `${column.width}px`;
             // rerender on column resize
             if (this.useVirtualList)
                 this.rerender();
@@ -614,6 +618,11 @@ window.qBittorrent.DynamicTable ??= (() => {
             const col = document.createElement("col");
             col.style.width = `${column.width}px`;
             this.colgroup.append(col);
+
+            const headerCol = document.createElement("col");
+            headerCol.style.width = `${column.width}px`;
+            this.fixedTableHeaderColgroup.append(headerCol);
+
             this.fixedTableHeader.append(document.createElement("th"));
         }
 
@@ -649,9 +658,14 @@ window.qBittorrent.DynamicTable ??= (() => {
         updateTableHeaders() {
             this.updateHeader(this.fixedTableHeader);
             const cols = this.colgroup.children;
+            const headerCols = this.fixedTableHeaderColgroup.children;
             for (let i = 0; i < this.columns.length; ++i) {
-                cols[i].style.width = `${this.columns[i].width}px`;
-                cols[i].classList.toggle("invisible", !this.columns[i].isVisible());
+                const width = `${this.columns[i].width}px`;
+                const visible = this.columns[i].isVisible();
+                cols[i].style.width = width;
+                cols[i].classList.toggle("invisible", !visible);
+                headerCols[i].style.width = width;
+                headerCols[i].classList.toggle("invisible", !visible);
             }
             this.setSortedColumnIcon(this.sortedColumn, null, (this.reverseSort === "1"));
         }
@@ -685,6 +699,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             const action = column.isVisible() ? "remove" : "add";
             fths[pos].classList[action]("invisible");
             this.colgroup.children[pos].classList[action]("invisible");
+            this.fixedTableHeaderColgroup.children[pos].classList[action]("invisible");
 
             for (const tr of this.getTrs()) {
                 const td = this.getRowCells(tr)[pos];
@@ -3145,13 +3160,14 @@ window.qBittorrent.DynamicTable ??= (() => {
         }
 
         setupCommonEvents() {
-            const headerDiv = document.getElementById("bulkRenameFilesTableFixedHeaderDiv");
             this.dynamicTableDiv.addEventListener("scroll", (e) => {
-                headerDiv.scrollLeft = this.dynamicTableDiv.scrollLeft;
-                // rerender on scroll
+                // rerender on vertical scroll
                 if (this.useVirtualList) {
-                    this.renderedOffset = this.dynamicTableDiv.scrollTop;
-                    this.rerender();
+                    const scrollTop = this.dynamicTableDiv.scrollTop;
+                    if (scrollTop !== this.renderedOffset) {
+                        this.renderedOffset = scrollTop;
+                        this.rerender();
+                    }
                 }
             });
         }

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -107,28 +107,28 @@
 
     <div id="logContentView">
         <div id="logMessageView">
-            <div id="logMessageTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-                <table class="dynamicTable unselectable" style="position:relative;">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
-                </table>
-            </div>
             <div id="logMessageTableDiv" class="dynamicTableDiv">
+                <div id="logMessageTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                    <table class="dynamicTable unselectable" style="position:relative;">
+                        <thead>
+                            <tr class="dynamicTableHeader"></tr>
+                        </thead>
+                    </table>
+                </div>
                 <table class="dynamicTable unselectable">
                     <tbody></tbody>
                 </table>
             </div>
         </div>
         <div id="logPeerView" class="invisible">
-            <div id="logPeerTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-                <table class="dynamicTable unselectable" style="position:relative;">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
-                </table>
-            </div>
             <div id="logPeerTableDiv" class="dynamicTableDiv">
+                <div id="logPeerTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                    <table class="dynamicTable unselectable" style="position:relative;">
+                        <thead>
+                            <tr class="dynamicTableHeader"></tr>
+                        </thead>
+                    </table>
+                </div>
                 <table class="dynamicTable unselectable">
                     <tbody></tbody>
                 </table>

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -109,14 +109,14 @@
 
 <div id="propTrackers" class="propertiesTabContent invisible unselectable">
     <div id="trackers">
-        <div id="torrentTrackersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
         <div id="torrentTrackersTableDiv" class="dynamicTableDiv">
+            <div id="torrentTrackersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                <table class="dynamicTable" style="position:relative;">
+                    <thead>
+                        <tr class="dynamicTableHeader"></tr>
+                    </thead>
+                </table>
+            </div>
             <table class="dynamicTable">
                 <tbody></tbody>
             </table>
@@ -126,14 +126,14 @@
 
 <div id="propPeers" class="propertiesTabContent invisible unselectable">
     <div>
-        <div id="torrentPeersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
         <div id="torrentPeersTableDiv" class="dynamicTableDiv">
+            <div id="torrentPeersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                <table class="dynamicTable" style="position:relative;">
+                    <thead>
+                        <tr class="dynamicTableHeader"></tr>
+                    </thead>
+                </table>
+            </div>
             <table class="dynamicTable">
                 <tbody></tbody>
             </table>
@@ -143,14 +143,14 @@
 
 <div id="propWebSeeds" class="propertiesTabContent invisible unselectable">
     <div id="webseeds">
-        <div id="torrentWebseedsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
         <div id="torrentWebseedsTableDiv" class="dynamicTableDiv">
+            <div id="torrentWebseedsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                <table class="dynamicTable" style="position:relative;">
+                    <thead>
+                        <tr class="dynamicTableHeader"></tr>
+                    </thead>
+                </table>
+            </div>
             <table class="dynamicTable">
                 <tbody></tbody>
             </table>
@@ -160,14 +160,14 @@
 
 <div id="propFiles" class="propertiesTabContent invisible unselectable">
     <div id="torrentFiles">
-        <div id="torrentFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
         <div id="torrentFilesTableDiv" class="dynamicTableDiv">
+            <div id="torrentFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                <table class="dynamicTable" style="position:relative;">
+                    <thead>
+                        <tr class="dynamicTableHeader"></tr>
+                    </thead>
+                </table>
+            </div>
             <table class="dynamicTable">
                 <tbody></tbody>
             </table>

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -152,28 +152,28 @@
     </div>
     <div id="rssContentView">
         <div id="leftRssColumn">
-            <div id="rssFeedFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-                <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
-                </table>
-            </div>
             <div id="rssFeedTableDiv" class="dynamicTableDiv">
+                <div id="rssFeedFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                    <table class="dynamicTable unselectable">
+                        <thead>
+                            <tr class="dynamicTableHeader"></tr>
+                        </thead>
+                    </table>
+                </div>
                 <table class="dynamicTable unselectable">
                     <tbody></tbody>
                 </table>
             </div>
         </div>
         <div id="centerRssColumn">
-            <div id="rssArticleFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-                <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
-                </table>
-            </div>
             <div id="rssArticleTableDiv" class="dynamicTableDiv">
+                <div id="rssArticleFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                    <table class="dynamicTable unselectable">
+                        <thead>
+                            <tr class="dynamicTableHeader"></tr>
+                        </thead>
+                    </table>
+                </div>
                 <table class="dynamicTable unselectable">
                     <tbody></tbody>
                 </table>

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -140,14 +140,14 @@
         </div>
         <div id="rulesTable">
             <div id="rulesSelectionCheckBoxList">
-                <div id="rssDownloaderRuleFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
-                    <table class="dynamicTable unselectable">
-                        <thead>
-                            <tr class="dynamicTableHeader"></tr>
-                        </thead>
-                    </table>
-                </div>
                 <div id="rssDownloaderRuleTableDiv" class="dynamicTableDiv">
+                    <div id="rssDownloaderRuleFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
+                        <table class="dynamicTable unselectable">
+                            <thead>
+                                <tr class="dynamicTableHeader"></tr>
+                            </thead>
+                        </table>
+                    </div>
                     <table class="dynamicTable unselectable">
                         <tbody></tbody>
                     </table>
@@ -285,14 +285,14 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         <fieldset class="settings" id="rssDownloaderFeeds">
             <legend>QBT_TR(Apply Rule to Feeds:)QBT_TR[CONTEXT=AutomatedRssDownloader]</legend>
             <div id="rssDownloaderFeedsTable">
-                <div id="rssDownloaderFeedSelectionFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
-                    <table class="dynamicTable unselectable">
-                        <thead>
-                            <tr class="dynamicTableHeader"></tr>
-                        </thead>
-                    </table>
-                </div>
                 <div id="rssDownloaderFeedSelectionTableDiv" class="dynamicTableDiv">
+                    <div id="rssDownloaderFeedSelectionFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
+                        <table class="dynamicTable unselectable">
+                            <thead>
+                                <tr class="dynamicTableHeader"></tr>
+                            </thead>
+                        </table>
+                    </div>
                     <table class="dynamicTable unselectable">
                         <tbody></tbody>
                     </table>
@@ -306,14 +306,14 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
     <div id="rightRssDownloaderColumn">
         <b id="articleTableDesc">QBT_TR(Matching RSS Articles)QBT_TR[CONTEXT=AutomatedRssDownloader]</b>
         <div id="rssDownloaderArticlesTable">
-            <div id="rssDownloaderArticlesFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
-                <table class="dynamicTable unselectable">
-                    <thead>
-                        <tr class="dynamicTableHeader"></tr>
-                    </thead>
-                </table>
-            </div>
             <div id="rssDownloaderArticlesTableDiv" class="dynamicTableDiv">
+                <div id="rssDownloaderArticlesFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
+                    <table class="dynamicTable unselectable">
+                        <thead>
+                            <tr class="dynamicTableHeader"></tr>
+                        </thead>
+                    </table>
+                </div>
                 <table class="dynamicTable unselectable">
                     <tbody></tbody>
                 </table>

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -201,14 +201,14 @@
     </div>
 
     <div id="searchResultsTableContainer" class="invisible">
-        <div id="searchResultsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable unselectable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
         <div id="searchResultsTableDiv" class="dynamicTableDiv">
+            <div id="searchResultsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                <table class="dynamicTable unselectable" style="position:relative;">
+                    <thead>
+                        <tr class="dynamicTableHeader"></tr>
+                    </thead>
+                </table>
+            </div>
             <table class="dynamicTable unselectable">
                 <tbody></tbody>
             </table>

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -37,14 +37,14 @@
     <h2>QBT_TR(Installed search plugins:)QBT_TR[CONTEXT=PluginSelectDlg]</h2>
 
     <div id="searchPluginsTable">
-        <div id="searchPluginsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable unselectable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader" id="searchPluginsTableFixedHeaderRow"></tr>
-                </thead>
-            </table>
-        </div>
         <div id="searchPluginsTableDiv" class="dynamicTableDiv">
+            <div id="searchPluginsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                <table class="dynamicTable unselectable" style="position:relative;">
+                    <thead>
+                        <tr class="dynamicTableHeader" id="searchPluginsTableFixedHeaderRow"></tr>
+                    </thead>
+                </table>
+            </div>
             <table class="dynamicTable unselectable">
                 <tbody></tbody>
             </table>

--- a/src/webui/www/private/views/torrentcreator.html
+++ b/src/webui/www/private/views/torrentcreator.html
@@ -40,14 +40,14 @@
         </button>
     </div>
     <div id="torrentCreatorContentView">
-        <div id="torrentCreationTasksTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
         <div id="torrentCreationTasksTableDiv" class="dynamicTableDiv">
+            <div id="torrentCreationTasksTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+                <table class="dynamicTable" style="position:relative;">
+                    <thead>
+                        <tr class="dynamicTableHeader"></tr>
+                    </thead>
+                </table>
+            </div>
             <table class="dynamicTable">
                 <tbody></tbody>
             </table>

--- a/src/webui/www/private/views/transferlist.html
+++ b/src/webui/www/private/views/transferlist.html
@@ -1,12 +1,11 @@
-<div id="torrentsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-    <table class="dynamicTable unselectable" style="position:relative;">
-        <thead>
-            <tr class="dynamicTableHeader"></tr>
-        </thead>
-    </table>
-</div>
-
 <div id="torrentsTableDiv" class="dynamicTableDiv">
+    <div id="torrentsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+        <table class="dynamicTable unselectable" style="position:relative;">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+        </table>
+    </div>
     <table class="dynamicTable unselectable">
         <tbody></tbody>
     </table>


### PR DESCRIPTION
DynamicTable used distinct tables for the fixed header and the body. This resulted in separate scroll containers that were kept in sync via JS. The scroll-linked handler ran a frame or more behind the composited scroll, so the header visibly trailed the body during horizontal scrolling.


The header and body now share a single scroll container, so they stay aligned during horizontal scrolling without JS.