### PR TITLE
Sort peer IP addresses numerically

### DIFF
--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -68,6 +68,11 @@ namespace
         return true;
     }
 
+    bool isIPv6LessThan(const QHostAddress &left, const QHostAddress &right)
+    {
+        return std::ranges::lexicographical_compare(left.toIPv6Address().c, right.toIPv6Address().c);
+    }
+
     bool isValidIPRange(const QHostAddress &first, const QHostAddress &last)
     {
         if (first.isNull() || last.isNull())
@@ -77,7 +82,7 @@ namespace
         if (first.protocol() == QAbstractSocket::IPv4Protocol)
             return first.toIPv4Address() <= last.toIPv4Address();
         if (first.protocol() == QAbstractSocket::IPv6Protocol)
-            return std::ranges::lexicographical_compare(first.toIPv6Address().c, last.toIPv6Address().c, std::less_equal());
+            return !isIPv6LessThan(last, first);
         return false;
     }
 }
@@ -122,6 +127,30 @@ namespace Utils
                 return addr.isInSubnet(subnet)
                     || (addrConversionOk && protocolEquivalentAddress.isInSubnet(subnet));
             });
+        }
+
+        bool isIPAddressLessThan(const QHostAddress &left, const QHostAddress &right)
+        {
+            const auto leftProtocol = left.protocol();
+            const auto rightProtocol = right.protocol();
+
+            if (leftProtocol == QAbstractSocket::IPv4Protocol)
+            {
+                if (rightProtocol == QAbstractSocket::IPv4Protocol)
+                    return (left.toIPv4Address() < right.toIPv4Address());
+                if (rightProtocol == QAbstractSocket::IPv6Protocol)
+                    return true;
+            }
+
+            if (leftProtocol == QAbstractSocket::IPv6Protocol)
+            {
+                if (rightProtocol == QAbstractSocket::IPv4Protocol)
+                    return false;
+                if (rightProtocol == QAbstractSocket::IPv6Protocol)
+                    return isIPv6LessThan(left, right);
+            }
+
+            return (left.toString() < right.toString());
         }
 
         QString subnetToString(const Subnet &subnet)

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -70,6 +70,9 @@ namespace
 
     bool isIPv6LessThan(const QHostAddress &left, const QHostAddress &right)
     {
+        Q_ASSERT(left.protocol() == QAbstractSocket::IPv6Protocol);
+        Q_ASSERT(right.protocol() == QAbstractSocket::IPv6Protocol);
+
         return std::ranges::lexicographical_compare(left.toIPv6Address().c, right.toIPv6Address().c);
     }
 

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -85,7 +85,7 @@ namespace
         if (first.protocol() == QAbstractSocket::IPv4Protocol)
             return first.toIPv4Address() <= last.toIPv4Address();
         if (first.protocol() == QAbstractSocket::IPv6Protocol)
-            return !isIPv6LessThan(last, first);
+            return (first == last) || isIPv6LessThan(first, last);
         return false;
     }
 }

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -68,12 +68,28 @@ namespace
         return true;
     }
 
-    bool isIPv6LessThan(const QHostAddress &left, const QHostAddress &right)
+    bool operator<(const QHostAddress &left, const QHostAddress &right)
     {
-        Q_ASSERT(left.protocol() == QAbstractSocket::IPv6Protocol);
-        Q_ASSERT(right.protocol() == QAbstractSocket::IPv6Protocol);
+        const auto leftProtocol = left.protocol();
+        const auto rightProtocol = right.protocol();
 
-        return std::ranges::lexicographical_compare(left.toIPv6Address().c, right.toIPv6Address().c);
+        if (leftProtocol == QAbstractSocket::IPv4Protocol)
+        {
+            if (rightProtocol == QAbstractSocket::IPv4Protocol)
+                return (left.toIPv4Address() < right.toIPv4Address());
+            if (rightProtocol == QAbstractSocket::IPv6Protocol)
+                return true;
+        }
+
+        if (leftProtocol == QAbstractSocket::IPv6Protocol)
+        {
+            if (rightProtocol == QAbstractSocket::IPv4Protocol)
+                return false;
+            if (rightProtocol == QAbstractSocket::IPv6Protocol)
+                return std::ranges::lexicographical_compare(left.toIPv6Address().c, right.toIPv6Address().c);
+        }
+
+        return (left.toString() < right.toString());
     }
 
     bool isValidIPRange(const QHostAddress &first, const QHostAddress &last)
