### PR TITLE
WebUI: Replace newline with empty space in translation strings

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -281,6 +281,10 @@ void WebApplication::translateDocument(QString &data) const
             // 2. The escaped quote/string is wrong for JS. JS use backslash to escape the quote: "\""
             translation.replace(u'"', u"&#34;"_s);
 
+            // replace newline with empty space because Javascript string cannot have a hard break within quotes
+            // some "translation" string in the webui_it has newlines in the text
+            translation.replace(u'\n', u""_s);
+
             data.replace(i, regexMatch.capturedLength(), translation);
             i += translation.length();
         }

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -281,8 +281,8 @@ void WebApplication::translateDocument(QString &data) const
             // 2. The escaped quote/string is wrong for JS. JS use backslash to escape the quote: "\""
             translation.replace(u'"', u"&#34;"_s);
 
-            // replace newline with empty space because Javascript string cannot have a hard break within quotes
-            // some "translation" string in the webui_it has newlines in the text
+            // Replace newline with empty space because Javascript string literal cannot have an
+            // unescaped line break. Some "translation" string in the webui_it has newlines in the text
             translation.replace(u'\n', u""_s);
 
             data.replace(i, regexMatch.capturedLength(), translation);


### PR DESCRIPTION
Closes #24610

The Italian translation has newline in the translation causing the Javascript strings to break.

Example:

https://github.com/qbittorrent/qBittorrent/blob/5527661610ccdb3167ce1f52c21bb45e7018abae/src/webui/www/translations/webui_it.ts#L5314-L5323

This is causing the generated HTML to be invalid because the javascript string would have a line break:

<img width="1147" height="322" alt="Screenshot from 2026-06-30 16-00-33" src="https://github.com/user-attachments/assets/74cbbdcf-ce25-400b-91fa-c4890e33fc2d" />

We replace the `\n` with `` (empty space) on the backend so the rendered HTML/ JS is valid
