### PR TITLE
Use cleaned (deduplicated) file paths when adding torrent

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2832,7 +2832,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         filePaths = addTorrentParams.filePaths;
         if (filePaths.isEmpty())
         {
-            filePaths = torrentInfo.filePaths();
+            filePaths = source.filePaths();
             if (loadTorrentParams.contentLayout != TorrentContentLayout::Original)
             {
                 const Path originalRootFolder = Path::findRootFolder(filePaths);

--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -264,6 +264,33 @@ QList<QUrl> BitTorrent::TorrentDescriptor::urlSeeds() const
     return urlSeeds;
 }
 
+PathList BitTorrent::TorrentDescriptor::filePaths() const
+{
+    if (!m_info)
+        return {};
+
+    const int filesCount = m_info->filesCount();
+    PathList paths;
+    paths.reserve(filesCount);
+#if LIBTORRENT_VERSION_NUM >= 20100
+    const lt::file_storage &ltFileStorage = m_ltAddTorrentParams.ti->layout();
+#else
+    const lt::file_storage &ltFileStorage = m_ltAddTorrentParams.ti->files();
+#endif
+    const QList<lt::file_index_t> nativeIndexes = m_info->nativeIndexes();
+    for (int i = 0; i < filesCount; ++i)
+    {
+        const lt::file_index_t nativeIndex = nativeIndexes[i];
+        const auto &renamedFiles = m_ltAddTorrentParams.renamed_files;
+        if (const auto it = renamedFiles.find(nativeIndex); it != renamedFiles.cend())
+            paths.emplaceBack(Path(it->second));
+        else
+            paths.emplaceBack(Path(ltFileStorage.file_path(nativeIndex)));
+    }
+
+    return paths;
+}
+
 const libtorrent::add_torrent_params &BitTorrent::TorrentDescriptor::ltAddTorrentParams() const
 {
     return m_ltAddTorrentParams;

--- a/src/base/bittorrent/torrentdescriptor.h
+++ b/src/base/bittorrent/torrentdescriptor.h
@@ -61,8 +61,9 @@ namespace BitTorrent
         QString comment() const;
         QList<TrackerEntry> trackers() const;
         QList<QUrl> urlSeeds() const;
-        const std::optional<TorrentInfo> &info() const;
+        PathList filePaths() const;
 
+        const std::optional<TorrentInfo> &info() const;
         void setTorrentInfo(TorrentInfo torrentInfo);
 
         static nonstd::expected<TorrentDescriptor, QString> load(const QByteArray &data) noexcept;

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -162,8 +162,9 @@ PathList TorrentInfo::filePaths() const
 {
     PathList list;
     list.reserve(filesCount());
+    const lt::file_storage &ltFileStorage = getFileStorage(*m_nativeInfo);
     for (int i = 0; i < filesCount(); ++i)
-        list << filePath(i);
+        list.append(Path(ltFileStorage.file_path(m_nativeIndexes[i])));
 
     return list;
 }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -820,7 +820,7 @@ void AddNewTorrentDialog::setupTreeview()
 
     BitTorrent::AddTorrentParams &addTorrentParams = m_currentContext->torrentParams;
     if (addTorrentParams.filePaths.isEmpty())
-        addTorrentParams.filePaths = torrentInfo.filePaths();
+        addTorrentParams.filePaths = torrentDescr.filePaths();
 
     if (addTorrentParams.filePriorities.isEmpty())
     {


### PR DESCRIPTION
`libtorrent` cleans file names when parsing torrent metadata (e.g. if there are unsupported characters or duplicate filenames on current platform) so when adding a torrent, we must use the cleaned names instead of the original ones. Otherwise, the user may get a name conflict if they do not manually clean them before adding.
For example, file names that differ only in case are usually allowed in *nix file systems, but adding a torrent with such files in Windows will give you a name conflict (they will all write to the same file).