@@ -85,7 +101,7 @@ namespace
         if (first.protocol() == QAbstractSocket::IPv4Protocol)
             return first.toIPv4Address() <= last.toIPv4Address();
         if (first.protocol() == QAbstractSocket::IPv6Protocol)
-            return (first == last) || isIPv6LessThan(first, last);
+            return !(last < first);
         return false;
     }
 }
@@ -130,30 +146,6 @@ namespace Utils
                 return addr.isInSubnet(subnet)
                     || (addrConversionOk && protocolEquivalentAddress.isInSubnet(subnet));
             });
-        }
-
-        bool isIPAddressLessThan(const QHostAddress &left, const QHostAddress &right)
-        {
-            const auto leftProtocol = left.protocol();
-            const auto rightProtocol = right.protocol();
-
-            if (leftProtocol == QAbstractSocket::IPv4Protocol)
-            {
-                if (rightProtocol == QAbstractSocket::IPv4Protocol)
-                    return (left.toIPv4Address() < right.toIPv4Address());
-                if (rightProtocol == QAbstractSocket::IPv6Protocol)
-                    return true;
-            }
-
-            if (leftProtocol == QAbstractSocket::IPv6Protocol)
-            {
-                if (rightProtocol == QAbstractSocket::IPv4Protocol)
-                    return false;
-                if (rightProtocol == QAbstractSocket::IPv6Protocol)
-                    return isIPv6LessThan(left, right);
-            }
-
-            return (left.toString() < right.toString());
         }
 
         QString subnetToString(const Subnet &subnet)

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -47,6 +47,7 @@ namespace Utils::Net
     bool isValidIP(const QString &ip);
     std::optional<Subnet> parseSubnet(const QString &subnetStr);
     bool isIPInSubnets(const QHostAddress &addr, const QList<Subnet> &subnets);
+    bool isIPAddressLessThan(const QHostAddress &left, const QHostAddress &right);
     QString subnetToString(const Subnet &subnet);
     IPRange subnetToIPRange(const Subnet &subnet);
     QHostAddress canonicalIPv6Addr(const QHostAddress &addr);

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -47,7 +47,6 @@ namespace Utils::Net
     bool isValidIP(const QString &ip);
     std::optional<Subnet> parseSubnet(const QString &subnetStr);
     bool isIPInSubnets(const QHostAddress &addr, const QList<Subnet> &subnets);
-    bool isIPAddressLessThan(const QHostAddress &left, const QHostAddress &right);
     QString subnetToString(const Subnet &subnet);
     IPRange subnetToIPRange(const Subnet &subnet);
     QHostAddress canonicalIPv6Addr(const QHostAddress &addr);

--- a/src/gui/properties/peerlistsortmodel.cpp
+++ b/src/gui/properties/peerlistsortmodel.cpp
@@ -28,7 +28,6 @@
 
 #include "peerlistsortmodel.h"
 
-#include <QHostAddress>
 #include <QMetaType>
 
 #include "base/utils/net.h"
