### PR TITLE
Add default WebSocket tracker for WebTorrent browser peer discovery

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -309,6 +309,8 @@ namespace BitTorrent
         virtual void setAddTrackersEnabled(bool enabled) = 0;
         virtual QString additionalTrackers() const = 0;
         virtual void setAdditionalTrackers(const QString &trackers) = 0;
+        virtual bool isAddWebSocketTrackersEnabled() const = 0;
+        virtual void setAddWebSocketTrackersEnabled(bool enabled) = 0;
         virtual bool isIPFilteringEnabled() const = 0;
         virtual void setIPFilteringEnabled(bool enabled) = 0;
         virtual Path IPFilterFile() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -129,6 +129,16 @@ namespace
     const auto USER_AGENT = QStringLiteral("qBittorrent/" QBT_VERSION_2);
     const QString DEFAULT_DHT_BOOTSTRAP_NODES = u"dht.libtorrent.org:25401, dht.transmissionbt.com:6881, router.bt.ouinet.work:6881"_s;
 
+    // Default WebSocket (WebTorrent/WebRTC) trackers used to make torrents reachable from
+    // browser-based WebTorrent peers. Torrents rarely carry a wss:// tracker themselves since
+    // ordinary scrapers only ever emit udp:// or http(s):// trackers.
+    const QList<TrackerEntry> DEFAULT_WEBSOCKET_TRACKERS =
+    {
+        {u"wss://tracker.btorrent.xyz"_s, 0},
+        {u"wss://tracker.openwebtorrent.com"_s, 0},
+        {u"wss://tracker.webtorrent.dev"_s, 0},
+    };
+
     void torrentQueuePositionUp(const lt::torrent_handle &handle)
     {
         try
@@ -518,6 +528,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_additionalTrackers(BITTORRENT_SESSION_KEY(u"AdditionalTrackers"_s))
     , m_isAddTrackersFromURLEnabled(BITTORRENT_SESSION_KEY(u"AddTrackersFromURLEnabled"_s), false)
     , m_additionalTrackersURL(BITTORRENT_SESSION_KEY(u"AdditionalTrackersURL"_s))
+    , m_isAddWebSocketTrackersEnabled(BITTORRENT_SESSION_KEY(u"AddWebSocketTrackersEnabled"_s), true)
     , m_globalMaxRatio(BITTORRENT_SESSION_KEY(u"GlobalMaxRatio"_s), -1, [](qreal r) { return r < 0 ? -1. : r; })
     , m_globalMaxSeedingMinutes(BITTORRENT_SESSION_KEY(u"GlobalMaxSeedingMinutes"_s)
         , NO_SEEDING_TIME_LIMIT, lowerLimited(NO_SEEDING_TIME_LIMIT))
@@ -2932,6 +2943,26 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         }
     }
 
+    if (isAddWebSocketTrackersEnabled() && !(hasMetadata && p.ti->priv()))
+    {
+        const std::vector<std::string> existingTrackers = p.trackers;
+        const auto maxTierIter = std::ranges::max_element(asConst(p.tracker_tiers));
+        const int baseTier = (maxTierIter != p.tracker_tiers.cend()) ? (*maxTierIter + 1) : 0;
+
+        p.trackers.reserve(p.trackers.size() + static_cast<std::size_t>(DEFAULT_WEBSOCKET_TRACKERS.size()));
+        p.tracker_tiers.reserve(p.trackers.size() + static_cast<std::size_t>(DEFAULT_WEBSOCKET_TRACKERS.size()));
+        p.tracker_tiers.resize(p.trackers.size(), 0);
+        for (const TrackerEntry &trackerEntry : DEFAULT_WEBSOCKET_TRACKERS)
+        {
+            const std::string url = trackerEntry.url.toStdString();
+            if (std::ranges::find(existingTrackers, url) != existingTrackers.cend())
+                continue;
+
+            p.trackers.emplace_back(url);
+            p.tracker_tiers.emplace_back(Utils::Number::clampingAdd(trackerEntry.tier, baseTier));
+        }
+    }
+
     p.upload_limit = addTorrentParams.uploadLimit;
     p.download_limit = addTorrentParams.downloadLimit;
 
@@ -4008,6 +4039,16 @@ void SessionImpl::setAdditionalTrackers(const QString &trackers)
 
     m_additionalTrackers = trackers;
     populateAdditionalTrackers();
+}
+
+bool SessionImpl::isAddWebSocketTrackersEnabled() const
+{
+    return m_isAddWebSocketTrackersEnabled;
+}
+
+void SessionImpl::setAddWebSocketTrackersEnabled(const bool enabled)
+{
+    m_isAddWebSocketTrackersEnabled = enabled;
 }
 
 bool SessionImpl::isAddTrackersFromURLEnabled() const

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -284,6 +284,8 @@ namespace BitTorrent
         void setAddTrackersEnabled(bool enabled) override;
         QString additionalTrackers() const override;
         void setAdditionalTrackers(const QString &trackers) override;
