### PR TITLE
GHA CI: suppress compiler warning on macOS

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build qBittorrent
         run: |
-          CXXFLAGS="$CXXFLAGS -DQT_FORCE_ASSERTS -Werror -Wno-error=deprecated-declarations" \
+          CXXFLAGS="$CXXFLAGS -DQT_FORCE_ASSERTS -Werror -Wno-error=deprecated-declarations -Wno-error=deprecated-literal-operator" \
           LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \


### PR DESCRIPTION
libtorrent 1.2.20 triggered `Wdeprecated-literal-operator` warning on macOS CI and this patch is to suppress it.
