### PR TITLE
Avoid repetitive heavy function call

### DIFF
--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -253,7 +253,7 @@ bool Net::DownloadManager::deleteCookie(const QNetworkCookie &cookie)
 
 bool Net::DownloadManager::hasSupportedScheme(const QString &url)
 {
-    const QStringList schemes = QNetworkAccessManager().supportedSchemes();
+    static const QStringList schemes = QNetworkAccessManager().supportedSchemes();
     return std::ranges::any_of(schemes, [&url](const QString &scheme)
     {
         return url.startsWith((scheme + u':'), Qt::CaseInsensitive);


### PR DESCRIPTION
Initializing `QNetworkAccessManager` class is heavy.
