### PR TITLE
Fix misleading peer block reason for libtorrent IP filter alerts

### DIFF
--- a/src/base/bittorrent/filterparserthread.cpp
+++ b/src/base/bittorrent/filterparserthread.cpp
@@ -29,6 +29,7 @@
 #include "filterparserthread.h"
 
 #include <cctype>
+#include <vector>
 
 #include <libtorrent/error_code.hpp>
 
@@ -202,8 +203,9 @@ int FilterParserThread::parseDATFilterFile()
             // 001.009.096.105 - 001.009.096.105 , 000 , Some organization
             // The 3rd entry is access level and if above 127 the IP range isn't blocked.
             const int firstComma = findAndNullDelimiter(buffer.data(), ',', start, endOfLine);
+            int secondComma = -1;
             if (firstComma != -1)
-                findAndNullDelimiter(buffer.data(), ',', firstComma + 1, endOfLine);
+                secondComma = findAndNullDelimiter(buffer.data(), ',', firstComma + 1, endOfLine);
 
             // Check if there is an access value (apparently not mandatory)
             if (firstComma != -1)
@@ -266,12 +268,28 @@ int FilterParserThread::parseDATFilterFile()
                 continue;
             }
 
+            QString ruleComment;
+            if (secondComma != -1)
+            {
+                int commentStart = secondComma + 1;
+                while ((commentStart < endOfLine) && std::isspace(static_cast<unsigned char>(buffer.data()[commentStart])))
+                    ++commentStart;
+
+                int commentEnd = endOfLine - 1;
+                while ((commentEnd >= commentStart) && std::isspace(static_cast<unsigned char>(buffer.data()[commentEnd])))
+                    --commentEnd;
+
+                if (commentStart <= commentEnd)
+                    ruleComment = QString::fromUtf8(buffer.data() + commentStart, commentEnd - commentStart + 1);
+            }
+
             start = endOfLine;
 
             // Now Add to the filter
             try
             {
                 m_filter.add_rule(startAddr, endAddr, lt::ip_filter::blocked);
+                recordBlockedRule(startAddr, endAddr, ruleComment);
                 ++ruleCount;
             }
             catch (const std::exception &e)
@@ -454,11 +472,14 @@ int FilterParserThread::parseP2PFilterFile()
                 continue;
             }
 
+            const QString ruleComment = QString::fromUtf8(buffer.data() + start, partsDelimiter - start).trimmed();
+
             start = endOfLine;
 
             try
             {
                 m_filter.add_rule(startAddr, endAddr, lt::ip_filter::blocked);
+                recordBlockedRule(startAddr, endAddr, ruleComment);
                 ++ruleCount;
             }
             catch (const std::exception &e)
@@ -536,9 +557,12 @@ int FilterParserThread::parseP2BFilterFile()
         qDebug ("p2b version 1 or 2");
         unsigned int start, end;
 
-        std::string name;
-        while (getlineInStream(stream, name, '\0') && !m_abort)
+        while (!m_abort)
         {
+            std::string name;
+            if (!getlineInStream(stream, name, '\0'))
+                break;
+
             if (!stream.readRawData(reinterpret_cast<char*>(&start), sizeof(start))
                 || !stream.readRawData(reinterpret_cast<char*>(&end), sizeof(end)))
                 {
@@ -555,6 +579,7 @@ int FilterParserThread::parseP2BFilterFile()
             try
             {
                 m_filter.add_rule(first, last, lt::ip_filter::blocked);
+                recordBlockedRule(first, last, QString::fromStdString(name));
                 ++ruleCount;
             }
             catch (const std::exception &) {}
@@ -571,7 +596,8 @@ int FilterParserThread::parseP2BFilterFile()
         }
 
         namecount = ntohl(namecount);
-        // Reading names although, we don't really care about them
+        std::vector<std::string> names;
+        names.reserve(namecount);
         for (unsigned int i = 0; i < namecount; ++i)
         {
             std::string name;
@@ -580,6 +606,8 @@ int FilterParserThread::parseP2BFilterFile()
                 LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
                 return ruleCount;
             }
+
+            names.push_back(name);
 
             if (m_abort) return ruleCount;
         }
@@ -607,12 +635,17 @@ int FilterParserThread::parseP2BFilterFile()
             // Network byte order to Host byte order
             // asio address_v4 constructor expects it
             // that way
