### PR TITLE
Fix: Add Qt environment setup to PATH for lupdate.exe

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Install boost
         run: |
           $boost_url="https://archives.boost.io/release/${{ matrix.libtorrent.boost_major_version }}.${{ matrix.libtorrent.boost_minor_version }}.${{ matrix.libtorrent.boost_patch_version }}/source/boost_${{ matrix.libtorrent.boost_major_version }}_${{ matrix.libtorrent.boost_minor_version }}_${{ matrix.libtorrent.boost_patch_version }}.tar.gz"
-          $boost_url2="https://sourceforge.net/projects/boost/files/boost/${{ matrix.libtorrent.boost_major_version }}.${{ matrix.libtorrent.boost_minor_version }}.${{ matrix.libtorrent.boost_patch_version }}/boost_${{ matrix.libtorrent.boost_major_version }}_${{ matrix.libtorrent.boost_minor_version }}_${{ matrix.libtorrent.boost_patch_version }}.tar.gz"
+          $boost_url2="https://sourceforge.net/projects/boost/files/boost/${{ matrix.libtorrent.boost_major_version }}.${{ matrix.libtorrent.boost_minor_version }}.${{ matrix.libtorrent.boost_patch_version }}/boost_${{ matrix.libtorrent.boost_major_version }}_${{ matrix.libtorrent.boost_minor_version }}_${{ matrix.libtorrent.boost_patch_version }}.tar.gz/download"
           curl -L -o "${{ runner.temp }}/boost.tar.gz" "$boost_url"
           tar -xf "${{ runner.temp }}/boost.tar.gz" -C "${{ github.workspace }}/.."
           if ($LastExitCode -ne 0)
@@ -128,6 +128,10 @@ jobs:
           archives: qtbase qtsvg qttools
           modules: qtimageformats
           cache: true
+
+      - name: Setup Qt environment
+        run: |
+          Add-Content $env:GITHUB_PATH "${{ env.Qt_ROOT_DIR }}\bin"
 
       - name: Install libtorrent
         run: |


### PR DESCRIPTION
The Qt 6.10.3 MSVC2022 environment wasn't being added to the system PATH, causing lupdate.exe (Qt translation utility) to fail with missing DLL errors (exit code 0xc0000135).

This adds a new step "Setup Qt environment" that appends the Qt bin directory to GITHUB_PATH, ensuring lupdate.exe and its dependencies are available during the qBittorrent build step.

Fixes build failures where the translation update step was causing the build to abort with DLL not found errors.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