@@ -48,6 +47,20 @@ bool PeerListSortModel::lessThan(const QModelIndex &left, const QModelIndex &rig
         {
             const QVariant leftData = left.data(UnderlyingDataRole);
             const QVariant rightData = right.data(UnderlyingDataRole);
+            static const QMetaType peerIPSortDataType = QMetaType::fromType<PeerListIPSortData>();
+            if ((leftData.metaType() == peerIPSortDataType) && (rightData.metaType() == peerIPSortDataType))
+            {
+                const PeerListIPSortData leftPeer = leftData.value<PeerListIPSortData>();
+                const PeerListIPSortData rightPeer = rightData.value<PeerListIPSortData>();
+
+                if (Utils::Net::isIPAddressLessThan(leftPeer.ip, rightPeer.ip))
+                    return true;
+                if (Utils::Net::isIPAddressLessThan(rightPeer.ip, leftPeer.ip))
+                    return false;
+
+                return (leftPeer.port < rightPeer.port);
+            }
+
             static const QMetaType hostAddressType = QMetaType::fromType<QHostAddress>();
             if ((leftData.metaType() == hostAddressType) && (rightData.metaType() == hostAddressType))
                 return Utils::Net::isIPAddressLessThan(leftData.value<QHostAddress>(), rightData.value<QHostAddress>());

--- a/src/gui/properties/peerlistsortmodel.cpp
+++ b/src/gui/properties/peerlistsortmodel.cpp
@@ -30,8 +30,34 @@
 
 #include <QMetaType>
 
-#include "base/utils/net.h"
 #include "peerlistwidget.h"
+
+namespace
+{
+    bool isIPAddressLessThan(const QHostAddress &left, const QHostAddress &right)
+    {
+        const auto leftProtocol = left.protocol();
+        const auto rightProtocol = right.protocol();
+
+        if (leftProtocol == QAbstractSocket::IPv4Protocol)
+        {
+            if (rightProtocol == QAbstractSocket::IPv4Protocol)
+                return (left.toIPv4Address() < right.toIPv4Address());
+            if (rightProtocol == QAbstractSocket::IPv6Protocol)
+                return true;
+        }
+
+        if (leftProtocol == QAbstractSocket::IPv6Protocol)
+        {
+            if (rightProtocol == QAbstractSocket::IPv4Protocol)
+                return false;
+            if (rightProtocol == QAbstractSocket::IPv6Protocol)
+                return std::ranges::lexicographical_compare(left.toIPv6Address().c, right.toIPv6Address().c);
+        }
+
+        return (left.toString() < right.toString());
+    }
+}
 
 PeerListSortModel::PeerListSortModel(QObject *parent)
     : QSortFilterProxyModel(parent)
@@ -45,25 +71,25 @@ bool PeerListSortModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     {
     case PeerListWidget::IP:
         {
+            const QMetaType peerIPSortDataType = QMetaType::fromType<PeerListIPSortData>();
+            const QMetaType hostAddressType = QMetaType::fromType<QHostAddress>();
             const QVariant leftData = left.data(UnderlyingDataRole);
             const QVariant rightData = right.data(UnderlyingDataRole);
-            static const QMetaType peerIPSortDataType = QMetaType::fromType<PeerListIPSortData>();
             if ((leftData.metaType() == peerIPSortDataType) && (rightData.metaType() == peerIPSortDataType))
             {
                 const PeerListIPSortData leftPeer = leftData.value<PeerListIPSortData>();
                 const PeerListIPSortData rightPeer = rightData.value<PeerListIPSortData>();
 
-                if (Utils::Net::isIPAddressLessThan(leftPeer.ip, rightPeer.ip))
+                if (isIPAddressLessThan(leftPeer.ip, rightPeer.ip))
                     return true;
-                if (Utils::Net::isIPAddressLessThan(rightPeer.ip, leftPeer.ip))
+                if (isIPAddressLessThan(rightPeer.ip, leftPeer.ip))
                     return false;
 
                 return (leftPeer.port < rightPeer.port);
             }
 
-            static const QMetaType hostAddressType = QMetaType::fromType<QHostAddress>();
             if ((leftData.metaType() == hostAddressType) && (rightData.metaType() == hostAddressType))
-                return Utils::Net::isIPAddressLessThan(leftData.value<QHostAddress>(), rightData.value<QHostAddress>());
+                return isIPAddressLessThan(leftData.value<QHostAddress>(), rightData.value<QHostAddress>());
 
             return m_naturalLessThan(leftData.toString(), rightData.toString());
         }

--- a/src/gui/properties/peerlistsortmodel.cpp
+++ b/src/gui/properties/peerlistsortmodel.cpp
@@ -48,13 +48,12 @@ bool PeerListSortModel::lessThan(const QModelIndex &left, const QModelIndex &rig
         {
             const QVariant leftData = left.data(UnderlyingDataRole);
             const QVariant rightData = right.data(UnderlyingDataRole);
-            const QMetaType hostAddressType = QMetaType::fromType<QHostAddress>();
+            static const QMetaType hostAddressType = QMetaType::fromType<QHostAddress>();
             if ((leftData.metaType() == hostAddressType) && (rightData.metaType() == hostAddressType))
                 return Utils::Net::isIPAddressLessThan(leftData.value<QHostAddress>(), rightData.value<QHostAddress>());
 
             return m_naturalLessThan(leftData.toString(), rightData.toString());
         }
-        break;
     case PeerListWidget::CLIENT:
         {
             const QString strL = left.data(UnderlyingDataRole).toString();

--- a/src/gui/properties/peerlistsortmodel.h
+++ b/src/gui/properties/peerlistsortmodel.h
@@ -28,9 +28,18 @@
 
 #pragma once
 
+#include <QHostAddress>
+#include <QMetaType>
 #include <QSortFilterProxyModel>
+#include <QtTypes>
 
 #include "base/utils/compare.h"
+
+struct PeerListIPSortData
+{
+    QHostAddress ip;
+    ushort port = 0;
+};
 
 class PeerListSortModel final : public QSortFilterProxyModel
 {
@@ -50,3 +59,5 @@ private:
 
     Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> m_naturalLessThan;
 };
+
+Q_DECLARE_METATYPE(PeerListIPSortData)

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -444,7 +444,7 @@ void PeerListWidget::loadPeers(const BitTorrent::Torrent *torrent)
                 const bool useI2PSocket = peer.useI2PSocket();
 
                 const QString peerIPString = useI2PSocket ? peer.I2PAddress() : peerEndpoint.address.ip.toString();
-                const QVariant peerIPSortData = useI2PSocket ? QVariant {peerIPString} : QVariant::fromValue(peerEndpoint.address.ip);
+                const QVariant peerIPSortData = useI2PSocket ? QVariant(peerIPString) : QVariant::fromValue(peerEndpoint.address.ip);
                 setModelData(m_listModel, row, PeerListColumns::IP, peerIPString, peerIPSortData, {}, peerIPString);
 
                 const QString peerIPHiddenString = useI2PSocket ? QString() : peerEndpoint.address.ip.toString();

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -444,7 +444,8 @@ void PeerListWidget::loadPeers(const BitTorrent::Torrent *torrent)
                 const bool useI2PSocket = peer.useI2PSocket();
 
                 const QString peerIPString = useI2PSocket ? peer.I2PAddress() : peerEndpoint.address.ip.toString();
-                setModelData(m_listModel, row, PeerListColumns::IP, peerIPString, peerIPString, {}, peerIPString);
+                const QVariant peerIPSortData = useI2PSocket ? QVariant {peerIPString} : QVariant::fromValue(peerEndpoint.address.ip);
+                setModelData(m_listModel, row, PeerListColumns::IP, peerIPString, peerIPSortData, {}, peerIPString);
 
                 const QString peerIPHiddenString = useI2PSocket ? QString() : peerEndpoint.address.ip.toString();
                 setModelData(m_listModel, row, PeerListColumns::IP_HIDDEN, peerIPHiddenString, peerIPHiddenString);

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -444,7 +444,9 @@ void PeerListWidget::loadPeers(const BitTorrent::Torrent *torrent)
                 const bool useI2PSocket = peer.useI2PSocket();
 
                 const QString peerIPString = useI2PSocket ? peer.I2PAddress() : peerEndpoint.address.ip.toString();
-                const QVariant peerIPSortData = useI2PSocket ? QVariant(peerIPString) : QVariant::fromValue(peerEndpoint.address.ip);
+                const QVariant peerIPSortData = useI2PSocket
+                    ? QVariant(peerIPString)
+                    : QVariant::fromValue(PeerListIPSortData {peerEndpoint.address.ip, peerEndpoint.address.port});
                 setModelData(m_listModel, row, PeerListColumns::IP, peerIPString, peerIPSortData, {}, peerIPString);
 
                 const QString peerIPHiddenString = useI2PSocket ? QString() : peerEndpoint.address.ip.toString();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(testFiles
     testutilsgzip.cpp
     testutilsio.cpp
     testutilsmisc.cpp
+    testutilsnet.cpp
     testutilsnumber.cpp
     testutilsstring.cpp
     testutilsversion.cpp

--- a/test/testutilsnet.cpp
+++ b/test/testutilsnet.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2013  Nick Tiskov <daymansmail@gmail.com>
+ * Copyright (C) 2026  Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,43 +26,35 @@
  * exception statement from your version.
  */
 
-#include "peerlistsortmodel.h"
-
 #include <QHostAddress>
-#include <QMetaType>
+#include <QObject>
+#include <QTest>
 
+#include "base/global.h"
 #include "base/utils/net.h"
-#include "peerlistwidget.h"
 
-PeerListSortModel::PeerListSortModel(QObject *parent)
-    : QSortFilterProxyModel(parent)
+class TestUtilsNet final : public QObject
 {
-    setSortRole(UnderlyingDataRole);
-}
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestUtilsNet)
 
-bool PeerListSortModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
-{
-    switch (sortColumn())
+public:
+    TestUtilsNet() = default;
+
+private slots:
+    void testIsIPAddressLessThan() const
     {
-    case PeerListWidget::IP:
-        {
-            const QVariant leftData = left.data(UnderlyingDataRole);
-            const QVariant rightData = right.data(UnderlyingDataRole);
-            const QMetaType hostAddressType = QMetaType::fromType<QHostAddress>();
-            if ((leftData.metaType() == hostAddressType) && (rightData.metaType() == hostAddressType))
-                return Utils::Net::isIPAddressLessThan(leftData.value<QHostAddress>(), rightData.value<QHostAddress>());
+        QVERIFY(Utils::Net::isIPAddressLessThan(QHostAddress(u"127.0.0.1"_s), QHostAddress(u"127.0.0.2"_s)));
+        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"127.0.0.1"_s), QHostAddress(u"127.0.0.1"_s)));
+        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"127.0.0.2"_s), QHostAddress(u"127.0.0.1"_s)));
 
-            return m_naturalLessThan(leftData.toString(), rightData.toString());
-        }
-        break;
-    case PeerListWidget::CLIENT:
-        {
-            const QString strL = left.data(UnderlyingDataRole).toString();
-            const QString strR = right.data(UnderlyingDataRole).toString();
-            return m_naturalLessThan(strL, strR);
-        }
-        break;
-    default:
-        return QSortFilterProxyModel::lessThan(left, right);
-    };
-}
+        QVERIFY(Utils::Net::isIPAddressLessThan(QHostAddress(u"2001:db8::f"_s), QHostAddress(u"2001:db8::10"_s)));
+        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"2001:db8::10"_s), QHostAddress(u"2001:db8::f"_s)));
+
+        QVERIFY(Utils::Net::isIPAddressLessThan(QHostAddress(u"255.255.255.255"_s), QHostAddress(u"::1"_s)));
+        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"::1"_s), QHostAddress(u"255.255.255.255"_s)));
+    }
+};
+
+QTEST_APPLESS_MAIN(TestUtilsNet)
+#include "testutilsnet.moc"

