### PR TITLE
Add automatic category rules

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -469,6 +469,7 @@ namespace BitTorrent
         virtual void banIP(const QString &ip) = 0;
 
         virtual bool isKnownTorrent(const InfoHash &infoHash) const = 0;
+        virtual void applyAutoCategory(const TorrentDescriptor &torrentDescr, AddTorrentParams *addTorrentParams) const = 0;
         virtual bool addTorrent(const TorrentDescriptor &torrentDescr, const AddTorrentParams &params = {}) = 0;
         virtual bool removeTorrent(const TorrentID &id, TorrentRemoveOption deleteOption = TorrentRemoveOption::KeepContent) = 0;
         virtual bool downloadMetadata(const TorrentDescriptor &torrentDescr) = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -119,6 +119,7 @@ using namespace std::chrono_literals;
 using namespace BitTorrent;
 
 const Path CATEGORIES_FILE_NAME {u"categories.json"_s};
+const Path AUTO_CATEGORY_RULES_FILE_NAME {u"auto_category_rules.json"_s};
 const Path ADDITIONAL_TRACKERS_FROM_URL_FILE_NAME {u"additional_trackers_from_url.txt"_s};
 const int MAX_PROCESSING_RESUMEDATA_COUNT = 50;
 const std::chrono::seconds FREEDISKSPACE_CHECK_TIMEOUT = 30s;
@@ -641,6 +642,7 @@ SessionImpl::SessionImpl(QObject *parent)
         enableBandwidthScheduler();
 
     loadCategories();
+    loadAutoCategoryRules();
 
     const QStringList storedTags = m_storedTags.get();
     for (const QString &tagStr : storedTags)
@@ -2805,7 +2807,10 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
     if (infoHash.isHybrid())
         cancelDownloadMetadata(altID);
 
-    LoadTorrentParams loadTorrentParams = initLoadTorrentParams(addTorrentParams);
+    AddTorrentParams effectiveAddTorrentParams = addTorrentParams;
+    applyAutoCategory(source, &effectiveAddTorrentParams);
+
+    LoadTorrentParams loadTorrentParams = initLoadTorrentParams(effectiveAddTorrentParams);
     lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;
     p = source.ltAddTorrentParams();
 
@@ -2827,9 +2832,10 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
 
         const TorrentInfo &torrentInfo = *source.info();
 
-        Q_ASSERT(addTorrentParams.filePaths.isEmpty() || (addTorrentParams.filePaths.size() == torrentInfo.filesCount()));
+        Q_ASSERT(effectiveAddTorrentParams.filePaths.isEmpty()
+                || (effectiveAddTorrentParams.filePaths.size() == torrentInfo.filesCount()));
 
-        filePaths = addTorrentParams.filePaths;
+        filePaths = effectiveAddTorrentParams.filePaths;
         if (filePaths.isEmpty())
         {
             filePaths = torrentInfo.filePaths();
@@ -2862,8 +2868,9 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
 
         const auto nativeIndexes = torrentInfo.nativeIndexes();
 
-        Q_ASSERT(addTorrentParams.filePriorities.isEmpty() || (addTorrentParams.filePriorities.size() == nativeIndexes.size()));
-        QList<DownloadPriority> filePriorities = addTorrentParams.filePriorities;
+        Q_ASSERT(effectiveAddTorrentParams.filePriorities.isEmpty()
+                || (effectiveAddTorrentParams.filePriorities.size() == nativeIndexes.size()));
+        QList<DownloadPriority> filePriorities = effectiveAddTorrentParams.filePriorities;
 
         // Filename filter should be applied before `findIncompleteFiles()` is called.
         if (filePriorities.isEmpty() && isExcludedFileNamesEnabled())
@@ -2932,20 +2939,20 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         }
     }
 
-    p.upload_limit = addTorrentParams.uploadLimit;
-    p.download_limit = addTorrentParams.downloadLimit;
+    p.upload_limit = effectiveAddTorrentParams.uploadLimit;
+    p.download_limit = effectiveAddTorrentParams.downloadLimit;
 
     // Preallocation mode
     p.storage_mode = isPreallocationEnabled() ? lt::storage_mode_allocate : lt::storage_mode_sparse;
 
-    if (addTorrentParams.sequential)
+    if (effectiveAddTorrentParams.sequential)
         p.flags |= lt::torrent_flags::sequential_download;
     else
         p.flags &= ~lt::torrent_flags::sequential_download;
 
     // Seeding mode
     // Skip checking and directly start seeding