+            const unsigned int nameIndex = ntohl(name);
             const lt::address_v4 first(ntohl(start));
             const lt::address_v4 last(ntohl(end));
             // Apply to bittorrent session
             try
             {
                 m_filter.add_rule(first, last, lt::ip_filter::blocked);
+                const QString ruleName = (nameIndex < names.size())
+                    ? QString::fromStdString(names[nameIndex])
+                    : QString();
+                recordBlockedRule(first, last, ruleName);
                 ++ruleCount;
             }
             catch (const std::exception &) {}
@@ -654,8 +687,19 @@ lt::ip_filter FilterParserThread::IPfilter()
     return m_filter;
 }
 
+QVector<ParsedIPFilterRule> FilterParserThread::IPFilterRules() const
+{
+    return m_blockedRules;
+}
+
+void FilterParserThread::recordBlockedRule(const lt::address &first, const lt::address &last, const QString &comment)
+{
+    m_blockedRules.append({first, last, comment.trimmed()});
+}
+
 void FilterParserThread::run()
 {
+    m_blockedRules.clear();
     qDebug("Processing filter file");
     int ruleCount = 0;
     if (m_filePath.hasExtension(u".p2p"_s))

--- a/src/base/bittorrent/filterparserthread.h
+++ b/src/base/bittorrent/filterparserthread.h
@@ -36,6 +36,13 @@
 
 class QDataStream;
 
+struct ParsedIPFilterRule
+{
+    lt::address first;
+    lt::address last;
+    QString comment;
+};
+
 class FilterParserThread final : public QThread
 {
     Q_OBJECT
@@ -46,6 +53,7 @@ public:
     ~FilterParserThread();
     void processFilterFile(const Path &filePath);
     lt::ip_filter IPfilter();
+    QVector<ParsedIPFilterRule> IPFilterRules() const;
 
 signals:
     void IPFilterParsed(int ruleCount);
@@ -53,6 +61,8 @@ signals:
 
 protected:
     void run() override;
+
+    void recordBlockedRule(const lt::address &first, const lt::address &last, const QString &comment);
 
 private:
     int findAndNullDelimiter(char *data, char delimiter, int start, int end, bool reverse = false);
@@ -65,4 +75,5 @@ private:
     bool m_abort = false;
     Path m_filePath;
     lt::ip_filter m_filter;
+    QVector<ParsedIPFilterRule> m_blockedRules;
 };

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1857,6 +1857,46 @@ void SessionImpl::initializeNativeSession()
     m_nativeSessionExtension = nativeSessionExtension.get();
 }
 
+const ParsedIPFilterRule *SessionImpl::findUserIPFilterRule(const lt::address &address) const
+{
+    for (const ParsedIPFilterRule &rule : asConst(m_currentIPFilterRules))
+    {
+        if (isAddressInRange(address, rule.first, rule.last))
+            return &rule;
+    }
+
+    return nullptr;
+}
+
+bool SessionImpl::isManuallyBannedIP(const lt::address &address) const
+{
+    return m_bannedIPs.get().contains(toString(address));
+}
+
+bool SessionImpl::isAddressInRange(const lt::address &address, const lt::address &first, const lt::address &last)
+{
+    if (address.is_v4() != first.is_v4())
+        return false;
+
+    if (address.is_v4() != last.is_v4())
+        return false;
+
+    if (address.is_v4())
+    {
+        const auto addressBytes = address.to_v4().to_bytes();
+        const auto firstBytes = first.to_v4().to_bytes();
+        const auto lastBytes = last.to_v4().to_bytes();
+
+        return ((addressBytes >= firstBytes) && (addressBytes <= lastBytes));
+    }
+
+    const auto addressBytes = address.to_v6().to_bytes();
+    const auto firstBytes = first.to_v6().to_bytes();
+    const auto lastBytes = last.to_v6().to_bytes();
+
+    return ((addressBytes >= firstBytes) && (addressBytes <= lastBytes));
+}
+
 void SessionImpl::processBannedIPs(lt::ip_filter &filter)
 {
     // First, import current filter
@@ -5891,6 +5931,7 @@ void SessionImpl::disableIPFilter()
     // which creates an empty filter and overrides all previously
     // applied bans.
     lt::ip_filter filter;
+    m_currentIPFilterRules.clear();
     processBannedIPs(filter);
     m_nativeSession->set_ip_filter(filter);
 }
@@ -5929,7 +5970,10 @@ void SessionImpl::handleIPFilterParsed(const int ruleCount)
     if (m_filterParser)
     {
         lt::ip_filter filter = m_filterParser->IPfilter();
+        QVector<ParsedIPFilterRule> parsedRules = m_filterParser->IPFilterRules();
+
         processBannedIPs(filter);
+        m_currentIPFilterRules = std::move(parsedRules);
         m_nativeSession->set_ip_filter(filter);
     }
     LogMsg(tr("Successfully parsed the IP filter file. Number of rules applied: %1").arg(ruleCount));
