### PR TITLE
Revamp .torrent files backup management

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -2,6 +2,14 @@
 
 ## 2.16.0
 
+* [#24641](https://github.com/qbittorrent/qBittorrent/pull/24641)
+  * `app/preferences` and `app/setPreferences` endpoints no longer include `export_dir` and `export_dir_fin` options as they are no longer supported by the core
+  * `app/preferences` and `app/setPreferences` endpoints include the following new options:
+    * `torrent_files_backup_enabled` (bool) - enable/disable saving backup copies of .torrent files
+    * `torrent_files_backup_dir` (string) - the folder path for saving backup copies of .torrent files
+    * `torrent_files_finished_backup_dir_enabled` (bool) - enable/disable moving backup copies of .torrent files to another folder when torrent is finished
+    * `torrent_files_finished_backup_dir` (string) - the folder path for moving backup copies of .torrent files when torrent is finished
+    * `remove_torrent_file_backup` (bool) - whether .torrent file backup should be removed when removing the torrent
 * [#24684](https://github.com/qbittorrent/qBittorrent/pull/24684)
   * `app/preferences` endpoint includes `enable_multi_connections_from_same_peer_id` option
   * `app/setPreferences` endpoint allows to set `enable_multi_connections_from_same_peer_id` option

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -48,7 +48,7 @@ using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
-    const int MIGRATION_VERSION = 10;
+    const int MIGRATION_VERSION = 11;
     const QString MIGRATION_VERSION_KEY = u"Meta/MigrationVersion"_s;
 
     void exportWebUIHttpsFiles()
@@ -557,6 +557,24 @@ namespace
         if (!settingsStorage->hasKey(key))
             SettingsStorage::instance()->storeValue(key, true);
     }
+
+    void migrateTorrentExportFolderSettings()
+    {
+        const auto doMigrate = [](const QString &oldKey, const QString &newKey, const QString &newEnabledKey)
+        {
+            auto *settingsStorage = SettingsStorage::instance();
+            if (settingsStorage->hasKey(oldKey))
+            {
+                const auto oldPath = settingsStorage->loadValue<Path>(oldKey);
+                settingsStorage->storeValue(newKey, oldPath);
+                settingsStorage->storeValue(newEnabledKey, !oldPath.isEmpty());
+                settingsStorage->removeValue(oldKey);
+            }
+        };
+
+        doMigrate(u"BitTorrent/Session/TorrentExportDirectory"_s, u"BitTorrent/Session/TorrentBackupDirectory"_s, u"BitTorrent/Session/TorrentBackupEnabled"_s);
+        doMigrate(u"BitTorrent/Session/FinishedTorrentExportDirectory"_s, u"BitTorrent/Session/FinishedTorrentBackupDirectory"_s, u"BitTorrent/Session/FinishedTorrentBackupDirectoryEnabled"_s);
+    }
 }
 
 bool upgrade()
@@ -608,6 +626,9 @@ bool upgrade()
             migrateSMTPEncryptionSetting();
             setResolvePeerCountriesSetting();
         }