-    if (addTorrentParams.skipChecking)
+    if (effectiveAddTorrentParams.skipChecking)
         p.flags |= lt::torrent_flags::seed_mode;
     else
         p.flags &= ~lt::torrent_flags::seed_mode;
@@ -5351,6 +5358,8 @@ void SessionImpl::handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const
 
 void SessionImpl::handleTorrentMetadataReceived(TorrentImpl *const torrent)
 {
+    applyAutoCategory(torrent);
+
     if (!torrentExportDirectory().isEmpty())
         exportTorrentFile(torrent, torrentExportDirectory());
 
@@ -5656,6 +5665,145 @@ void SessionImpl::loadCategories()
     }
 
     m_categories = expandCategories(m_categories);
+}
+
+void SessionImpl::loadAutoCategoryRules()
+{
+    m_autoCategoryRules.clear();
+
+    const Path path = specialFolderLocation(SpecialFolder::Config) / AUTO_CATEGORY_RULES_FILE_NAME;
+    if (!path.exists())
+        return;
+
+    constexpr int fileMaxSize = 1024 * 1024;
+    const auto readResult = Utils::IO::readFile(path, fileMaxSize);
+    if (!readResult)
+    {
+        LogMsg(tr("Failed to load automatic category rules. File: \"%1\". Error: \"%2\"")
+                .arg(path.toString(), readResult.error().message), Log::WARNING);
+        return;
+    }
+
+    QJsonParseError jsonError;
+    const QJsonDocument jsonDoc = QJsonDocument::fromJson(readResult.value(), &jsonError);
+    if (jsonError.error != QJsonParseError::NoError)
+    {
+        LogMsg(tr("Failed to parse automatic category rules. File: \"%1\". Error: \"%2\"")
+                .arg(path.toString(), jsonError.errorString()), Log::WARNING);
+        return;
+    }
+    if (!jsonDoc.isObject())
+    {
+        LogMsg(tr("Failed to load automatic category rules. File: \"%1\". Error: \"Invalid data format\"")
+                .arg(path.toString()), Log::WARNING);
+        return;
+    }
+
+    const QJsonValue rulesValue = jsonDoc.object().value(u"rules"_s);
+    if (!rulesValue.isArray())
+    {
+        LogMsg(tr("Failed to load automatic category rules. File: \"%1\". Error: \"Invalid data format\"")
+                .arg(path.toString()), Log::WARNING);
+        return;
+    }
+
+    const QJsonArray rules = rulesValue.toArray();
+    for (const QJsonValue &ruleValue : rules)
+    {
+        if (!ruleValue.isObject())
+        {
+            LogMsg(tr("Ignoring invalid automatic category rule. File: \"%1\"")
+                    .arg(path.toString()), Log::WARNING);
+            continue;
+        }
+
+        const QJsonObject ruleObject = ruleValue.toObject();
+        AutoCategoryRule rule;
+        rule.category = ruleObject.value(u"category"_s).toString().trimmed();
+        if (rule.category.isEmpty())
+            continue;
+        if (!isValidCategoryName(rule.category))
+        {
+            LogMsg(tr("Ignoring automatic category rule with invalid category \"%1\". File: \"%2\"")
+                    .arg(rule.category, path.toString()), Log::WARNING);
+            continue;
+        }
+
+        QStringList patterns;
+        const QString pattern = ruleObject.value(u"pattern"_s).toString();
+        if (!pattern.isEmpty())
+            patterns = pattern.split(u'|', Qt::SkipEmptyParts);
+
+        for (const QJsonValue &patternValue : ruleObject.value(u"patterns"_s).toArray())
+        {
+            if (patternValue.isString())
+                patterns.append(patternValue.toString());
+        }
+
+        for (const QString &patternText : asConst(patterns))
+        {
+            const QString trimmedPattern = patternText.trimmed();
+            if (trimmedPattern.isEmpty())
+                continue;
+
+            const QRegularExpression patternRegExp {Utils::String::wildcardToRegexPattern(trimmedPattern)
+                    , QRegularExpression::CaseInsensitiveOption};
+            if (patternRegExp.isValid())
+            {
+                rule.patterns.append(patternRegExp);
+            }
+            else
+            {
+                LogMsg(tr("Ignoring invalid automatic category pattern \"%1\" for category \"%2\". Error: \"%3\"")
+                        .arg(patternText, rule.category, patternRegExp.errorString()), Log::WARNING);
+            }
+        }
+
+        if (!rule.patterns.empty())
+            m_autoCategoryRules.append(rule);
+    }
+
+    LogMsg(tr("Loaded %1 automatic category rules. File: \"%2\"")
+            .arg(m_autoCategoryRules.size()).arg(path.toString()));
+}
+
+void SessionImpl::applyAutoCategory(const TorrentDescriptor &torrentDescr, AddTorrentParams *addTorrentParams) const
+{
+    if (!addTorrentParams->category.isEmpty())
+        return;
+
+    const PathList filePaths = (torrentDescr.info() ? torrentDescr.info()->filePaths() : PathList {});
+    addTorrentParams->category = findAutoCategory(torrentDescr.name(), filePaths);
+}
+
+void SessionImpl::applyAutoCategory(TorrentImpl *torrent)
+{
+    if (!torrent->category().isEmpty())
+        return;
+
+    const QString category = findAutoCategory(torrent->name(), torrent->filePaths());
+    if (!category.isEmpty() && (m_categories.contains(category) || addCategory(category)))
+        torrent->setCategory(category);
+}
+
+QString SessionImpl::findAutoCategory(const QString &torrentName, const PathList &filePaths) const
+{
+    for (const AutoCategoryRule &rule : m_autoCategoryRules)
+    {
+        for (const QRegularExpression &pattern : rule.patterns)
+        {
+            if (pattern.match(torrentName).hasMatch())
+                return rule.category;
+
+            for (const Path &filePath : filePaths)
+            {
+                if (pattern.match(filePath.toString()).hasMatch())
+                    return rule.category;
+            }
+        }
+    }
+
+    return {};
 }
 
 void SessionImpl::configureDeferred()

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -45,6 +45,7 @@
 #include <QMap>
 #include <QMutex>
 #include <QPointer>
