### PR TITLE
GHA CI: Raise libtorrent-2.1 to v2.1.0 (release)

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         libtorrent:
-          - version: "2.1.0-rc2"
+          - version: "2.1.0"
             boost_major_version: "1"
             boost_minor_version: "91"
             boost_patch_version: "0"

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         libtorrent:
-          - version: "2.1.0-rc2"
+          - version: "2.1.0"
             boost_major_version: "1"
             boost_minor_version: "77"
             boost_patch_version: "0"

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         libtorrent:
-          - version: "2.1.0-rc2"
+          - version: "2.1.0"
             boost_major_version: "1"
             boost_minor_version: "91"
             boost_patch_version: "0"


### PR DESCRIPTION
https://github.com/arvidn/libtorrent/releases/tag/v2.1.0