+
+        if (version < 11)
+            migrateTorrentExportFolderSettings();
 
         version = MIGRATION_VERSION;
     }

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(qbt_base STATIC
     http/server.h
     indexrange.h
     interfaces/iapplication.h
+    keyvaluedatastorage.h
     logger.h
     net/dnsupdater.h
     net/downloadhandlerimpl.h
@@ -174,6 +175,7 @@ add_library(qbt_base STATIC
     http/requestparser.cpp
     http/responsewriterimpl.cpp
     http/server.cpp
+    keyvaluedatastorage.cpp
     logger.cpp
     net/dnsupdater.cpp
     net/downloadhandlerimpl.cpp

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -230,10 +230,17 @@ namespace BitTorrent
         virtual void setRefreshInterval(int value) = 0;
         virtual bool isPreallocationEnabled() const = 0;
         virtual void setPreallocationEnabled(bool enabled) = 0;
-        virtual Path torrentExportDirectory() const = 0;
-        virtual void setTorrentExportDirectory(const Path &path) = 0;
-        virtual Path finishedTorrentExportDirectory() const = 0;
-        virtual void setFinishedTorrentExportDirectory(const Path &path) = 0;
+
+        virtual bool isTorrentFileBackupEnabled() const = 0;
+        virtual void setTorrentFileBackupEnabled(bool enabled) = 0;
+        virtual Path torrentBackupDirectory() const = 0;
+        virtual void setTorrentBackupDirectory(const Path &path) = 0;
+        virtual bool isFinishedTorrentBackupDirectoryEnabled() const = 0;
+        virtual void setFinishedTorrentBackupDirectoryEnabled(bool enabled) = 0;
+        virtual Path finishedTorrentBackupDirectory() const = 0;
+        virtual void setFinishedTorrentBackupDirectory(const Path &path) = 0;
+        virtual bool removeTorrentFileBackup() const = 0;
+        virtual void setRemoveTorrentFileBackup(bool remove) = 0;
 
         virtual bool isAddTrackersFromURLEnabled() const = 0;
         virtual void setAddTrackersFromURLEnabled(bool enabled) = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -82,6 +82,7 @@
 #include "base/algorithm.h"
 #include "base/freediskspacechecker.h"
 #include "base/global.h"
+#include "base/keyvaluedatastorage.h"
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
 #include "base/net/proxyconfigurationmanager.h"
@@ -128,6 +129,21 @@ namespace
     const char PEER_ID[] = "qB";
     const auto USER_AGENT = QStringLiteral("qBittorrent/" QBT_VERSION_2);
     const QString DEFAULT_DHT_BOOTSTRAP_NODES = u"dht.libtorrent.org:25401, dht.transmissionbt.com:6881, router.bt.ouinet.work:6881"_s;
+
+    Path makeUniqueFilePath(const Path &dirPath, const QString &baseName, const QString &extension)
+    {
+        QString filename = u"%1.%2"_s.arg(baseName, extension);
+        Path path = dirPath / Path(filename);
+        int counter = 0;
+        while (path.exists())
+        {
+            // Append number to torrent name to make it unique
+            filename = u"%1 (%2).%3"_s.arg(baseName, QString::number(++counter), extension);
+            path = dirPath / Path(filename);
+        }
+
+        return path;
+    }
 
     void torrentQueuePositionUp(const lt::torrent_handle &handle)
     {
@@ -372,6 +388,11 @@ namespace
         return hasMetadata ? getInfoHash(*addTorrentParams.ti) : InfoHash(addTorrentParams.info_hash);
     }
  #endif
+
+    Path resolvePath(const Path &path, const Path &basePath)
+    {
+        return path.isAbsolute() ? path : (basePath / path);
+    }
 }
 
 struct BitTorrent::SessionImpl::ResumeSessionContext final : public QObject
@@ -544,8 +565,11 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_isUnwantedFolderEnabled(BITTORRENT_SESSION_KEY(u"UseUnwantedFolder"_s), false)
     , m_refreshInterval(BITTORRENT_SESSION_KEY(u"RefreshInterval"_s), 1500)
     , m_isPreallocationEnabled(BITTORRENT_SESSION_KEY(u"Preallocation"_s), false)
-    , m_torrentExportDirectory(BITTORRENT_SESSION_KEY(u"TorrentExportDirectory"_s))
-    , m_finishedTorrentExportDirectory(BITTORRENT_SESSION_KEY(u"FinishedTorrentExportDirectory"_s))
+    , m_isTorrentFileBackupEnabled(BITTORRENT_SESSION_KEY(u"TorrentBackupEnabled"_s), false)
+    , m_torrentBackupDirectory(BITTORRENT_SESSION_KEY(u"TorrentBackupDirectory"_s))
+    , m_isFinishedTorrentBackupDirectoryEnabled(BITTORRENT_SESSION_KEY(u"FinishedTorrentBackupDirectoryEnabled"_s), false)
+    , m_finishedTorrentBackupDirectory(BITTORRENT_SESSION_KEY(u"FinishedTorrentBackupDirectory"_s))
+    , m_removeTorrentFileBackup(BITTORRENT_SESSION_KEY(u"RemoveTorrentFileBackup"_s), false)
     , m_globalDownloadSpeedLimit(BITTORRENT_SESSION_KEY(u"GlobalDLSpeedLimit"_s), 0, lowerLimited(0))
     , m_globalUploadSpeedLimit(BITTORRENT_SESSION_KEY(u"GlobalUPSpeedLimit"_s), 0, lowerLimited(0))
     , m_altGlobalDownloadSpeedLimit(BITTORRENT_SESSION_KEY(u"AlternativeGlobalDLSpeedLimit"_s), 10, lowerLimited(0))
@@ -609,6 +633,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_recentErroredTorrentsTimer {new QTimer(this)}
     , m_freeDiskSpaceChecker {new FreeDiskSpaceChecker(savePath())}
     , m_freeDiskSpaceCheckingTimer {new QTimer(this)}
+    , m_backupTorrentFilesRegistry {new KeyValueDataStorage(u"BackupTorrentFiles"_s, this)}
 {
     m_shareLimits = {
         .ratioLimit = m_globalMaxRatio,
@@ -904,26 +929,63 @@ void SessionImpl::setPreallocationEnabled(const bool enabled)
     m_isPreallocationEnabled = enabled;
 }
 
-Path SessionImpl::torrentExportDirectory() const
+bool SessionImpl::isTorrentFileBackupEnabled() const
 {
-    return m_torrentExportDirectory;
+    return m_isTorrentFileBackupEnabled;
 }
 
-void SessionImpl::setTorrentExportDirectory(const Path &path)
+void SessionImpl::setTorrentFileBackupEnabled(const bool enabled)
 {
-    if (path != torrentExportDirectory())
-        m_torrentExportDirectory = path;
+    if (enabled != isTorrentFileBackupEnabled())
+        m_isTorrentFileBackupEnabled = enabled;
 }
 
-Path SessionImpl::finishedTorrentExportDirectory() const
+Path SessionImpl::torrentBackupDirectory() const
 {
-    return m_finishedTorrentExportDirectory;
+    if (const Path &path = m_torrentBackupDirectory; !path.isEmpty())
+        return path;
+    return Path(u"backup"_s);
 }
 
-void SessionImpl::setFinishedTorrentExportDirectory(const Path &path)
+void SessionImpl::setTorrentBackupDirectory(const Path &path)
 {
-    if (path != finishedTorrentExportDirectory())
-        m_finishedTorrentExportDirectory = path;
+    if (path != torrentBackupDirectory())
+        m_torrentBackupDirectory = path;
+}
+
+bool SessionImpl::isFinishedTorrentBackupDirectoryEnabled() const
+{
+    return m_isFinishedTorrentBackupDirectoryEnabled;
+}
+
+void SessionImpl::setFinishedTorrentBackupDirectoryEnabled(const bool enabled)
+{
+    if (enabled != isFinishedTorrentBackupDirectoryEnabled())
+        m_isFinishedTorrentBackupDirectoryEnabled = enabled;
+}
+
+Path SessionImpl::finishedTorrentBackupDirectory() const
+{
+    if (const Path &path = m_finishedTorrentBackupDirectory; !path.isEmpty())
+        return path;
+    return Path(u"backup"_s);
+}
+
+void SessionImpl::setFinishedTorrentBackupDirectory(const Path &path)
+{
+    if (path != finishedTorrentBackupDirectory())
+        m_finishedTorrentBackupDirectory = path;
+}
+
+bool SessionImpl::removeTorrentFileBackup() const
+{
+    return m_removeTorrentFileBackup;
+}
+
+void SessionImpl::setRemoveTorrentFileBackup(const bool remove)
+{
+    if (remove != removeTorrentFileBackup())
+        m_removeTorrentFileBackup = remove;
 }
 
 Path SessionImpl::savePath() const
@@ -2592,6 +2654,22 @@ bool SessionImpl::removeTorrent(const TorrentID &id, const TorrentRemoveOption d
     // Remove it from torrent resume directory
     m_resumeDataStorage->remove(torrentID);
 
+    if (removeTorrentFileBackup())
+    {
+        const QString torrentBackupInfo = m_backupTorrentFilesRegistry->fetchValue(torrent->id().toString()).takeResult().toString();
+        if (!torrentBackupInfo.isEmpty() && !torrentBackupInfo.startsWith(u"magnet:", Qt::CaseInsensitive))
+        {
+            const Path torrentBackupPath = resolvePath(Path(torrentBackupInfo), specialFolderLocation(SpecialFolder::Data));
+            if (const auto removeResult = Utils::Fs::removeFile(torrentBackupPath); !removeResult)
+            {
+                LogMsg(tr("Could not remove .torrent file backup. Torrent: \"%1\". File: \"%2\". Reason: %3")
+                       .arg(torrentName, torrentBackupPath.toString(), removeResult.error()));
+            }
+        }
+    }
+
+    m_backupTorrentFilesRegistry->removeValue(torrent->id().toString());
+
     LogMsg(tr("Torrent removed. Torrent: \"%1\"").arg(torrentName));
     delete torrent;
     return true;
@@ -2761,12 +2839,12 @@ LoadTorrentParams SessionImpl::initLoadTorrentParams(const AddTorrentParams &add
 }
 
 // Add a torrent to the BitTorrent session
-bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorrentParams &addTorrentParams)
+bool SessionImpl::addTorrent_impl(const TorrentDescriptor &torrentDescr, const AddTorrentParams &addTorrentParams)
 {
     Q_ASSERT(isRestored());
 
-    const bool hasMetadata = (source.info().has_value());
-    const auto infoHash = source.infoHash();
+    const bool hasMetadata = (torrentDescr.info().has_value());
+    const auto infoHash = torrentDescr.infoHash();
     const auto id = TorrentID::fromInfoHash(infoHash);
 
     // alternative ID can be useful to find existing torrent in case if hybrid torrent was added by v1 info hash
@@ -2779,7 +2857,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         if (hasMetadata)
         {
             // Trying to set metadata to existing torrent in case if it has none
-            torrent->setMetadata(*source.info());
+            torrent->setMetadata(*torrentDescr.info());
         }
 
         if (!isMergeTrackersEnabled())
@@ -2791,7 +2869,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
             return false;
         }
 
-        const bool isPrivate = torrent->isPrivate() || (hasMetadata && source.info()->isPrivate());
+        const bool isPrivate = torrent->isPrivate() || (hasMetadata && torrentDescr.info()->isPrivate());
         if (isPrivate)
         {
             const QString message = tr("Trackers cannot be merged because it is a private torrent");
@@ -2802,8 +2880,8 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         }
 
         // merge trackers and web seeds
-        torrent->addTrackers(source.trackers());
-        torrent->addUrlSeeds(source.urlSeeds());
+        torrent->addTrackers(torrentDescr.trackers());
+        torrent->addUrlSeeds(torrentDescr.urlSeeds());
 
         const QString message = tr("Trackers are merged from new source");
         LogMsg(tr("Detected an attempt to add a duplicate torrent. Existing torrent: \"%1\". Torrent infohash: %2. Result: %3")
@@ -2822,7 +2900,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
 
     LoadTorrentParams loadTorrentParams = initLoadTorrentParams(addTorrentParams);
     lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;
-    p = source.ltAddTorrentParams();
+    p = torrentDescr.ltAddTorrentParams();
 
     const bool useAutoTMM = loadTorrentParams.useAutoTMM;
     const Path actualSavePath = useAutoTMM ? categorySavePath(loadTorrentParams.category) : loadTorrentParams.savePath;
@@ -2840,7 +2918,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
             loadTorrentParams.stopCondition = Torrent::StopCondition::None;
         }
 
-        const TorrentInfo &torrentInfo = *source.info();
+        const TorrentInfo &torrentInfo = *torrentDescr.info();
 
         Q_ASSERT(addTorrentParams.filePaths.isEmpty() || (addTorrentParams.filePaths.size() == torrentInfo.filesCount()));
 
@@ -2997,7 +3075,8 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         return findIncompleteFiles(actualSavePath, actualDownloadPath, filePaths);
     };
 
-    resolveFileNames().then(this, [this, id, loadTorrentParams = std::move(loadTorrentParams)](const FileSearchResult &result) mutable
+    resolveFileNames().then(this
+        , [this, id, torrentDescr, loadTorrentParams = std::move(loadTorrentParams)](const FileSearchResult &result) mutable
     {
         lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;
 
@@ -3011,7 +3090,8 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         }
 
         m_nativeSession->async_add_torrent(p);
-        m_addTorrentAlertHandlers.append([this, loadTorrentParams = std::move(loadTorrentParams)](const lt::add_torrent_alert *alert) mutable
+        m_addTorrentAlertHandlers.append(
+            [this, torrentDescr, loadTorrentParams = std::move(loadTorrentParams)](const lt::add_torrent_alert *alert) mutable
         {
             if (alert->error)
             {
@@ -3042,12 +3122,8 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
                 LogMsg(tr("Added new torrent. Torrent: \"%1\"").arg(torrent->name()));
                 emit torrentAdded(torrent);
 
-                // The following is useless for newly added magnet
-                if (torrent->hasMetadata())
-                {
-                    if (!torrentExportDirectory().isEmpty())
-                        exportTorrentFile(torrent, torrentExportDirectory());
-                }
+                if (isTorrentFileBackupEnabled())
+                    backupTorrentFile(torrent, torrentDescr);
             }
         });
     });
@@ -3233,30 +3309,6 @@ bool SessionImpl::downloadMetadata(const TorrentDescriptor &torrentDescr)
     });
 
     return true;