+        bool isAddWebSocketTrackersEnabled() const override;
+        void setAddWebSocketTrackersEnabled(bool enabled) override;
         bool isIPFilteringEnabled() const override;
         void setIPFilteringEnabled(bool enabled) override;
         Path IPFilterFile() const override;
@@ -719,6 +721,7 @@ namespace BitTorrent
         CachedSettingValue<QString> m_additionalTrackers;
         CachedSettingValue<bool> m_isAddTrackersFromURLEnabled;
         CachedSettingValue<QString> m_additionalTrackersURL;
+        CachedSettingValue<bool> m_isAddWebSocketTrackersEnabled;
         CachedSettingValue<qreal> m_globalMaxRatio;
         CachedSettingValue<int> m_globalMaxSeedingMinutes;
         CachedSettingValue<int> m_globalMaxInactiveSeedingMinutes;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1236,6 +1236,8 @@ void OptionsDialog::loadBittorrentTabOptions()
     m_ui->textTrackersURL->setText(session->additionalTrackersURL());
     m_ui->textTrackersFromURL->setPlainText(session->additionalTrackersFromURL());
 
+    m_ui->checkAddWebSocketTrackers->setChecked(session->isAddWebSocketTrackersEnabled());
+
     connect(m_ui->checkDHT, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkPeX, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkLSD, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -1273,6 +1275,8 @@ void OptionsDialog::loadBittorrentTabOptions()
 
     connect(m_ui->checkAddTrackersFromURL, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textTrackersURL, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+
+    connect(m_ui->checkAddWebSocketTrackers, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 }
 
 void OptionsDialog::saveBittorrentTabOptions() const
@@ -1316,6 +1320,8 @@ void OptionsDialog::saveBittorrentTabOptions() const
 
     session->setAddTrackersFromURLEnabled(m_ui->checkAddTrackersFromURL->isChecked());
     session->setAdditionalTrackersURL(m_ui->textTrackersURL->text());
+
+    session->setAddWebSocketTrackersEnabled(m_ui->checkAddWebSocketTrackers->isChecked());
 }
 
 void OptionsDialog::loadRSSTabOptions()

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3354,6 +3354,16 @@ Disable encryption: Only connect to peers without protocol encryption</string>
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="checkAddWebSocketTrackers">
+              <property name="text">
+               <string>Announce torrents to a WebTorrent tracker for browser peer discovery</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_8">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -328,6 +328,7 @@ void AppController::preferencesAction()
     data[u"add_trackers_from_url_enabled"_s] = session->isAddTrackersFromURLEnabled();
     data[u"add_trackers_url"_s] = session->additionalTrackersURL();
     data[u"add_trackers_url_list"_s] = session->additionalTrackersFromURL();
+    data[u"add_websocket_trackers_enabled"_s] = session->isAddWebSocketTrackersEnabled();
 
     // WebUI
     // HTTP Server
@@ -883,6 +884,8 @@ void AppController::setPreferencesAction()
         session->setAddTrackersFromURLEnabled(it.value().toBool());
     if (hasKey(u"add_trackers_url"_s))
         session->setAdditionalTrackersURL(it.value().toString());
+    if (hasKey(u"add_websocket_trackers_enabled"_s))
+        session->setAddWebSocketTrackersEnabled(it.value().toBool());
 
     // WebUI
     // HTTP Server


### PR DESCRIPTION
## Summary
- Adds an opt-out preference ("Announce torrents to a WebTorrent tracker for browser peer discovery", Settings > BitTorrent, on by default) that appends `wss://tracker.btorrent.xyz`, `wss://tracker.openwebtorrent.com`, and `wss://tracker.webtorrent.dev` to a new torrent's announce list on add, skipping duplicates and private torrents.
- Follows PR #24564, which enabled the WebTorrent/WebRTC build flag but added no code path that ever populates a `wss://` tracker, so torrents were only reachable from browser-based WebTorrent clients if they already carried one.
- Exposed via the WebUI preferences API (`add_websocket_trackers_enabled`) for `qbittorrent-nox` users.

Draft PR opened to exercise the existing CI matrix (macOS/Ubuntu/Windows, including the libtorrent 2.1.0-rc2 `-Dwebtorrent=ON` build and the webtorrent-disabled builds) against these changes -- not requesting review yet.

Refs #4163

## Test plan
- [ ] CI green on libtorrent 2.1.0-rc2 (`-Dwebtorrent=ON`) build
- [ ] CI green on libtorrent 2.0.13 / 1.2.20 (webtorrent-disabled) builds, confirming no regression when the flag is off
- [ ] Manual: add a torrent with the preference enabled, confirm `wss://tracker.btorrent.xyz` etc. appear in its tracker list and existing trackers are preserved
- [ ] Manual: confirm private torrents are not given the extra trackers