### PR TITLE
Resolve relative UI theme paths against config folder

### DIFF
--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -60,7 +60,7 @@ namespace
 
     Path resolveThemePath(const Path &themePath)
     {
-        return (themePath.isAbsolute() ? themePath : (Profile::instance()->rootPath() / themePath));
+        return (themePath.isAbsolute() ? themePath : (Profile::instance()->location(SpecialFolder::Config) / themePath));
     }
 }
 


### PR DESCRIPTION
The #24514 fixed issue #24489 but added an inconsistency. qBittorrent does not store all its files in the `rootPath` (`profile` in portable installation). It has one subdirectory with current internal profile name (that by default is just the name of the app):

<img width="825" height="377" alt="image" src="https://github.com/user-attachments/assets/0d12f311-d070-4d61-b30e-7a641386957e" />

The real config directory is two levels deeper (`profile/qBittorrent/config`), the ini-file that points to the theme file is also stored there. It would be logical to resolve theme path from the config directory. This PR should fix the inconsistency.