-}
-
-void SessionImpl::exportTorrentFile(const Torrent *torrent, const Path &folderPath)
-{
-    if (!folderPath.exists() && !Utils::Fs::mkpath(folderPath))
-        return;
-
-    const QString validName = Utils::Fs::toValidFileName(torrent->name());
-    QString torrentExportFilename = u"%1.torrent"_s.arg(validName);
-    Path newTorrentPath = folderPath / Path(torrentExportFilename);
-    int counter = 0;
-    while (newTorrentPath.exists())
-    {
-        // Append number to torrent name to make it unique
-        torrentExportFilename = u"%1 (%2).torrent"_s.arg(validName).arg(++counter);
-        newTorrentPath = folderPath / Path(torrentExportFilename);
-    }
-
-    const nonstd::expected<void, QString> result = torrent->exportToFile(newTorrentPath);
-    if (!result)
-    {
-        LogMsg(tr("Failed to export torrent. Torrent: \"%1\". Destination: \"%2\". Reason: \"%3\"")
-               .arg(torrent->name(), newTorrentPath.toString(), result.error()), Log::WARNING);
-    }
 }
 
 void SessionImpl::generateResumeData()
@@ -5319,6 +5371,71 @@ void SessionImpl::updateShareLimitsTimer()
     }
 }
 
