### PR TITLE
Restructure MatchAny seeding limit evaluation logic

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2389,30 +2389,41 @@ void SessionImpl::processTorrentShareLimits(TorrentImpl *torrent)
 
     if (shareLimits.mode == ShareLimitsMode::MatchAny)
     {
-        if (const qreal ratio = torrent->realRatio();
-            (shareLimits.ratioLimit >= 0) && (ratio >= shareLimits.ratioLimit))
+        const qreal ratio = torrent->realRatio();
+        const qlonglong seedingTimeInMinutes = torrent->finishedTime() / 60;
+
+        // 1. Check if primary limits are active and if they have been met
+        const bool isRatioActive = (shareLimits.ratioLimit >= 0);
+        const bool isRatioMet = isRatioActive && (ratio >= shareLimits.ratioLimit);
+
+        const bool isSeedingTimeActive = (shareLimits.seedingTimeLimit >= 0);
+        const bool isSeedingTimeMet = isSeedingTimeActive && (seedingTimeInMinutes >= shareLimits.seedingTimeLimit);
+
+        // 2. Track if a primary hurdle was cleared (or if no primary limits exist)
+        const bool hasPrimaryLimits = (isRatioActive || isSeedingTimeActive);
+        const bool primaryGoalSatisfied = (!hasPrimaryLimits) || isRatioMet || isSeedingTimeMet;
+
+        // 3. Process the outcomes sequentially
+        if (isRatioMet)
         {
             reached = true;
             description = tr("Torrent reached the share ratio limit.");
         }
-        else if (const qlonglong seedingTimeInMinutes = torrent->finishedTime() / 60;
-            (shareLimits.seedingTimeLimit >= 0) && (seedingTimeInMinutes >= shareLimits.seedingTimeLimit))
+        else if (isSeedingTimeMet)
         {
             reached = true;
             description = tr("Torrent reached the seeding time limit.");
         }
-        else if (const qlonglong inactiveSeedingTimeInMinutes = torrent->timeSinceActivity() / 60;
-            (shareLimits.inactiveSeedingTimeLimit >= 0) && (inactiveSeedingTimeInMinutes >= shareLimits.inactiveSeedingTimeLimit))
+        else if (primaryGoalSatisfied && (shareLimits.inactiveSeedingTimeLimit >= 0))
         {
-            reached = true;
-            description = tr("Torrent reached the inactive seeding time limit.");
+            const qlonglong inactiveSeedingTimeInMinutes = torrent->timeSinceActivity() / 60;
+            if (inactiveSeedingTimeInMinutes >= shareLimits.inactiveSeedingTimeLimit)
+            {
+                reached = true;
+                description = tr("Torrent reached the inactive seeding time limit.");
+            }
         }
     }
-    else
-    {
-        reached = true;
-        description = tr("Torrent reached the share limit(s).");
-
         if (const qreal ratio = torrent->realRatio();
             (shareLimits.ratioLimit >= 0) && (ratio < shareLimits.ratioLimit))
         {

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2424,6 +2424,11 @@ void SessionImpl::processTorrentShareLimits(TorrentImpl *torrent)
             }
         }
     }