--- a/test/testutilsnet.cpp
+++ b/test/testutilsnet.cpp
@@ -26,7 +26,6 @@
  * exception statement from your version.
  */
 
-#include <QHostAddress>
 #include <QObject>
 #include <QTest>
 
@@ -42,19 +41,6 @@ public:
     TestUtilsNet() = default;
 
 private slots:
-    void testIsIPAddressLessThan() const
-    {
-        QVERIFY(Utils::Net::isIPAddressLessThan(QHostAddress(u"127.0.0.1"_s), QHostAddress(u"127.0.0.2"_s)));
-        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"127.0.0.1"_s), QHostAddress(u"127.0.0.1"_s)));
-        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"127.0.0.2"_s), QHostAddress(u"127.0.0.1"_s)));
-
-        QVERIFY(Utils::Net::isIPAddressLessThan(QHostAddress(u"2001:db8::f"_s), QHostAddress(u"2001:db8::10"_s)));
-        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"2001:db8::10"_s), QHostAddress(u"2001:db8::f"_s)));
-
-        QVERIFY(Utils::Net::isIPAddressLessThan(QHostAddress(u"255.255.255.255"_s), QHostAddress(u"::1"_s)));
-        QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"::1"_s), QHostAddress(u"255.255.255.255"_s)));
-    }
-
     void testParseIPv6Range() const
     {
         QVERIFY(Utils::Net::parseIPRange(u"2001:db8::1"_s));

--- a/test/testutilsnet.cpp
+++ b/test/testutilsnet.cpp
@@ -54,6 +54,13 @@ private slots:
         QVERIFY(Utils::Net::isIPAddressLessThan(QHostAddress(u"255.255.255.255"_s), QHostAddress(u"::1"_s)));
         QVERIFY(!Utils::Net::isIPAddressLessThan(QHostAddress(u"::1"_s), QHostAddress(u"255.255.255.255"_s)));
     }
+
+    void testParseIPv6Range() const
+    {
+        QVERIFY(Utils::Net::parseIPRange(u"2001:db8::1"_s));
+        QVERIFY(Utils::Net::parseIPRange(u"2001:db8::1 - 2001:db8::2"_s));
+        QVERIFY(!Utils::Net::parseIPRange(u"2001:db8::2 - 2001:db8::1"_s));
+    }
 };
 
 QTEST_APPLESS_MAIN(TestUtilsNet)


### PR DESCRIPTION
Closes #13241.

Sorts peer IP addresses by their parsed address values instead of their display strings, so IPv6 peers with hexadecimal segments order numerically. Adds coverage for the address comparator used by the peer list.
