### PR TITLE
Add download duration column

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -197,6 +197,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
+            case TR_DOWNLOAD_DURATION: return tr("Download Duration", "Time taken to complete the download");
             default: return {};
             }
         }
@@ -234,6 +235,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_LAST_ACTIVITY:
             case TR_AVAILABILITY:
             case TR_REANNOUNCE:
+            case TR_DOWNLOAD_DURATION:
                 return QVariant(Qt::AlignRight | Qt::AlignVCenter);
             default:
                 return QAbstractListModel::headerData(section, orientation, role);
@@ -370,6 +372,24 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return tr("N/A");
     };
 
+    const auto downloadDurationString = [hideValues](const BitTorrent::Torrent *torrent) -> QString
+    {
+        const auto completed = torrent->completedTime();
+
+        if (!completed.isValid())
+            return {};
+
+        const qint64 secs = torrent->addedTime().secsTo(completed);
+
+        if (hideValues && (secs == 0))
+            return {};
+
+        if (secs < 0)
+            return {};
+
+        return Utils::Misc::userFriendlyDuration(secs);
+    };
+
     switch (column)
     {
     case TR_NAME:
@@ -448,6 +468,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return reannounceString(torrent->nextAnnounce());
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
+    case TR_DOWNLOAD_DURATION:
+        return downloadDurationString(torrent);
     }
 
     return {};
@@ -533,6 +555,9 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->nextAnnounce();
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
+    case TR_DOWNLOAD_DURATION:
+        return (torrent->completedTime().isValid()
+                ? torrent->addedTime().secsTo(torrent->completedTime()) : QVariant());
     }
 
     return {};

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -93,6 +93,7 @@ public:
         TR_REANNOUNCE,
         TR_PRIVATE,
         TR_CREATE_DATE,
+        TR_DOWNLOAD_DURATION,
 
         NB_COLUMNS
     };

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -243,6 +243,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_REANNOUNCE:
     case TransferListModel::TR_SIZE:
     case TransferListModel::TR_TIME_ELAPSED:
+    case TransferListModel::TR_DOWNLOAD_DURATION:
     case TransferListModel::TR_TOTAL_SIZE:
         return customCompare(leftValue.toLongLong(), rightValue.toLongLong());
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -168,6 +168,7 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
         setColumnHidden(TransferListModel::TR_AMOUNT_UPLOADED_SESSION, true);
         setColumnHidden(TransferListModel::TR_AMOUNT_LEFT, true);
         setColumnHidden(TransferListModel::TR_TIME_ELAPSED, true);
+        setColumnHidden(TransferListModel::TR_DOWNLOAD_DURATION, true);
         setColumnHidden(TransferListModel::TR_SAVE_PATH, true);
         setColumnHidden(TransferListModel::TR_DOWNLOAD_PATH, true);
         setColumnHidden(TransferListModel::TR_INFOHASH_V1, true);


### PR DESCRIPTION
## Summary

Add an optional **Download Duration** column to the transfer list.

The column displays the elapsed time between when a torrent was added and when it completed downloading.

### Behavior

* Hidden by default.
* Supports sorting.
* Displays an empty value for incomplete torrents.
* Respects the "Hide zero and infinity values" setting.

## Testing

* Verified that the column can be enabled from the column visibility menu.
* Verified that completed torrents display the correct duration.
* Verified that incomplete torrents display an empty value.
* Verified that sorting works correctly.
* Verified that the "Hide zero and infinity values" setting is respected.
