### PR TITLE
Put an upper limit on incoming data

### DIFF
--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -87,6 +87,13 @@ void Http::Connection::read()
     const qint64 bytesAvailable = m_socket->bytesAvailable();
     if (bytesAvailable > 0)
     {
+        // drop suspiciously large input data
+        if (bytesAvailable > (RequestParser::MAX_REQUEST_SIZE))
+        {
+            m_socket->close();
+            return;
+        }
+
         // reuse existing buffer and avoid unnecessary memory allocation/relocation
         const qsizetype previousSize = m_receivedData.size();
         m_receivedData.resize(previousSize + bytesAvailable);
@@ -135,7 +142,7 @@ bool Http::Connection::processRequest()
         return true;
 
     case RequestParser::ParseStatus::Incomplete:
-        if (const long bufferLimit = RequestParser::MAX_CONTENT_SIZE * 1.1; m_receivedData.size() > bufferLimit)  // some margin for headers
+        if (const long bufferLimit = RequestParser::MAX_REQUEST_SIZE; m_receivedData.size() > bufferLimit)
         {
             qWarning("%s", qUtf8Printable(tr("Http request size exceeds limitation, closing socket. Limit: %1, IP: %2")
                     .arg(QString::number(bufferLimit), m_socket->peerAddress().toString())));

--- a/src/base/http/requestparser.h
+++ b/src/base/http/requestparser.h
@@ -56,6 +56,7 @@ namespace Http
         static ParseResult parse(const QByteArray &data);
 
         static const long MAX_CONTENT_SIZE = 64 * 1024 * 1024;  // 64 MB
+        static const long MAX_REQUEST_SIZE = MAX_CONTENT_SIZE * 1.1;   // some margin for headers
 
     private:
         RequestParser() = default;


### PR DESCRIPTION
This avoids enlarging the receiving buffer unnecessarily.