+void SessionImpl::backupTorrentFile(const Torrent *torrent, const TorrentDescriptor &torrentDescr)
+{
+    const Path backupDirPathConf = torrentBackupDirectory();
+    const Path backupDirPath = resolvePath(backupDirPathConf, specialFolderLocation(SpecialFolder::Data));
+    const QString torrentFileBasename = Utils::Fs::toValidFileName(torrent->name());
+    const Path torrentBackupPath = makeUniqueFilePath(backupDirPath, torrentFileBasename, u"torrent"_s);
+    const Path torrentBackupPathConf = backupDirPathConf.isAbsolute() ? torrentBackupPath : (backupDirPathConf / Path(torrentBackupPath.filename()));
+
+    if (const QString torrentSource = torrentDescr.source();
+            !torrentSource.isEmpty() && !torrentSource.startsWith(u"magnet:", Qt::CaseInsensitive))
+    {
+        const Path sourceFilePath {torrentSource};
+        if (Utils::Fs::copyFile(sourceFilePath, torrentBackupPath))
+        {
+            m_backupTorrentFilesRegistry->storeValue(torrent->id().toString(), torrentBackupPathConf.data());
+            return;
+        }
+    }
+
+    if (const nonstd::expected<void, QString> result = torrentDescr.saveToFile(torrentBackupPath))
+    {
+        m_backupTorrentFilesRegistry->storeValue(torrent->id().toString(), torrentBackupPathConf.data());
+    }
+    else if (const QString torrentSource = torrentDescr.source();
+            torrentSource.startsWith(u"magnet:", Qt::CaseInsensitive))
+    {
+        // Store original Magnet URI in order to generate .torrent file later
+        m_backupTorrentFilesRegistry->storeValue(torrent->id().toString(), torrentSource);
+    }
+    else
+    {
+        LogMsg(tr("Failed to backup .torrent file. Torrent: \"%1\". Destination: \"%2\". Reason: \"%3\"")
+               .arg(torrent->name(), torrentBackupPath.toString(), result.error()), Log::WARNING);
+    }
+}
+
+void SessionImpl::backupTorrentFile(const Torrent *torrent, const QString &magnetURI, const Path &backupDirPathConf)
+{
+    // Generate .torrent file based on original Magnet URI
+
+    if (auto parseResult = TorrentDescriptor::parse(magnetURI))
+    {
+        const Path backupDirPath = resolvePath(backupDirPathConf, specialFolderLocation(SpecialFolder::Data));
+        const QString torrentFileBasename = Utils::Fs::toValidFileName(torrent->name());
+        const Path torrentBackupPath = makeUniqueFilePath(backupDirPath, torrentFileBasename, u"torrent"_s);
+        TorrentDescriptor &torrentDescr = parseResult.value();
+        torrentDescr.setTorrentInfo(torrent->info());
+        if (const auto saveResult = torrentDescr.saveToFile(torrentBackupPath))
+        {
+            const Path torrentBackupPathConf = backupDirPathConf.isAbsolute() ? torrentBackupPath : (backupDirPathConf / Path(torrentBackupPath.filename()));
+            m_backupTorrentFilesRegistry->storeValue(torrent->id().toString(), torrentBackupPathConf.data());
+        }
+        else
+        {
+            LogMsg(tr("Failed to backup .torrent file. Torrent: \"%1\". Destination: \"%2\". Reason: \"%3\"")
+                   .arg(torrent->name(), torrentBackupPath.toString(), saveResult.error()), Log::WARNING);
+        }
+    }
+    else
+    {
+        LogMsg(tr("Could not parse backup Magnet URI. Torrent: \"%1\". URI: \"%2\".")
+               .arg(torrent->name(), magnetURI));
+    }
+}
+
 void SessionImpl::handleTorrentShareLimitChanged(TorrentImpl *const)
 {
     updateShareLimitsTimer();
@@ -5386,10 +5503,14 @@ void SessionImpl::handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const
 
 void SessionImpl::handleTorrentMetadataReceived(TorrentImpl *const torrent)
 {
-    if (!torrentExportDirectory().isEmpty())
-        exportTorrentFile(torrent, torrentExportDirectory());
-
     emit torrentMetadataReceived(torrent);
+
+    if (!isTorrentFileBackupEnabled() || torrent->infoHash().v2().isValid())
+        return;
+
+    const QString torrentBackupInfo = m_backupTorrentFilesRegistry->fetchValue(torrent->id().toString()).takeResult().toString();
+    if (torrentBackupInfo.startsWith(u"magnet:", Qt::CaseInsensitive))
+        backupTorrentFile(torrent, torrentBackupInfo, torrentBackupDirectory());
 }
 
 void SessionImpl::handleTorrentStopped(TorrentImpl *const torrent)
@@ -5422,6 +5543,41 @@ void SessionImpl::handleTorrentChecked(TorrentImpl *const torrent)
 void SessionImpl::handleTorrentFinished(TorrentImpl *const torrent)
 {
     m_pendingFinishedTorrents.append(torrent);
+
+    const QString torrentBackupInfo = m_backupTorrentFilesRegistry->fetchValue(torrent->id().toString()).takeResult().toString();
+    if (torrentBackupInfo.isEmpty())
+        return;
+
+    const QString torrentFileBasename = Utils::Fs::toValidFileName(torrent->name());
+
+    if (torrentBackupInfo.startsWith(u"magnet:", Qt::CaseInsensitive))
+    {
+        if (isTorrentFileBackupEnabled())
+        {
+            const Path backupDirPathConf = isFinishedTorrentBackupDirectoryEnabled() ? finishedTorrentBackupDirectory() : torrentBackupDirectory();
+            backupTorrentFile(torrent, torrentBackupInfo, backupDirPathConf);
+        }
+    }
+    else if (isFinishedTorrentBackupDirectoryEnabled())
+    {
+        const Path backupDirPathConf = finishedTorrentBackupDirectory();
+        const Path backupDirPath = resolvePath(backupDirPathConf, specialFolderLocation(SpecialFolder::Data));
+        const Path oldTorrentBackupPath = resolvePath(Path(torrentBackupInfo), specialFolderLocation(SpecialFolder::Data));
+        if (backupDirPath != oldTorrentBackupPath.parentPath())
+        {
+            const Path torrentBackupPath = makeUniqueFilePath(backupDirPath, torrentFileBasename, u"torrent"_s);
+            if (Utils::Fs::renameFile(oldTorrentBackupPath, torrentBackupPath))
+            {
+                const Path torrentBackupPathConf = backupDirPathConf.isAbsolute() ? torrentBackupPath : (backupDirPathConf / Path(torrentBackupPath.filename()));
+                m_backupTorrentFilesRegistry->storeValue(torrent->id().toString(), torrentBackupPathConf.data());
+            }
+            else
+            {
+                LogMsg(tr("Could not move .torrent file backup. Torrent: \"%1\". File: \"%2\".")
+                       .arg(torrent->name(), oldTorrentBackupPath.toString()));
+            }
+        }
+    }
 }
 
 void SessionImpl::handleTorrentResumeDataReady(TorrentImpl *const torrent, LoadTorrentParams data)
@@ -5591,9 +5747,6 @@ void SessionImpl::processPendingFinishedTorrents()
     {
         LogMsg(tr("Torrent download finished. Torrent: \"%1\"").arg(torrent->name()));
         emit torrentFinished(torrent);
-
-        if (const Path exportPath = finishedTorrentExportDirectory(); !exportPath.isEmpty())
-            exportTorrentFile(torrent, exportPath);
 
         processTorrentShareLimits(torrent);
     }

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -68,6 +68,7 @@ class BandwidthScheduler;
 class FileSearcher;
 class FilterParserThread;
 class FreeDiskSpaceChecker;
+class KeyValueDataStorage;
 class NativeSessionExtension;
 
 struct FileSearchResult;
@@ -212,10 +213,17 @@ namespace BitTorrent
         void setRefreshInterval(int value) override;
         bool isPreallocationEnabled() const override;
         void setPreallocationEnabled(bool enabled) override;
-        Path torrentExportDirectory() const override;
-        void setTorrentExportDirectory(const Path &path) override;
-        Path finishedTorrentExportDirectory() const override;
-        void setFinishedTorrentExportDirectory(const Path &path) override;
+
+        bool isTorrentFileBackupEnabled() const override;
+        void setTorrentFileBackupEnabled(bool enabled) override;
+        Path torrentBackupDirectory() const override;
+        void setTorrentBackupDirectory(const Path &path) override;
+        bool isFinishedTorrentBackupDirectoryEnabled() const override;
+        void setFinishedTorrentBackupDirectoryEnabled(bool enabled) override;
+        Path finishedTorrentBackupDirectory() const override;
+        void setFinishedTorrentBackupDirectory(const Path &path) override;
+        bool removeTorrentFileBackup() const override;
+        void setRemoveTorrentFileBackup(bool remove) override;
 
         int globalDownloadSpeedLimit() const override;
         void setGlobalDownloadSpeedLimit(int limit) override;
@@ -580,7 +588,8 @@ namespace BitTorrent
         bool addTorrent_impl(const TorrentDescriptor &source, const AddTorrentParams &addTorrentParams);
 
         void updateShareLimitsTimer();
-        void exportTorrentFile(const Torrent *torrent, const Path &folderPath);
+        void backupTorrentFile(const Torrent *torrent, const TorrentDescriptor &torrentDescr);
+        void backupTorrentFile(const Torrent *torrent, const QString &magnetURI, const Path &backupDirPathConf);
 
         void handleAlert(lt::alert *alert);
         void handleAddTorrentAlert(const lt::add_torrent_alert *alert);
@@ -733,8 +742,11 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isUnwantedFolderEnabled;
         CachedSettingValue<int> m_refreshInterval;
         CachedSettingValue<bool> m_isPreallocationEnabled;
-        CachedSettingValue<Path> m_torrentExportDirectory;
-        CachedSettingValue<Path> m_finishedTorrentExportDirectory;
+        CachedSettingValue<bool> m_isTorrentFileBackupEnabled;
+        CachedSettingValue<Path> m_torrentBackupDirectory;
+        CachedSettingValue<bool> m_isFinishedTorrentBackupDirectoryEnabled;
+        CachedSettingValue<Path> m_finishedTorrentBackupDirectory;
+        CachedSettingValue<bool> m_removeTorrentFileBackup;
         CachedSettingValue<int> m_globalDownloadSpeedLimit;
         CachedSettingValue<int> m_globalUploadSpeedLimit;
         CachedSettingValue<int> m_altGlobalDownloadSpeedLimit;
@@ -887,6 +899,8 @@ namespace BitTorrent
         qint64 m_freeDiskSpace = -1;
 
         ShareLimits m_shareLimits;
+
+        KeyValueDataStorage *m_backupTorrentFilesRegistry = nullptr;
 
         friend void Session::initInstance();
         friend void Session::freeInstance();

--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -38,11 +38,13 @@
 #include <QRegularExpression>
 #include <QUrl>
 
-#include "base/global.h"
+#include "base/path.h"
 #include "base/preferences.h"
 #include "base/utils/io.h"
 #include "infohash.h"
 #include "trackerentry.h"
+
+using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
@@ -103,7 +105,9 @@ nonstd::expected<BitTorrent::TorrentDescriptor, QString>
 BitTorrent::TorrentDescriptor::loadFromFile(const Path &path) noexcept
 try
 {
-    return TorrentDescriptor(lt::load_torrent_file(path.toString().toStdString(), loadTorrentLimits()));
+    TorrentDescriptor torrentDescriptor {lt::load_torrent_file(path.toString().toStdString(), loadTorrentLimits())};
+    torrentDescriptor.m_source = path.data();
+    return torrentDescriptor;
 }
 catch (const lt::system_error &err)
 {
@@ -120,7 +124,9 @@ try
     else if (isV1Hash(str))
         magnetURI = u"magnet:?xt=urn:btih:" + str;
 
-    return TorrentDescriptor(lt::parse_magnet_uri(magnetURI.toStdString()));
+    TorrentDescriptor torrentDescriptor {lt::parse_magnet_uri(magnetURI.toStdString())};
+    torrentDescriptor.m_source = magnetURI;
+    return torrentDescriptor;
 }
 catch (const lt::system_error &err)
 {
@@ -262,6 +268,11 @@ QList<QUrl> BitTorrent::TorrentDescriptor::urlSeeds() const
         urlSeeds.append(QUrl(QString::fromStdString(nativeURLSeed)));
 
     return urlSeeds;
+}
+
+QString BitTorrent::TorrentDescriptor::source() const
+{
+    return m_source;
 }
 
 const libtorrent::add_torrent_params &BitTorrent::TorrentDescriptor::ltAddTorrentParams() const

--- a/src/base/bittorrent/torrentdescriptor.h
+++ b/src/base/bittorrent/torrentdescriptor.h
@@ -38,7 +38,7 @@
 #include <QString>
 
 #include "base/3rdparty/expected.hpp"
-#include "base/path.h"
+#include "base/pathfwd.h"
 #include "torrentinfo.h"
 
 class QByteArray;
@@ -63,6 +63,8 @@ namespace BitTorrent
         QList<QUrl> urlSeeds() const;
         const std::optional<TorrentInfo> &info() const;
 
+        QString source() const;
+
         void setTorrentInfo(TorrentInfo torrentInfo);
 
         static nonstd::expected<TorrentDescriptor, QString> load(const QByteArray &data) noexcept;
@@ -76,6 +78,7 @@ namespace BitTorrent
     private:
         explicit TorrentDescriptor(lt::add_torrent_params ltAddTorrentParams);
 
+        QString m_source;
         lt::add_torrent_params m_ltAddTorrentParams;
         std::optional<TorrentInfo> m_info;
         QDateTime m_creationDate;

--- a/src/base/keyvaluedatastorage.cpp
+++ b/src/base/keyvaluedatastorage.cpp
@@ -1,0 +1,439 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "keyvaluedatastorage.h"
+
+#include <concepts>
+#include <memory>
+#include <queue>
+
+#include <QHash>
+#include <QMutex>
+#include <QPromise>
+#include <QReadWriteLock>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QThread>
+#include <QWaitCondition>
+
+#include "exceptions.h"
+#include "logger.h"
+#include "path.h"
+#include "profile.h"
+
+using namespace Qt::Literals::StringLiterals;
+
+const QString DB_STORAGE_PREFIX = u"QBT_KeyValueDataStorage_"_s;
+const QString DB_COLUMN_ID = u"id"_s;
+const QString DB_COLUMN_KEY = u"key"_s;
+const QString DB_COLUMN_VALUE = u"value"_s;
+
+namespace
+{
+    Path makeDBPath(const QString &storageName)
+    {
+        return specialFolderLocation(SpecialFolder::Data) / Path(storageName + u".db");
+    }
+
+    class Job
+    {
+    public:
+        explicit Job(const QString &storageName, const QString &tableName)
+            : m_storageName {storageName}
+            , m_tableName {tableName}
+        {
+        }
+
+        virtual ~Job() = default;
+        virtual void perform(QSqlDatabase db) = 0;
+
+    protected:
+        QString m_storageName;
+        QString m_tableName;
+    };
+
+    class StoreValueJob final : public Job
+    {
+    public:
+        StoreValueJob(const QString &storageName, const QString &tableName, const QString &key, QVariant value)
+            : Job(storageName, tableName)
+            , m_key {key}
+            , m_value {std::move(value)}
+        {
+        }
+
+        void perform(QSqlDatabase db) override
+        {
+            const QString insertStatement = u"INSERT INTO `%1` (%2, %3) VALUES (:%2, :%3) ON CONFLICT (%2) DO UPDATE SET (%2, %3) = (:%2, :%3)"_s
+                    .arg(m_tableName, DB_COLUMN_KEY, DB_COLUMN_VALUE);
+
+            QSqlQuery query {db};
+            try
+            {
+                if (!query.prepare(insertStatement))
+                    throw RuntimeError(query.lastError().text());
+
+                query.bindValue((u":" + DB_COLUMN_KEY), m_key);
+                query.bindValue((u":" + DB_COLUMN_VALUE), m_value);
+
+                if (!query.exec())
+                    throw RuntimeError(query.lastError().text());
+            }
+            catch (const RuntimeError &err)
+            {
+                LogMsg(KeyValueDataStorage::tr("Inserting (updating) database record failed. Database: %1. Error: %2")
+                        .arg(m_storageName, err.message()), Log::WARNING);
+            }
+        }
+
+    private:
+        QString m_key;
+        QVariant m_value;
+    };
+
+    class FetchValueJob final : public Job
+    {
+    public:
+        explicit FetchValueJob(const QString &storageName, const QString &tableName, const QString &key, QPromise<QVariant> &&promise)
+            : Job(storageName, tableName)
+            , m_key {key}
+            , m_promise {std::move(promise)}
+        {
+        }
+
+        void perform(QSqlDatabase db) override
+        {
+            const QString selectStatement = u"SELECT `%1` FROM `%2` WHERE `%3` = :%3;"_s
+                    .arg(DB_COLUMN_VALUE, m_tableName, DB_COLUMN_KEY);
+
+            QSqlQuery query {db};
+            try
+            {
+                if (!query.prepare(selectStatement))
+                    throw RuntimeError(query.lastError().text());
+
+                query.bindValue((u":" + DB_COLUMN_KEY), m_key);
+                if (!query.exec())
+                    throw RuntimeError(query.lastError().text());
+
+                if (query.next())
+                    m_promise.addResult(query.value(DB_COLUMN_VALUE));
+                else
+                    m_promise.addResult({});
+
+                m_promise.finish();
+            }
+            catch (const RuntimeError &err)
+            {
+                m_promise.addResult({});
+                LogMsg(KeyValueDataStorage::tr("Fetching database record failed. Database: %1. Error: %2")
+                        .arg(m_storageName, err.message()), Log::WARNING);
+            }
+        }
+
+    private:
+        QString m_key;
+        QPromise<QVariant> m_promise;
+    };
+
+    class RemoveValueJob final : public Job
+    {
+    public:
+        explicit RemoveValueJob(const QString &storageName, const QString &tableName, const QString &key)
+            : Job(storageName, tableName)
+            , m_key {key}
+        {
+        }
+
+        void perform(QSqlDatabase db) override
+        {
+            const auto deleteStatement = u"DELETE FROM `%1` WHERE `%2` = :%2;"_s
+                    .arg(m_tableName, DB_COLUMN_KEY);
+
+            QSqlQuery query {db};
+            try
+            {
+                if (!query.prepare(deleteStatement))
+                    throw RuntimeError(query.lastError().text());
+
+                query.bindValue((u":" + DB_COLUMN_KEY), m_key);
+
+                if (!query.exec())
+                    throw RuntimeError(query.lastError().text());
+            }
+            catch (const RuntimeError &err)
+            {
+                LogMsg(KeyValueDataStorage::tr("Deleting database record failed. Database: %1. Error: %2")
+                        .arg(m_storageName, err.message()), Log::WARNING);
+            }
+        }
+
+    private:
+        QString m_key;
+    };
+
+    template <std::integral T>
+    QByteArray toHex(const T value)
+    {
+        return QByteArray(reinterpret_cast<const char *>(&value), sizeof(value)).toHex();
+    }
+}
+
+class KeyValueDataStorage::Worker final : public QThread
+{
+    Q_DISABLE_COPY_MOVE(Worker)
+
+public:
+    explicit Worker(const Path &dbPath, const QString &storageName, QObject *parent = nullptr);
+
+    void run() override;
+    void requestInterruption();
+
+    void storeValue(const QString &key, QVariant &&value);
+    void fetchValue(const QString &key, QPromise<QVariant> &&promise);
+    void removeValue(const QString &key);
+
+private:
+    bool initDB(QSqlDatabase &db);
+    void addJob(std::unique_ptr<Job> job);
+
+    Path m_dbPath;
+    QString m_storageName;
+    QString m_tableName;
+
+    QReadWriteLock m_dbLock;
+
+    std::queue<std::unique_ptr<Job>> m_jobs;
+    QMutex m_jobsMutex;
+    QWaitCondition m_waitCondition;
+};
+
+KeyValueDataStorage::KeyValueDataStorage(const QString &storageName, QObject *parent)
+    : QObject(parent)
+    , m_storageName {storageName}
+{
+}
+
+KeyValueDataStorage::~KeyValueDataStorage()
+{
+    if (m_asyncWorker)
+    {
+        m_asyncWorker->requestInterruption();
+        m_asyncWorker->wait();
+    }
+}
+
+QFuture<QVariant> KeyValueDataStorage::fetchValue(const QString &key) const
+{
+    if (!m_asyncWorker)
+    {
+        const Path dbPath = makeDBPath(m_storageName);
+        if (dbPath.exists())
+        {
+            m_asyncWorker = new Worker(dbPath, m_storageName, const_cast<KeyValueDataStorage *>(this));
+            m_asyncWorker->start();
+        }
+    }
+
+    if (!m_asyncWorker)
+        return QtFuture::makeReadyValueFuture<QVariant>({});
+
+    QPromise<QVariant> promise;
+    const auto future = promise.future();
+    promise.start();
+    m_asyncWorker->fetchValue(key, std::move(promise));
+    return future;
+}
+
+void KeyValueDataStorage::storeValue(const QString &key, const QVariant &value)
+{
+    storeValue(key, QVariant(value));
+}
+
+void KeyValueDataStorage::storeValue(const QString &key, QVariant &&value)
+{
+    if (!m_asyncWorker)
+    {
+        m_asyncWorker = new Worker(makeDBPath(m_storageName), m_storageName, this);
+        m_asyncWorker->start();
+    }
+
+    m_asyncWorker->storeValue(key, std::move(value));
+}
+
+void KeyValueDataStorage::removeValue(const QString &key)
+{
+    if (!m_asyncWorker)
+    {
+        const Path dbPath = makeDBPath(m_storageName);
+        if (dbPath.exists())
+        {
+            m_asyncWorker = new Worker(dbPath, m_storageName, this);
+            m_asyncWorker->start();
+        }
+    }
+
+    if (m_asyncWorker)
+        m_asyncWorker->removeValue(key);
+}
+
+KeyValueDataStorage::Worker::Worker(const Path &dbPath, const QString &storageName, QObject *parent)
+    : QThread(parent)
+    , m_dbPath {dbPath}
+    , m_storageName {storageName}
+    , m_tableName {DB_STORAGE_PREFIX + storageName}
+{
+}
+
+void KeyValueDataStorage::Worker::run()
+{
+    const QString connectionName = DB_STORAGE_PREFIX + QString::fromLatin1(toHex(qHash(this)));
+    Q_ASSERT(!QSqlDatabase::database(connectionName, false).isValid());
+
+    {
+        auto db = QSqlDatabase::addDatabase(u"QSQLITE"_s, connectionName);
+        db.setDatabaseName(m_dbPath.data());
+    }
+
+    {
+        auto db = QSqlDatabase::database(connectionName, false);
+
+        {
+            const QMutexLocker jobsMutexLocker {&m_jobsMutex};
+            if (!m_jobs.empty())
+            {
+                m_dbLock.lockForWrite();
+                if (!initDB(db))
+                {
+                    m_dbLock.unlock();
+                    return;
+                }
+            }
+        }
+
+        int64_t transactedJobsCount = 0;
+        while (true)
+        {
+            QMutexLocker jobsMutexLocker {&m_jobsMutex};
+            if (m_jobs.empty())
+            {
+                if (transactedJobsCount > 0)
+                {
+                    db.commit();
+                    db.close();
+                    m_dbLock.unlock();
+
+                    transactedJobsCount = 0;
+                }
+
+                if (isInterruptionRequested())
+                    break;
+
+                m_waitCondition.wait(&m_jobsMutex);
+                if (isInterruptionRequested())
+                    break;
+
+                m_dbLock.lockForWrite();
+                if (!initDB(db))
+                {
+                    m_dbLock.unlock();
+                    break;
+                }
+            }
+            std::unique_ptr<Job> job = std::move(m_jobs.front());
+            m_jobs.pop();
+            jobsMutexLocker.unlock();
+
+            job->perform(db);
+            ++transactedJobsCount;
+        }
+    }
+
+    QSqlDatabase::removeDatabase(connectionName);
+}
+
+void KeyValueDataStorage::Worker::requestInterruption()
+{
+    QThread::requestInterruption();
+    m_waitCondition.wakeAll();
+}
+
+void KeyValueDataStorage::Worker::storeValue(const QString &key, QVariant &&value)
+{
+    addJob(std::make_unique<StoreValueJob>(m_storageName, m_tableName, key, std::move(value)));
+}
+
+void KeyValueDataStorage::Worker::fetchValue(const QString &key, QPromise<QVariant> &&promise)
+{
+    addJob(std::make_unique<FetchValueJob>(m_storageName, m_tableName, key, std::move(promise)));
+}
+
+void KeyValueDataStorage::Worker::removeValue(const QString &key)
+{
+    addJob(std::make_unique<RemoveValueJob>(m_storageName, m_tableName, key));
+}
+
+bool KeyValueDataStorage::Worker::initDB(QSqlDatabase &db)
+{
+    if (!db.open())
+    {
+        LogMsg(tr("Opening database failed. Database: %1. Error: %2")
+                .arg(m_storageName, db.lastError().text()), Log::WARNING);
+        return false;
+    }
+
+    if (!db.transaction())
+    {
+        LogMsg(tr("Starting database transaction failed. Database: %1. Error: %2")
+                .arg(m_storageName, db.lastError().text()), Log::WARNING);
+        return false;
+    }
+
+    QSqlQuery query {db};
+
+    const QString createTableQuery = u"CREATE TABLE IF NOT EXISTS `%1` (%2 INTEGER PRIMARY KEY, %3 TEXT NOT NULL UNIQUE, %4 BLOB)"_s
+            .arg(m_tableName, DB_COLUMN_ID, DB_COLUMN_KEY, DB_COLUMN_VALUE);
+    if (!query.exec(createTableQuery))
+    {
+        LogMsg(tr("Creating database table failed. Database: %1. Error: %2")
+                .arg(m_storageName, db.lastError().text()), Log::WARNING);
+        return false;
+    }
+
+    return true;
+}
+
+void KeyValueDataStorage::Worker::addJob(std::unique_ptr<Job> job)
+{
+    m_jobsMutex.lock();
+    m_jobs.push(std::move(job));
+    m_jobsMutex.unlock();
+
+    m_waitCondition.wakeAll();
+}

--- a/src/base/keyvaluedatastorage.h
+++ b/src/base/keyvaluedatastorage.h
@@ -1,0 +1,54 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QFuture>
+#include <QObject>
+#include <QVariant>
+
+class KeyValueDataStorage final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(KeyValueDataStorage)
+
+public:
+    explicit KeyValueDataStorage(const QString &storageName, QObject *parent = nullptr);
+    ~KeyValueDataStorage() override;
+
+    QFuture<QVariant> fetchValue(const QString &key) const;
+    void storeValue(const QString &key, const QVariant &value);
+    void storeValue(const QString &key, QVariant &&value);
+    void removeValue(const QString &key);
+
+private:
+    QString m_storageName;
+
+    class Worker;
+    mutable Worker *m_asyncWorker = nullptr;
+};

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -404,6 +404,12 @@ bool Utils::Fs::copyFile(const Path &from, const Path &to)
 
 bool Utils::Fs::renameFile(const Path &from, const Path &to)
 {
+    if (!from.exists())
+        return false;
+
+    if (!mkpath(to.parentPath()))
+        return false;
+
     return QFile::rename(from.data(), to.data());
 }
 

