### PR TITLE
Fix qBittorrent not quitting with Cmd+Q on macOS

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1181,6 +1181,22 @@ bool Application::event(QEvent *ev)
         return true;
     }
 
+    if (ev->type() == QEvent::Quit)
+    {
+        // On macOS a QEvent::Quit is delivered when the user quits via Cmd+Q,
+        // the Dock menu or the application menu. The default handler closes all
+        // top-level windows, but MainWindow::closeEvent only hides the window
+        // (ignoring the close) unless an explicit exit was requested. That would
+        // cancel the termination and leave qBittorrent stuck running with no
+        // visible window. Route the request through the same path as the "Exit"
+        // menu action so the application actually quits.
+        if (m_window)
+        {
+            m_window->forceExit();
+            return true;
+        }
+    }
+
     return BaseApplication::event(ev);
 }
 #endif // Q_OS_MACOS

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1002,6 +1002,11 @@ void MainWindow::on_actionSetGlobalSpeedLimits_triggered()
 // in one time if "close to systray" is enabled
 void MainWindow::on_actionExit_triggered()
 {
+    forceExit();
+}
+
+void MainWindow::forceExit()
+{
     // UI locking enforcement.
     if (isHidden() && m_uiLocked)
         // Ask for UI lock password

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -107,6 +107,9 @@ public:
 
     void activate();
     void cleanup();
+    // Triggers a real application exit (honoring the UI lock). On macOS this is
+    // also used to handle quitting via Cmd+Q, the Dock menu or the app menu.
+    void forceExit();
 
 private slots:
     void showFilterContextMenu();


### PR DESCRIPTION
On macOS, pressing **Cmd+Q** (or choosing Quit from the Dock or application menu) doesn't actually quit qBittorrent. The window disappears, but the process keeps running and lingers in the app switcher and the Force Quit list.

### Why it happens

On a quit request, Qt sends a `QEvent::Quit` to the application and the default handler tries to `close()` every top-level window. If any window ignores its close event, Qt treats the quit as cancelled.

`MainWindow::closeEvent` intentionally ignores the close on macOS (so the red ✕ just hides the window to the Dock) unless `m_forceExit` is set — and nothing ever set that flag for the native quit path. So the close gets ignored, the quit gets cancelled, and the app is left running with no window.

### The fix

Intercept `QEvent::Quit` in the macOS `Application::event()` override and route it through the same path as the existing "Exit" menu action (which sets `m_forceExit` before closing). Hide-to-Dock on window close is unchanged — only genuine quit requests are affected. qBittorrent's own shutdown code all uses `exit()` rather than `quit()`, so nothing else trips this path.

### Testing

Built and tested locally on macOS. Cmd+Q, the Dock/menu Quit items, and close-to-Dock-then-reopen-then-Cmd+Q all quit cleanly now, and confirm-on-exit still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
