### PR TITLE
Use stricter parsing for Peer Address inputs

### DIFF
--- a/src/base/bittorrent/peeraddress.cpp
+++ b/src/base/bittorrent/peeraddress.cpp
@@ -37,7 +37,9 @@ PeerAddress PeerAddress::parse(const QStringView address)
     QList<QStringView> ipPort;
 
     if (address.startsWith(u'[') && address.contains(u"]:"))
-    {  // IPv6
+    {
+        // IPv6
+
         ipPort = address.split(u"]:");
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
         ipPort[0].slice(1);  // chop '['
@@ -46,8 +48,12 @@ PeerAddress PeerAddress::parse(const QStringView address)
 #endif
     }
     else if (address.contains(u':'))
-    {  // IPv4
-        ipPort = address.split(u':');
+    {
+        // IPv4
+
+        ipPort = address.split(u':', Qt::KeepEmptyParts);
+        if (ipPort.size() > 2)
+            return {};
     }
     else
     {
@@ -62,7 +68,7 @@ PeerAddress PeerAddress::parse(const QStringView address)
     if (port == 0)
         return {};
 
-    return {ip, port};
+    return {.ip = ip, .port = port};
 }
 
 QString PeerAddress::toString() const

--- a/test/testbittorrentpeeraddress.cpp
+++ b/test/testbittorrentpeeraddress.cpp
@@ -30,7 +30,8 @@
 #include <QTest>
 
 #include "base/bittorrent/peeraddress.h"
-#include "base/global.h"
+
+using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
@@ -51,9 +52,13 @@ public:
 private slots:
     void testParse() const
     {
-        QCOMPARE(BitTorrent::PeerAddress::parse({}), BitTorrent::PeerAddress());
+        QCOMPARE(BitTorrent::PeerAddress::parse({}), {});
         QCOMPARE(BitTorrent::PeerAddress::parse(ipv4Str), ipv4);
         QCOMPARE(BitTorrent::PeerAddress::parse(ipv6Str), ipv6);
+
+        // malformed inputs
+        QCOMPARE(BitTorrent::PeerAddress::parse(u"1.2.3.4:80:80"), {});
+        QCOMPARE(BitTorrent::PeerAddress::parse(u"[2001::1]:80:80"), {});
     }
 
     void testToString() const


### PR DESCRIPTION
Now malformed inputs such as `1.2.3.4:80:90` will not be accepted. Previously it will be parsed into `{.ip = "1.2.3.4", .port = 80}`.