+    else
+    {
+        reached = true;
+        description = tr("Torrent reached the share limit(s).");
+
         if (const qreal ratio = torrent->realRatio();
             (shareLimits.ratioLimit >= 0) && (ratio < shareLimits.ratioLimit))
         {

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1437,15 +1437,15 @@ qlonglong TorrentImpl::eta() const
             if (seedingTimeEta >= 0) activePrimaryEtas.append(seedingTimeEta);
 
             const bool hasPrimaryLimits = !activePrimaryEtas.isEmpty();
-            
+
             // Primary goals are satisfied if none are set, or if at least one has reached 0
-            const bool primaryGoalSatisfied = !hasPrimaryLimits 
-                || (ratioEta == ZERO_ETA) 
+            const bool primaryGoalSatisfied = !hasPrimaryLimits
+                || (ratioEta == ZERO_ETA)
                 || (seedingTimeEta == ZERO_ETA);
 
             // Collect valid candidates for MatchAny
             QList<qint64> validCandidates;
-            
+
             // Add primary ETAs that haven't finished yet
             for (qint64 etaVal : activePrimaryEtas)
             {

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1392,10 +1392,15 @@ qlonglong TorrentImpl::eta() const
     if (isFinished())
     {
         const qint64 ZERO_ETA = 0;
-
         const ShareLimits shareLimits = effectiveShareLimits();
         QList<qint64> etaList;
 
+        // 1. Declare variables at the top of the function scope so the logic engine can read them later
+        qint64 ratioEta = ZERO_ETA;
+        qint64 seedingTimeEta = MAX_ETA;
+        qint64 inactiveSeedingTimeEta = MAX_ETA;
+
+        // 2. Calculate Ratio Limit if active
         if (shareLimits.ratioLimit >= 0)
         {
             qint64 realDL = totalDownload();
@@ -1404,7 +1409,6 @@ qlonglong TorrentImpl::eta() const
 
             const qreal uploadLimit = realDL * shareLimits.ratioLimit;
             const qint64 uploaded = totalUpload();
-            qint64 ratioEta = ZERO_ETA;
             if (uploadLimit > uploaded)
             {
                 ratioEta = (speedAverage.upload > 0)
@@ -1414,16 +1418,18 @@ qlonglong TorrentImpl::eta() const
             etaList.append(ratioEta);
         }
 
+        // 3. Calculate Seeding Time Limit if active
         if (shareLimits.seedingTimeLimit >= 0)
         {
-            const qint64 seedingTimeEta = std::max(
+            seedingTimeEta = std::max(
                     ((shareLimits.seedingTimeLimit * 60) - finishedTime()), ZERO_ETA);
             etaList.append(seedingTimeEta);
         }
 
+        // 4. Calculate Inactive Seeding Time Limit if active
         if (shareLimits.inactiveSeedingTimeLimit >= 0)
         {
-            const qint64 inactiveSeedingTimeEta = std::max(
+            inactiveSeedingTimeEta = std::max(
                     ((shareLimits.inactiveSeedingTimeLimit * 60) - timeSinceActivity()), ZERO_ETA);
             etaList.append(inactiveSeedingTimeEta);
         }
@@ -1431,9 +1437,27 @@ qlonglong TorrentImpl::eta() const
         if (etaList.isEmpty())
             return MAX_ETA;
 
-        return (shareLimits.mode == ShareLimitsMode::MatchAny)
-                ? std::ranges::min(etaList)
-                : std::ranges::max(etaList);
+        // 5. Evaluate the custom "Smart" MatchAny logic
+        if (shareLimits.mode == ShareLimitsMode::MatchAny)
+        {
+            // Primary constraints: find whichever finishes first (Ratio OR Total Time)
+            qint64 primaryEta = MAX_ETA;
+            if (shareLimits.ratioLimit >= 0)
+                primaryEta = std::min(primaryEta, ratioEta);
+            if (shareLimits.seedingTimeLimit >= 0)
+                primaryEta = std::min(primaryEta, seedingTimeEta);
+
+            // If no primary limits are active, default entirely to the inactive timer
+            if (primaryEta == MAX_ETA)
+                return (shareLimits.inactiveSeedingTimeLimit >= 0) ? inactiveSeedingTimeEta : MAX_ETA;
+
+            // The inactive timer acts as the ultimate gatekeeper (AND logic with the primary winner)
+            qint64 fallbackEta = (shareLimits.inactiveSeedingTimeLimit >= 0) ? inactiveSeedingTimeEta : ZERO_ETA;
+            return std::max(primaryEta, fallbackEta);
+        }
+
+        // MatchAll calculates the maximum remaining time required across all active rules combined
+        return std::ranges::max(etaList);
     }
 
     if (!speedAverage.download)

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1392,15 +1392,10 @@ qlonglong TorrentImpl::eta() const
     if (isFinished())
     {
         const qint64 ZERO_ETA = 0;
+
         const ShareLimits shareLimits = effectiveShareLimits();
         QList<qint64> etaList;
 
-        // 1. Declare variables at the top of the function scope so the logic engine can read them later
-        qint64 ratioEta = ZERO_ETA;
-        qint64 seedingTimeEta = MAX_ETA;
-        qint64 inactiveSeedingTimeEta = MAX_ETA;
-
-        // 2. Calculate Ratio Limit if active
         if (shareLimits.ratioLimit >= 0)
         {
             qint64 realDL = totalDownload();
@@ -1409,6 +1404,7 @@ qlonglong TorrentImpl::eta() const
 
             const qreal uploadLimit = realDL * shareLimits.ratioLimit;
             const qint64 uploaded = totalUpload();
+            qint64 ratioEta = ZERO_ETA;
             if (uploadLimit > uploaded)
             {
                 ratioEta = (speedAverage.upload > 0)
@@ -1418,18 +1414,16 @@ qlonglong TorrentImpl::eta() const
             etaList.append(ratioEta);
         }
 
-        // 3. Calculate Seeding Time Limit if active
         if (shareLimits.seedingTimeLimit >= 0)
         {
-            seedingTimeEta = std::max(
+            const qint64 seedingTimeEta = std::max(
                     ((shareLimits.seedingTimeLimit * 60) - finishedTime()), ZERO_ETA);
             etaList.append(seedingTimeEta);
         }
 
-        // 4. Calculate Inactive Seeding Time Limit if active
         if (shareLimits.inactiveSeedingTimeLimit >= 0)
         {
-            inactiveSeedingTimeEta = std::max(
+            const qint64 inactiveSeedingTimeEta = std::max(
                     ((shareLimits.inactiveSeedingTimeLimit * 60) - timeSinceActivity()), ZERO_ETA);
             etaList.append(inactiveSeedingTimeEta);
         }
@@ -1437,27 +1431,9 @@ qlonglong TorrentImpl::eta() const
         if (etaList.isEmpty())
             return MAX_ETA;
 
-        // 5. Evaluate the custom "Smart" MatchAny logic
-        if (shareLimits.mode == ShareLimitsMode::MatchAny)
-        {
-            // Primary constraints: find whichever finishes first (Ratio OR Total Time)
-            qint64 primaryEta = MAX_ETA;
-            if (shareLimits.ratioLimit >= 0)
-                primaryEta = std::min(primaryEta, ratioEta);
-            if (shareLimits.seedingTimeLimit >= 0)
-                primaryEta = std::min(primaryEta, seedingTimeEta);
-
-            // If no primary limits are active, default entirely to the inactive timer
-            if (primaryEta == MAX_ETA)
-                return (shareLimits.inactiveSeedingTimeLimit >= 0) ? inactiveSeedingTimeEta : MAX_ETA;
-
-            // The inactive timer acts as the ultimate gatekeeper (AND logic with the primary winner)
-            qint64 fallbackEta = (shareLimits.inactiveSeedingTimeLimit >= 0) ? inactiveSeedingTimeEta : ZERO_ETA;
-            return std::max(primaryEta, fallbackEta);
-        }
-
-        // MatchAll calculates the maximum remaining time required across all active rules combined
-        return std::ranges::max(etaList);
+        return (shareLimits.mode == ShareLimitsMode::MatchAny)
+                ? std::ranges::min(etaList)
+                : std::ranges::max(etaList);
     }
 
     if (!speedAverage.download)

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1392,10 +1392,13 @@ qlonglong TorrentImpl::eta() const
     if (isFinished())
     {
         const qint64 ZERO_ETA = 0;
-
         const ShareLimits shareLimits = effectiveShareLimits();
-        QList<qint64> etaList;
 
+        qint64 ratioEta = -1;
+        qint64 seedingTimeEta = -1;
+        qint64 inactiveSeedingTimeEta = -1;
+
+        // 1. Calculate individual ETAs if active
         if (shareLimits.ratioLimit >= 0)
         {
             qint64 realDL = totalDownload();
@@ -1404,36 +1407,79 @@ qlonglong TorrentImpl::eta() const
 
             const qreal uploadLimit = realDL * shareLimits.ratioLimit;
             const qint64 uploaded = totalUpload();
-            qint64 ratioEta = ZERO_ETA;
+            ratioEta = ZERO_ETA;
             if (uploadLimit > uploaded)
             {
                 ratioEta = (speedAverage.upload > 0)
                         ? (uploadLimit - uploaded) / speedAverage.upload
                         : MAX_ETA;
             }
-            etaList.append(ratioEta);
         }
 
         if (shareLimits.seedingTimeLimit >= 0)
         {
-            const qint64 seedingTimeEta = std::max(
+            seedingTimeEta = std::max(
                     ((shareLimits.seedingTimeLimit * 60) - finishedTime()), ZERO_ETA);
-            etaList.append(seedingTimeEta);
         }
 
         if (shareLimits.inactiveSeedingTimeLimit >= 0)
         {
-            const qint64 inactiveSeedingTimeEta = std::max(
+            inactiveSeedingTimeEta = std::max(
                     ((shareLimits.inactiveSeedingTimeLimit * 60) - timeSinceActivity()), ZERO_ETA);
-            etaList.append(inactiveSeedingTimeEta);
         }
 
-        if (etaList.isEmpty())
-            return MAX_ETA;
+        // 2. Resolve final UI ETA based on configuration mode
+        if (shareLimits.mode == ShareLimitsMode::MatchAny)
+        {
+            // Track active primary ETAs
+            QList<qint64> activePrimaryEtas;
+            if (ratioEta >= 0) activePrimaryEtas.append(ratioEta);
+            if (seedingTimeEta >= 0) activePrimaryEtas.append(seedingTimeEta);
 
-        return (shareLimits.mode == ShareLimitsMode::MatchAny)
-                ? std::ranges::min(etaList)
-                : std::ranges::max(etaList);
+            const bool hasPrimaryLimits = !activePrimaryEtas.isEmpty();
+            
+            // Primary goals are satisfied if none are set, or if at least one has reached 0
+            const bool primaryGoalSatisfied = !hasPrimaryLimits 
+                || (ratioEta == ZERO_ETA) 
+                || (seedingTimeEta == ZERO_ETA);
+
+            // Collect valid candidates for MatchAny
+            QList<qint64> validCandidates;
+            
+            // Add primary ETAs that haven't finished yet
+            for (qint64 etaVal : activePrimaryEtas)
+            {
+                if (etaVal > ZERO_ETA)
+                    validCandidates.append(etaVal);
+            }
+
+            // Inactive ETA is only a valid candidate if the primary gate is clear
+            if (primaryGoalSatisfied && (inactiveSeedingTimeEta >= 0))
+                validCandidates.append(inactiveSeedingTimeEta);
+
+            // Fallback options if things are already achieved or empty
+            if (validCandidates.isEmpty())
+            {
+                if (primaryGoalSatisfied && (inactiveSeedingTimeEta >= 0))
+                    return ZERO_ETA;
+                return (!activePrimaryEtas.isEmpty()) ? ZERO_ETA : MAX_ETA;
+            }
+
+            return std::ranges::min(validCandidates);
+        }
+        else
+        {
+            // MatchAll standard behavior
+            QList<qint64> allEtas;
+            if (ratioEta >= 0) allEtas.append(ratioEta);
+            if (seedingTimeEta >= 0) allEtas.append(seedingTimeEta);
+            if (inactiveSeedingTimeEta >= 0) allEtas.append(inactiveSeedingTimeEta);
+
+            if (allEtas.isEmpty())
+                return MAX_ETA;
+
+            return std::ranges::max(allEtas);
+        }
     }
 
     if (!speedAverage.download)


### PR DESCRIPTION
Closes #24500 

Changes MatchAny limits behavior by preventing inactive seeding time from triggering until either ratio or seeding time is met, thereby preventing torrents from timing out too early when inactive seeding time is less than total seeding time. Torrent will continue to seed even if inactive until either ratio or total seeding time are met; once one of these "primary" limits is satisfied, inactive timer can take over.

ETA calculation was likewise adjusted to show ETA until primary limit is met.