@@ -5939,6 +5983,7 @@ void SessionImpl::handleIPFilterParsed(const int ruleCount)
 void SessionImpl::handleIPFilterError()
 {
     lt::ip_filter filter;
+    m_currentIPFilterRules.clear();
     processBannedIPs(filter);
     m_nativeSession->set_ip_filter(filter);
 
@@ -6337,8 +6382,24 @@ void SessionImpl::handlePeerBlockedAlert(const lt::peer_blocked_alert *alert)
     switch (alert->reason)
     {
     case lt::peer_blocked_alert::ip_filter:
-        reason = tr("IP filter", "this peer was blocked. Reason: IP filter.");
+    {
+        const lt::address peerAddress = ipEndpoint.address();
+        if (const ParsedIPFilterRule *rule = findUserIPFilterRule(peerAddress))
+        {
+            reason = rule->comment.isEmpty()
+                ? tr("user IP filter", "this peer was blocked. Reason: user IP filter.")
+                : tr("user IP filter - %1", "this peer was blocked. Reason: user IP filter - <comment>.").arg(rule->comment);
+        }
+        else if (isManuallyBannedIP(peerAddress))
+        {
+            reason = tr("manually banned IP address", "this peer was blocked. Reason: manually banned IP address.");
+        }
+        else
+        {
+            reason = tr("libtorrent IP filter", "this peer was blocked. Reason: libtorrent IP filter.");
+        }
         break;
+    }
     case lt::peer_blocked_alert::port_filter:
         reason = tr("filtered port (%1)", "this peer was blocked. Reason: filtered port (8899).").arg(QString::number(ipEndpoint.port()));
         break;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -54,6 +54,7 @@
 #include "addtorrentparams.h"
 #include "cachestatus.h"
 #include "categoryoptions.h"
+#include "filterparserthread.h"
 #include "session.h"
 #include "sessionstatus.h"
 #include "torrentinfo.h"
@@ -570,6 +571,10 @@ namespace BitTorrent
         void initMetrics();
         void applyBandwidthLimits();
         void processBannedIPs(lt::ip_filter &filter);
+        const ParsedIPFilterRule *findUserIPFilterRule(const lt::address &address) const;
+        bool isManuallyBannedIP(const lt::address &address) const;
+
+        static bool isAddressInRange(const lt::address &address, const lt::address &first, const lt::address &last);
         QStringList getListeningIPs() const;
         void configureListeningInterface();
         void enableTracker(bool enable);
@@ -790,6 +795,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isExcludedFileNamesEnabled;
         CachedSettingValue<QStringList> m_excludedFileNames;
         CachedSettingValue<QStringList> m_bannedIPs;
+        QVector<ParsedIPFilterRule> m_currentIPFilterRules;
         CachedSettingValue<ResumeDataStorageType> m_resumeDataStorageType;
         CachedSettingValue<bool> m_isMergeTrackersEnabled;
         CachedSettingValue<bool> m_isI2PEnabled;


### PR DESCRIPTION
Closes #16756 

### Description

This improves peer log attribution for `peer_blocked_alert::ip_filter` by preserving qBittorrent-side source information for parsed IP filter rules.

The peer log can now distinguish:

- configured user IP filter matches
- user IP filter matches with comments/names from supported filter formats
- manually banned IP addresses
- unattributed libtorrent IP filter blocks

This PR is attribution-only. It does not change filtering behavior, IP-filter UI, automatic updates, blocklist formats, or the underlying libtorrent/DHT behavior.

### Supported filter metadata

This preserves comments/names from:

- DAT/eMule-style filters
- P2P/PeerGuardian text filters
- P2B v1/v2/v3 filters

### Testing

Built locally on macOS arm64.

Runtime-tested these cases:

- manual ban logs `manually banned IP address`
- DAT rule with comment logs `user IP filter - <comment>`
- P2P rule with label logs `user IP filter - <label>`
- removing a DAT/P2P rule and refreshing no longer leaves stale attribution
- unattributed blocks continue to use `libtorrent IP filter`

### Related issues

- #16756 — primary issue: improve IP-filter block reason attribution.
- #23139 — related diagnostic ambiguity: runtime IP-filter blocks could appear to come from the user IP filter even when qBittorrent could not prove that source.
- #13331 — related logging/diagnostic issue: blocked-IP logs can be noisy and hard to interpret when IP filtering is enabled.

### Notes

AI-assisted planning and implementation review were used while preparing this PR: ChatGPT.