+#include <QRegularExpression>
 #include <QSet>
 #include <QThreadPool>
 
@@ -444,6 +445,7 @@ namespace BitTorrent
         void banIP(const QString &ip) override;
 
         bool isKnownTorrent(const InfoHash &infoHash) const override;
+        void applyAutoCategory(const TorrentDescriptor &torrentDescr, AddTorrentParams *addTorrentParams) const override;
         bool addTorrent(const TorrentDescriptor &torrentDescr, const AddTorrentParams &params = {}) override;
         bool removeTorrent(const TorrentID &id, TorrentRemoveOption deleteOption = TorrentRemoveOption::KeepContent) override;
         bool downloadMetadata(const TorrentDescriptor &torrentDescr) override;
@@ -530,6 +532,12 @@ namespace BitTorrent
 
     private:
         struct ResumeSessionContext;
+
+        struct AutoCategoryRule
+        {
+            QString category;
+            QList<QRegularExpression> patterns;
+        };
 
         struct MoveStorageJob
         {
@@ -637,9 +645,12 @@ namespace BitTorrent
         void processPendingFinishedTorrents();
 
         void loadCategories();
+        void loadAutoCategoryRules();
         void storeCategories() const;
         void upgradeCategories();
         DownloadPathOption resolveCategoryDownloadPathOption(const QString &categoryName, const std::optional<DownloadPathOption> &option) const;
+        void applyAutoCategory(TorrentImpl *torrent);
+        QString findAutoCategory(const QString &torrentName, const PathList &filePaths) const;
 
         void saveStatistics() const;
         void loadStatistics();
@@ -816,6 +827,7 @@ namespace BitTorrent
 
         bool m_torrentsQueueChanged = false;
         bool m_needSaveTorrentsQueue = false;
+        QList<AutoCategoryRule> m_autoCategoryRules;
         bool m_refreshEnqueued = false;
         QTimer *m_seedingLimitTimer = nullptr;
         QTimer *m_resumeDataTimer = nullptr;

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -236,6 +236,10 @@ bool GUIAddTorrentManager::processTorrent(const QString &source
     if (!hasMetadata)
         btSession()->downloadMetadata(torrentDescr);
 
+    BitTorrent::AddTorrentParams effectiveParams = params;
+    if (hasMetadata)
+        btSession()->applyAutoCategory(torrentDescr, &effectiveParams);
+
 #ifdef Q_OS_MACOS
     const bool attached = false;
 #else
@@ -244,7 +248,7 @@ bool GUIAddTorrentManager::processTorrent(const QString &source
 
     // By not setting a parent to the "AddNewTorrentDialog", all those dialogs
     // will be displayed on top and will not overlap with the main window.
-    auto *dlg = new AddNewTorrentDialog(torrentDescr, params, (attached ? app()->mainWindow() : nullptr));
+    auto *dlg = new AddNewTorrentDialog(torrentDescr, effectiveParams, (attached ? app()->mainWindow() : nullptr));
     // Qt::Window is required to avoid showing only two dialog on top (see #12852).
     // Also improves the general convenience of adding multiple torrents.
     if (!attached)


### PR DESCRIPTION

## Description

This PR adds a focused implementation of automatic category assignment for newly added torrents.

The original request in #5779 asks for eMule-style automatic category assignment, where a category can be selected when the filename matches wildcard patterns separated with `|`, such as `*.avi|a*.*`. A recent comment in that issue also notes that the discussion already has enough feedback and that "just any basic implementation is needed":

https://github.com/qbittorrent/qBittorrent/issues/5779#issuecomment-4794202226

This PR keeps the scope intentionally narrow: it only assigns categories. It does not introduce a general torrent automation framework, and it does not set tags, save paths, tracker-based conditions, size-based conditions, or other torrent parameters.

There is prior exploratory work in #20502 for a broader metadata-based rule/modifier system. This PR takes a smaller approach for the category-assignment use case discussed in #5779.

## Behavior

qBittorrent now loads `auto_category_rules.json` from the config directory at startup. If the file exists, rules are applied when torrents are added.

Rules:

- match torrent names
- match torrent file paths when metadata is available
- use wildcard matching
- match case-insensitively
- support pipe-separated patterns via `pattern`
- support multiple patterns via `patterns`
- use first match wins behavior
- preserve an explicitly provided category
- create valid matched categories when needed
- reflect the matched category in the Add New Torrent dialog when metadata is already available
- retry uncategorized magnet torrents when metadata is received

Example config:

```json
{
  "rules": [
    { "category": "Videos", "pattern": "*.avi|*.mkv|*.mp4" },
    { "category": "Linux ISOs", "patterns": ["*ubuntu*", "*fedora*"] }
  ]
}
```

Invalid JSON, invalid rule shapes, invalid category names, and invalid wildcard patterns are ignored with warning log messages.

## What This Does Not Do

This PR does not:

- add a general torrent automation framework
- add condition/modifier objects
- assign tags
- set save paths directly
- add tracker-based, size-based, ratio-based, or other metadata conditions
- retroactively categorize existing torrents
- reload rules without restarting qBittorrent
- add a GUI editor for category rules

## Relation to #20502

| Area | This PR | #20502 |
| --- | --- | --- |
| Goal | Implement the basic category-assignment behavior requested in #5779 | Explore a broader metadata-based automation system |
| Scope | Automatic category assignment only | General rule/condition/modifier framework |
| Match inputs | Torrent name and file paths | Multiple metadata condition types |
| Actions | Set category only | Modify multiple torrent parameters |
| Config shape | Simple category-to-wildcard rules | Structured condition/modifier rules |
| UI surface | No rule editor; reflects the matched category in the add dialog when metadata is already available | Broader add-dialog parameter refresh work |

The intent is to keep this feature small enough to review and merge independently, while leaving room for broader automation work to evolve separately.

## Scope

The rule file is loaded from the same config area used for other qBittorrent settings and is applied automatically without user interaction.

No screenshots are included because this does not add a new UI surface or visual design changes.

Closes #5779.

## Manual Test Plan

To verify the feature manually:

1. Run qBittorrent with an isolated profile, or use the config directory printed in the startup log as `Using config directory: ...`.
2. Create `auto_category_rules.json` in that config directory:

```json
{
  "rules": [
    { "category": "Videos", "pattern": "*.avi|a*.*" },
    { "category": "Linux ISOs", "patterns": ["*ubuntu*", "*fedora*"] }
  ]
}
```

3. Restart qBittorrent so the rules file is loaded.
4. Add a `.torrent` file whose torrent name or file path matches one of the rules.
5. If the Add New Torrent dialog is enabled and metadata is already available, confirm that the matched category is preselected.
6. Add the torrent and confirm that the torrent appears in the expected category and that the category exists in the category list.
7. Change the category manually in the Add New Torrent dialog before accepting, and confirm that the manual category is preserved.
8. Add a magnet link that starts without metadata, then allow metadata retrieval to complete and confirm that an uncategorized matching torrent is categorized after metadata is received.
9. Try a malformed rule or invalid category name and confirm qBittorrent ignores it and logs a warning instead of failing startup.

## Testing

- `git diff --check`
- `cmake --build build --target qbt_base -j4`
- `cmake --build build --target qbt_app -j4`

## Notes

AI-assisted planning was used for scoping and implementation review: GPT 5.6 Sol.
