### PR TITLE
Fix crash when changing file priorities

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1107,7 +1107,9 @@ Path TorrentImpl::actualFilePath(const int index) const
 
 #if LIBTORRENT_VERSION_NUM >= 20100
     const lt::file_storage &fs = nativeTorrentInfo()->layout();
-    const lt::filenames files {fs, m_nativeStatus.renamed_files};
+    const lt::renamed_files &renamedFiles = m_nativeStatus.torrent_file.expired()
+            ? m_ltAddTorrentParams.renamed_files : m_nativeStatus.renamed_files;
+    const lt::filenames files {fs, renamedFiles};
 #else
     const lt::file_storage &files = nativeTorrentInfo()->files();
 #endif
@@ -1134,7 +1136,9 @@ PathList TorrentImpl::actualFilePaths() const
 
 #if LIBTORRENT_VERSION_NUM >= 20100
     const lt::file_storage &fs = nativeTorrentInfo()->layout();
-    const lt::filenames files {fs, m_nativeStatus.renamed_files};
+    const lt::renamed_files &renamedFiles = m_nativeStatus.torrent_file.expired()
+            ? m_ltAddTorrentParams.renamed_files : m_nativeStatus.renamed_files;
+    const lt::filenames files {fs, renamedFiles};
 #else
     const lt::file_storage &files = nativeTorrentInfo()->files();
 #endif
@@ -1865,9 +1869,11 @@ void TorrentImpl::doRenameFolder(const Path &oldFolderPath, const Path &newFolde
 
 std::shared_ptr<const libtorrent::torrent_info> TorrentImpl::nativeTorrentInfo() const
 {
-    Q_ASSERT(!m_nativeStatus.torrent_file.expired());
+    if (const auto torrentFile = m_nativeStatus.torrent_file.lock())
+        return torrentFile;
 
-    return m_nativeStatus.torrent_file.lock();
+    Q_ASSERT(m_ltAddTorrentParams.ti);
+    return m_ltAddTorrentParams.ti;
 }
 
 void TorrentImpl::endReceivedMetadataHandling(const Path &savePath, const PathList &fileNames)


### PR DESCRIPTION
Related to #24651.

## Problem

A crash occurs when the user changes the file selection of a torrent that was added with the "stop after metadata received" condition.

Stack trace (from #24651):

```
13# BitTorrent::TorrentImpl::manageActualFilePaths()
14# BitTorrent::TorrentImpl::prioritizeFiles(...)
15# TorrentContentModel::setItemPriority(...)
```

## Root cause

When metadata arrives, `endReceivedMetadataHandling()` calls `reload()`, which removes the old libtorrent torrent and re-adds it via `reloadTorrent()`. The new `ExtensionData` is default-constructed, so `m_nativeStatus` is immediately replaced with an empty `lt::torrent_status` — one where `torrent_file` is an expired `weak_ptr` and `renamed_files` is empty.

Both fields are repopulated only when libtorrent delivers the next `state_update_alert`, which happens asynchronously. Because the torrent is immediately stopped after reload, there is no active download to drive that alert quickly. The user sees the content dialog and can interact with it before the alert arrives.

Changing the file selection triggers:

```
TorrentContentModel::setItemPriority()
  → TorrentImpl::prioritizeFiles()
    → TorrentImpl::manageActualFilePaths()
      → TorrentImpl::actualFilePath()
        → TorrentImpl::nativeTorrentInfo()
          → m_nativeStatus.torrent_file.lock()  // returns null
            → null->layout()                    // undefined behavior → crash
```

In release builds, `Q_ASSERT` is a no-op, so the expired `weak_ptr` is silently locked to null. Dereferencing null is undefined behavior that manifests as `std::length_error` thrown from inside `libtorrent::file_storage::file_path()`, as observed in the report.

The same window exists after the other two `reload()` call sites (`TorrentImpl::start()` and `TorrentImpl::handleMoveStorageJobFinished()`), though it is much harder to hit there in practice.

## Fix

`nativeTorrentInfo()` now falls back to `m_ltAddTorrentParams.ti` when `m_nativeStatus.torrent_file` is expired. `m_ltAddTorrentParams.ti` is always valid while `hasMetadata()` is true: it is set in `endReceivedMetadataHandling()` before `reload()` is called, and kept up to date by `prepareResumeData()` thereafter.

The same condition is applied to the `renamed_files` selection in `actualFilePath()` and `actualFilePaths()` (libtorrent2 only). Both `torrent_file` and `renamed_files` come from the same `state_update_alert`, so they are absent together: if `torrent_file` is expired, `renamed_files` is also empty, and the correct data is in `m_ltAddTorrentParams.renamed_files` instead.