--- a/src/base/utils/io.cpp
+++ b/src/base/utils/io.cpp
@@ -140,6 +140,9 @@ nonstd::expected<void, QString> Utils::IO::saveToFile(const Path &path, const QB
 
 nonstd::expected<void, QString> Utils::IO::saveToFile(const Path &path, const lt::entry &data)
 {
+    if (const Path parentPath = path.parentPath(); !parentPath.isEmpty())
+        Utils::Fs::mkpath(parentPath);
+
     QSaveFile file {path.data()};
     if (!file.open(QIODevice::WriteOnly))
         return nonstd::make_unexpected(file.errorString());

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -604,6 +604,20 @@ void OptionsDialog::loadDownloadsTabOptions()
         m_ui->checkConfirmMergeTrackers->setChecked(m_ui->checkConfirmMergeTrackers->isEnabled() ? pref->confirmMergeTrackers() : false);
     });
 
+    m_ui->backupDirCheckBox->setChecked(session->isTorrentFileBackupEnabled());
+    m_ui->backupDirPathEdit->setDialogCaption(tr("Choose backup directory"));
+    m_ui->backupDirPathEdit->setMode(FileSystemPathEdit::Mode::DirectorySave);
+    m_ui->backupDirPathEdit->setBasePath(specialFolderLocation(SpecialFolder::Data));
+    m_ui->backupDirPathEdit->setSelectedPath(session->torrentBackupDirectory());
+    m_ui->backupDirPathEdit->setEnabled(m_ui->backupDirCheckBox->isChecked());
+    m_ui->finishedBackupDirCheckBox->setChecked(session->isFinishedTorrentBackupDirectoryEnabled());
+    m_ui->finishedBackupDirPathEdit->setDialogCaption(tr("Choose backup directory"));
+    m_ui->finishedBackupDirPathEdit->setMode(FileSystemPathEdit::Mode::DirectorySave);
+    m_ui->finishedBackupDirPathEdit->setBasePath(specialFolderLocation(SpecialFolder::Data));
+    m_ui->finishedBackupDirPathEdit->setSelectedPath(session->finishedTorrentBackupDirectory());
+    m_ui->finishedBackupDirPathEdit->setEnabled(m_ui->finishedBackupDirCheckBox->isChecked());
+    m_ui->removeBackupTorrentFileCheckBox->setChecked(session->removeTorrentFileBackup());
+
     const TorrentFileGuard::AutoDeleteMode autoDeleteMode = TorrentFileGuard::autoDeleteMode();
     m_ui->deleteTorrentBox->setChecked(autoDeleteMode != TorrentFileGuard::Never);
     m_ui->deleteCancelledTorrentBox->setChecked(autoDeleteMode == TorrentFileGuard::Always);
