### PR TITLE
Avoid duplicate reverse IP lookup operations

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(qbt_base STATIC
     utils/foreignapps.h
     utils/fs.h
     utils/gzip.h
+    utils/hashvalue.h
     utils/io.h
     utils/misc.h
     utils/net.h

--- a/src/base/net/reverseresolution.cpp
+++ b/src/base/net/reverseresolution.cpp
@@ -31,6 +31,8 @@
 #include <QHostInfo>
 #include <QString>
 
+#include "base/utils/hashvalue.h"
+
 const int CACHE_SIZE = 2048;
 
 using namespace Net;
@@ -70,8 +72,8 @@ ReverseResolution::ReverseResolution()
 ReverseResolution::~ReverseResolution()
 {
     // abort on-going lookups instead of waiting them
-    for (auto iter = m_lookups.cbegin(); iter != m_lookups.cend(); ++iter)
-        QHostInfo::abortHostLookup(iter.key());
+    for (const LookupRequest &data : m_lookups)
+        QHostInfo::abortHostLookup(data.id);
 }
 
 QString ReverseResolution::resolve(const QHostAddress &ip)
@@ -80,15 +82,20 @@ QString ReverseResolution::resolve(const QHostAddress &ip)
     if (hostname)
         return *hostname;
 
+    // in-flight requests
+    if (const auto &byAddress = m_lookups.get<ByAddress>(); byAddress.find(ip) != byAddress.end())
+        return {};
+
     // do reverse lookup: IP -> hostname
     const int lookupId = QHostInfo::lookupHost(ip.toString(), this, &ReverseResolution::hostResolved);
-    m_lookups.insert(lookupId, ip);
+    m_lookups.insert({.id = lookupId, .address = ip});
+
     return {};
 }
 
 void ReverseResolution::hostResolved(const QHostInfo &host)
 {
-    const QHostAddress ip = m_lookups.take(host.lookupId());
+    const QHostAddress ip = m_lookups.get<ByLookupID>().extract(host.lookupId()).value().address;
 
     if (host.error() != QHostInfo::NoError)
     {

--- a/src/base/net/reverseresolution.h
+++ b/src/base/net/reverseresolution.h
@@ -28,6 +28,11 @@
 
 #pragma once
 
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/key.hpp>
+#include <boost/multi_index/tag.hpp>
+
 #include <QCache>
 #include <QHostAddress>
 #include <QObject>
@@ -61,7 +66,19 @@ namespace Net
 
         static ReverseResolution *m_instance;
 
-        QHash<int, QHostAddress> m_lookups;  // <LookupID, IP>
+        struct LookupRequest
+        {
+            int id = -1;  // lookup ID
+            QHostAddress address;
+        };
+
+        using Lookups = boost::multi_index_container<
+            LookupRequest,
+            boost::multi_index::indexed_by<
+                boost::multi_index::hashed_unique<boost::multi_index::tag<struct ByLookupID>, boost::multi_index::key<&LookupRequest::id>>,
+                boost::multi_index::hashed_unique<boost::multi_index::tag<struct ByAddress>, boost::multi_index::key<&LookupRequest::address>>>>;
+        Lookups m_lookups;
+
         QCache<QHostAddress, QString> m_cache;  // <IP, HostName>
     };
 }

--- a/src/base/utils/hashvalue.h
+++ b/src/base/utils/hashvalue.h
@@ -1,0 +1,48 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QHash>
+
+class QString;
+
+// boost doesn't use `std::hash` and instead use their own `boost::hash_value()`
+// so we need to provide a hash template for Qt types
+template <typename T>
+std::size_t hash_value(const T &value)
+{
+    return ::qHash(value);
+}
+
+// boost hash will sometimes confuse on Qt types, so to avoid ambiguity create specific  `hash_value()` functions below
+
+inline std::size_t hash_value(const QString &value)
+{
+    return hash_value<QString>(value);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(testFiles
     testutilscompare.cpp
     testutilsdatetime.cpp
     testutilsgzip.cpp
+    testutilshashvalue.cpp
     testutilsio.cpp
     testutilsmisc.cpp
     testutilsnumber.cpp

--- a/test/testutilshashvalue.cpp
+++ b/test/testutilshashvalue.cpp
@@ -1,0 +1,61 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <boost/unordered_set.hpp>
+
+#include <QObject>
+#include <QString>
+#include <QTest>
+
+#include "base/utils/hashvalue.h"
+
+using namespace Qt::Literals::StringLiterals;
+
+class TestUtilsHashValue final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestUtilsHashValue)
+
+public:
+    TestUtilsHashValue() = default;
+
+private slots:
+    void testHashValue() const
+    {
+        QCOMPARE_NE(hash_value(u"a"_s), hash_value(u"b"_s));
+
+        // test whether boost hash-based containers is able to store/hash Qt types
+        boost::unordered_set<QString> set;
+        set.insert(QString());
+        QCOMPARE(set.size(), 1);
+        QCOMPARE(*set.begin(), QString());
+    }
+};
+
+QTEST_APPLESS_MAIN(TestUtilsHashValue)
+#include "testutilshashvalue.moc"


### PR DESCRIPTION
Previously when quickly switching between torrents, a new lookup will be performed for every unresolved hostname. Now in-flight requests are checked before actually starting a new lookup operation.
