### PR TITLE
Enable links in add torrent comments

### DIFF
--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -484,7 +484,7 @@
                      <bool>true</bool>
                     </property>
                     <property name="textInteractionFlags">
-                     <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+                     <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
Closes #23797.

Enables mouse and keyboard link activation for Add Torrent dialog comments while keeping the existing text selection behavior.