@@ -644,22 +658,6 @@ void OptionsDialog::loadDownloadsTabOptions()
     m_ui->textDownloadPath->setEnabled(m_ui->checkUseDownloadPath->isChecked());
     m_ui->textDownloadPath->setMode(FileSystemPathEdit::Mode::DirectorySave);
     m_ui->textDownloadPath->setSelectedPath(session->downloadPath());
-
-    const bool isExportDirEmpty = session->torrentExportDirectory().isEmpty();
-    m_ui->checkExportDir->setChecked(!isExportDirEmpty);
-    m_ui->textExportDir->setDialogCaption(tr("Choose export directory"));
-    m_ui->textExportDir->setEnabled(m_ui->checkExportDir->isChecked());
-    m_ui->textExportDir->setMode(FileSystemPathEdit::Mode::DirectorySave);
-    if (!isExportDirEmpty)
-        m_ui->textExportDir->setSelectedPath(session->torrentExportDirectory());
-
-    const bool isExportDirFinEmpty = session->finishedTorrentExportDirectory().isEmpty();
-    m_ui->checkExportDirFin->setChecked(!isExportDirFinEmpty);
-    m_ui->textExportDirFin->setDialogCaption(tr("Choose export directory"));
-    m_ui->textExportDirFin->setEnabled(m_ui->checkExportDirFin->isChecked());
-    m_ui->textExportDirFin->setMode(FileSystemPathEdit::Mode::DirectorySave);
-    if (!isExportDirFinEmpty)
-        m_ui->textExportDirFin->setSelectedPath(session->finishedTorrentExportDirectory());
 
     auto *watchedFoldersModel = new WatchedFoldersModel(TorrentFilesWatcher::instance(), this);
     connect(watchedFoldersModel, &QAbstractListModel::dataChanged, this, &ThisType::enableApplyButton);
@@ -762,6 +760,15 @@ void OptionsDialog::loadDownloadsTabOptions()
     connect(m_ui->stopConditionComboBox, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkMergeTrackers, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkConfirmMergeTrackers, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+
+    connect(m_ui->backupDirCheckBox, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->backupDirCheckBox, &QAbstractButton::toggled, m_ui->backupDirPathEdit, &QWidget::setEnabled);
+    connect(m_ui->finishedBackupDirCheckBox, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->finishedBackupDirCheckBox, &QAbstractButton::toggled, m_ui->finishedBackupDirPathEdit, &QWidget::setEnabled);
+    connect(m_ui->backupDirPathEdit, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->finishedBackupDirPathEdit, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->removeBackupTorrentFileCheckBox, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+
     connect(m_ui->deleteTorrentBox, &QGroupBox::toggled, m_ui->deleteTorrentWarningIcon, &QWidget::setVisible);
     connect(m_ui->deleteTorrentBox, &QGroupBox::toggled, m_ui->deleteTorrentWarningLabel, &QWidget::setVisible);
     connect(m_ui->deleteTorrentBox, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
@@ -782,12 +789,6 @@ void OptionsDialog::loadDownloadsTabOptions()
     connect(m_ui->textSavePath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textDownloadPath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
 
-    connect(m_ui->checkExportDir, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkExportDir, &QAbstractButton::toggled, m_ui->textExportDir, &QWidget::setEnabled);
-    connect(m_ui->checkExportDirFin, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkExportDirFin, &QAbstractButton::toggled, m_ui->textExportDirFin, &QWidget::setEnabled);
-    connect(m_ui->textExportDir, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->textExportDirFin, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseDownloadPath, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseDownloadPath, &QAbstractButton::toggled, m_ui->textDownloadPath, &QWidget::setEnabled);
 
@@ -832,9 +833,17 @@ void OptionsDialog::saveDownloadsTabOptions() const
     session->setAddTorrentToQueueTop(m_ui->checkAddToQueueTop->isChecked());
     session->setAddTorrentStopped(addTorrentsStopped());
     session->setTorrentStopCondition(m_ui->stopConditionComboBox->currentData().value<BitTorrent::Torrent::StopCondition>());
+
+    session->setTorrentFileBackupEnabled(m_ui->backupDirCheckBox->isChecked());
+    session->setTorrentBackupDirectory(m_ui->backupDirPathEdit->selectedPath());
+    session->setFinishedTorrentBackupDirectoryEnabled(m_ui->finishedBackupDirCheckBox->isChecked());
+    session->setFinishedTorrentBackupDirectory(m_ui->finishedBackupDirPathEdit->selectedPath());
+    session->setRemoveTorrentFileBackup(m_ui->removeBackupTorrentFileCheckBox->isChecked());
+
     TorrentFileGuard::setAutoDeleteMode(!m_ui->deleteTorrentBox->isChecked() ? TorrentFileGuard::Never
-                             : !m_ui->deleteCancelledTorrentBox->isChecked() ? TorrentFileGuard::IfAdded
-                             : TorrentFileGuard::Always);
+            : !m_ui->deleteCancelledTorrentBox->isChecked() ? TorrentFileGuard::IfAdded
+            : TorrentFileGuard::Always);
+
     session->setMergeTrackersEnabled(m_ui->checkMergeTrackers->isChecked());
     if (m_ui->checkConfirmMergeTrackers->isEnabled())
         pref->setConfirmMergeTrackers(m_ui->checkConfirmMergeTrackers->isChecked());
@@ -854,8 +863,6 @@ void OptionsDialog::saveDownloadsTabOptions() const
     session->setSavePath(Path(m_ui->textSavePath->selectedPath()));
     session->setDownloadPathEnabled(m_ui->checkUseDownloadPath->isChecked());
     session->setDownloadPath(m_ui->textDownloadPath->selectedPath());
-    session->setTorrentExportDirectory(getTorrentExportDir());
-    session->setFinishedTorrentExportDirectory(getFinishedTorrentExportDir());
 
     auto *watchedFoldersModel = static_cast<WatchedFoldersModel *>(m_ui->scanFoldersView->model());
     watchedFoldersModel->apply();
@@ -2064,20 +2071,6 @@ void OptionsDialog::setLocale(const QString &localeStr)
         Q_ASSERT(index >= 0);
     }
     m_ui->comboLanguage->setCurrentIndex(index);
-}
-
-Path OptionsDialog::getTorrentExportDir() const
-{
-    if (m_ui->checkExportDir->isChecked())
-        return m_ui->textExportDir->selectedPath();
-    return {};
-}
-
-Path OptionsDialog::getFinishedTorrentExportDir() const
-{
-    if (m_ui->checkExportDirFin->isChecked())
-        return m_ui->textExportDirFin->selectedPath();
-    return {};
 }
 
 void OptionsDialog::on_addWatchedFolderButton_clicked()

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -159,8 +159,6 @@ private:
     bool preAllocateAllFiles() const;
     bool useAdditionDialog() const;
     bool addTorrentsStopped() const;
-    Path getTorrentExportDir() const;
-    Path getFinishedTorrentExportDir() const;
     // Connection options
     int getPort() const;
     bool isUPnPEnabled() const;

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1152,12 +1152,48 @@
                 </widget>
                </item>
                <item>
+                <widget class="QGroupBox" name="backupTorrentFileGroupBox">
+                 <property name="title">
+                  <string>Store backup .torrent file</string>
+                 </property>
+                 <layout class="QGridLayout" name="backupTorrentFileLayout">
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="backupDirCheckBox">
+                    <property name="text">
+                     <string>Store backup in:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="FileSystemPathLineEdit" name="backupDirPathEdit" native="true"/>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QCheckBox" name="finishedBackupDirCheckBox">
+                    <property name="text">
+                     <string>When torrent finished move backup to:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="FileSystemPathLineEdit" name="finishedBackupDirPathEdit" native="true"/>
+                  </item>
+                  <item row="2" column="0" colspan="2">
+                   <widget class="QCheckBox" name="removeBackupTorrentFileCheckBox">
+                    <property name="text">
+                     <string>Remove backup when removing torrent</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="deleteTorrentBox">
                  <property name="toolTip">
                   <string>Whether the .torrent file should be deleted after adding it</string>
                  </property>
                  <property name="title">
-                  <string>De&amp;lete .torrent files afterwards </string>
+                  <string>De&amp;lete .torrent file afterwards </string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -1446,26 +1482,6 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                  </item>
                  <item row="1" column="1">
                   <widget class="FileSystemPathLineEdit" name="textDownloadPath" native="true"/>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QCheckBox" name="checkExportDir">
-                   <property name="text">
-                    <string>Copy .torrent files to:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="FileSystemPathLineEdit" name="textExportDir" native="true"/>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QCheckBox" name="checkExportDirFin">
-                   <property name="text">
-                    <string>Copy .torrent files for finished downloads to:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="1">
-                  <widget class="FileSystemPathLineEdit" name="textExportDirFin" native="true"/>
                  </item>
                 </layout>
                </item>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -187,8 +187,12 @@ void AppController::preferencesAction()
     data[u"temp_path_enabled"_s] = session->isDownloadPathEnabled();
     data[u"temp_path"_s] = session->downloadPath().toString();
     data[u"use_category_paths_in_manual_mode"_s] = session->useCategoryPathsInManualMode();
-    data[u"export_dir"_s] = session->torrentExportDirectory().toString();
-    data[u"export_dir_fin"_s] = session->finishedTorrentExportDirectory().toString();
+    // .torrent files backup management
+    data[u"torrent_files_backup_enabled"_s] = session->isTorrentFileBackupEnabled();
+    data[u"torrent_files_backup_dir"_s] = session->torrentBackupDirectory().toString();
+    data[u"torrent_files_finished_backup_dir_enabled"_s] = session->isFinishedTorrentBackupDirectoryEnabled();
+    data[u"torrent_files_finished_backup_dir"_s] = session->finishedTorrentBackupDirectory().toString();
+    data[u"remove_torrent_file_backup"_s] = session->removeTorrentFileBackup();
 
     // TODO: The following code is deprecated. Delete it once replaced by updated API method.
     // === BEGIN DEPRECATED CODE === //
@@ -606,10 +610,18 @@ void AppController::setPreferencesAction()
         session->setDownloadPath(Path(it.value().toString()));
     if (hasKey(u"use_category_paths_in_manual_mode"_s))
         session->setUseCategoryPathsInManualMode(it.value().toBool());
-    if (hasKey(u"export_dir"_s))
-        session->setTorrentExportDirectory(Path(it.value().toString()));
-    if (hasKey(u"export_dir_fin"_s))
-        session->setFinishedTorrentExportDirectory(Path(it.value().toString()));
+
+    // .torrent files backup management
+    if (hasKey(u"torrent_files_backup_enabled"_s))
+        session->setTorrentFileBackupEnabled(it.value().toBool());
+    if (hasKey(u"torrent_files_backup_dir"_s))
+        session->setTorrentBackupDirectory(Path(it.value().toString()));
+    if (hasKey(u"torrent_files_finished_backup_dir_enabled"_s))
+        session->setFinishedTorrentBackupDirectoryEnabled(it.value().toBool());
+    if (hasKey(u"torrent_files_finished_backup_dir"_s))
+        session->setFinishedTorrentBackupDirectory(Path(it.value().toString()));
+    if (hasKey(u"remove_torrent_file_backup"_s))
+        session->setRemoveTorrentFileBackup(it.value().toBool());
 
     // TODO: The following code is deprecated. Delete it once replaced by updated API method.
     // === BEGIN DEPRECATED CODE === //

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -188,6 +188,39 @@
                 <label for="mergeTrackersInput">QBT_TR(Merge trackers to existing torrent)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
         </fieldset>
+        <fieldset class="settings">
+            <legend>
+                <label>QBT_TR(Store backup .torrent file)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
+            <table id="torrentBackupSettings">
+                <tbody>
+                    <tr>
+                        <td>
+                            <input type="checkbox" id="torrentBackupDirCheckbox" onclick="qBittorrent.Preferences.updateTorrentBackupControls();">
+                            <label id="backupDirLabel" for="torrentBackupDirCheckbox">QBT_TR(Store backup in:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="torrentBackupDir" class="pathDirectory" style="width: 30em;" autocorrect="off" autocapitalize="none" aria-labelledby="backupDirLabel">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input type="checkbox" id="torrentBackupFinishedDirCheckbox" onclick="qBittorrent.Preferences.updateFinishedTorrentBackupControls();">
+                            <label id="backupDirFinLabel" for="torrentBackupFinishedDirCheckbox">QBT_TR(When torrent finished move backup to:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="torrentBackupFinishedDir" class="pathDirectory" style="width: 30em;" autocorrect="off" autocapitalize="none" aria-labelledby="backupDirFinLabel">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input type="checkbox" id="torrentBackupRemoveCheckbox">
+                            <label id="backupRemoveLabel" for="torrentBackupRemoveCheckbox">QBT_TR(Remove backup when removing torrent)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </fieldset>
         <div class="formRow">
             <input type="checkbox" id="deletetorrentfileafter_checkbox">
             <label for="deletetorrentfileafter_checkbox">QBT_TR(Delete .torrent files afterwards)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -282,24 +315,6 @@
                     </td>
                     <td>
                         <input type="text" id="temppath_text" class="pathDirectory" autocorrect="off" autocapitalize="none" aria-labelledby="tempPathLabel">
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <input type="checkbox" id="exportdir_checkbox" onclick="qBittorrent.Preferences.updateExportDirEnabled();">
-                        <label id="exportDirLabel" for="exportdir_checkbox">QBT_TR(Copy .torrent files to:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                    </td>
-                    <td>
-                        <input type="text" id="exportdir_text" class="pathDirectory" autocorrect="off" autocapitalize="none" aria-labelledby="exportDirLabel">
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <input type="checkbox" id="exportdirfin_checkbox" onclick="qBittorrent.Preferences.updateExportDirFinEnabled();">
-                        <label id="exportDirFinLabel" for="exportdirfin_checkbox">QBT_TR(Copy .torrent files for finished downloads to:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                    </td>
-                    <td>
-                        <input type="text" id="exportdirfin_text" class="pathDirectory" autocorrect="off" autocapitalize="none" aria-labelledby="exportDirFinLabel">
                     </td>
                 </tr>
             </tbody>
@@ -1878,8 +1893,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateFileLogBackupEnabled: updateFileLogBackupEnabled,
                 updateFileLogDeleteEnabled: updateFileLogDeleteEnabled,
                 updateTempDirEnabled: updateTempDirEnabled,
-                updateExportDirEnabled: updateExportDirEnabled,
-                updateExportDirFinEnabled: updateExportDirFinEnabled,
+                updateTorrentBackupControls: updateTorrentBackupControls,
+                updateFinishedTorrentBackupControls: updateFinishedTorrentBackupControls,
                 addWatchFolder: addWatchFolder,
                 updateExcludedFileNamesEnabled: updateExcludedFileNamesEnabled,
                 changeWatchFolderSelect: changeWatchFolderSelect,
@@ -2035,14 +2050,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             document.getElementById("excludedFileNamesTextarea").disabled = !isAExcludedFileNamesEnabled;
         };
 
-        const updateExportDirEnabled = () => {
-            const isExportDirEnabled = document.getElementById("exportdir_checkbox").checked;
-            document.getElementById("exportdir_text").disabled = !isExportDirEnabled;
+        const updateTorrentBackupControls = () => {
+            const isTorrentBackupEnabled = document.getElementById("torrentBackupDirCheckbox").checked;
+            document.getElementById("torrentBackupDir").disabled = !isTorrentBackupEnabled;
         };
 
-        const updateExportDirFinEnabled = () => {
-            const isExportDirFinEnabled = document.getElementById("exportdirfin_checkbox").checked;
-            document.getElementById("exportdirfin_text").disabled = !isExportDirFinEnabled;
+        const updateFinishedTorrentBackupControls = () => {
+            const isFinishedTorrentBackupEnabled = document.getElementById("torrentBackupFinishedDirCheckbox").checked;
+            document.getElementById("torrentBackupFinishedDir").disabled = !isFinishedTorrentBackupEnabled;
         };
 
         const updateMailNotification = () => {
@@ -2460,24 +2475,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("temppath_checkbox").checked = pref.temp_path_enabled;
                     document.getElementById("temppath_text").value = pref.temp_path;
                     updateTempDirEnabled();
-                    if (pref.export_dir !== "") {
-                        document.getElementById("exportdir_checkbox").checked = true;
-                        document.getElementById("exportdir_text").value = pref.export_dir;
-                    }
-                    else {
-                        document.getElementById("exportdir_checkbox").checked = false;
-                        document.getElementById("exportdir_text").value = "";
-                    }
-                    updateExportDirEnabled();
-                    if (pref.export_dir_fin !== "") {
-                        document.getElementById("exportdirfin_checkbox").checked = true;
-                        document.getElementById("exportdirfin_text").value = pref.export_dir_fin;
-                    }
-                    else {
-                        document.getElementById("exportdirfin_checkbox").checked = false;
-                        document.getElementById("exportdirfin_text").value = "";
-                    }
-                    updateExportDirFinEnabled();
+
+                    document.getElementById("torrentBackupDirCheckbox").checked = pref.torrent_files_backup_enabled;
+                    document.getElementById("torrentBackupDir").value = pref.torrent_files_backup_dir;
+                    updateTorrentBackupControls();
+                    document.getElementById("torrentBackupFinishedDirCheckbox").checked = pref.torrent_files_finished_backup_dir_enabled;
+                    document.getElementById("torrentBackupFinishedDir").value = pref.torrent_files_finished_backup_dir;
+                    updateFinishedTorrentBackupControls();
+                    document.getElementById("torrentBackupRemoveCheckbox").checked = pref.remove_torrent_file_backup;
 
                     // Automatically add torrents from
                     for (const folder in pref.scan_dirs) {
@@ -2887,14 +2892,13 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["save_path"] = document.getElementById("savepath_text").value;
             settings["temp_path_enabled"] = document.getElementById("temppath_checkbox").checked;
             settings["temp_path"] = document.getElementById("temppath_text").value;
-            if (document.getElementById("exportdir_checkbox").checked)
-                settings["export_dir"] = document.getElementById("exportdir_text").value;
-            else
-                settings["export_dir"] = "";
-            if (document.getElementById("exportdirfin_checkbox").checked)
-                settings["export_dir_fin"] = document.getElementById("exportdirfin_text").value;
-            else
-                settings["export_dir_fin"] = "";
+
+            // Backup management
+            settings["torrent_files_backup_enabled"] = document.getElementById("torrentBackupDirCheckbox").checked;
+            settings["torrent_files_backup_dir"] = document.getElementById("torrentBackupDir").value;
+            settings["torrent_files_finished_backup_dir_enabled"] = document.getElementById("torrentBackupFinishedDirCheckbox").checked;
+            settings["torrent_files_finished_backup_dir"] = document.getElementById("torrentBackupFinishedDir").value;
+            settings["remove_torrent_file_backup"] = document.getElementById("torrentBackupRemoveCheckbox").checked;
 
             // Automatically add torrents from
             settings["scan_dirs"] = getWatchedFolders();


### PR DESCRIPTION
This turns current options that have confusing behavior into more clear "Backup .torrent files" feature. It works like the following: 
1. If a torrent is added from a .torrent file, then this particular .torrent file is copied to the backup folder.
2. If a torrent is added from a magnet link, then it is this link that is saved until the corresponding .torrent file can be generated based on this link and the received metadata.

I.e. we can say that this is a backup copy of the original .torrent file without any modifications the user have applied to corresponding torrent.

The feature is deliberately designed to store its data separately, rather than in the torrent resume data, as it has nothing to do with the operation of the torrent itself.
 
**GUI**
<img width="622" height="129" alt="000" src="https://github.com/user-attachments/assets/fa9706a1-e6af-4bb3-abd6-1e30e111eea0" />

**WebUI**
<img width="684" height="127" alt="001" src="https://github.com/user-attachments/assets/db470f14-442b-444a-bdf9-8c4b0647b900" />

---

This also implements a service class `KeyValueDataStorage`, which is a general purpose `key=value` data storage that uses SQLite as backend. In the future, it can also be used to save other data (such as saved states of GUI widget, etc., which are currently saved in the configuration file).
