### PR TITLE
Update share limits timer when share limits change 

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1087,6 +1087,7 @@ bool SessionImpl::setCategoryOptions(const QString &categoryName, const Category
 
     currentOptions = options;
     storeCategories();
+    updateShareLimitsTimer();
 
     for (TorrentImpl *const torrent : asConst(m_torrents))
     {
@@ -1265,6 +1266,8 @@ void SessionImpl::setShareLimits(ShareLimits shareLimits)
         m_globalMaxInactiveSeedingMinutes = shareLimits.inactiveSeedingTimeLimit;
         m_shareLimitAction = shareLimits.action;
         m_shareLimitsMode = shareLimits.mode;
+
+        updateShareLimitsTimer();
     }
 }
 
@@ -5300,6 +5303,7 @@ void SessionImpl::handleTorrentSavePathChanged(TorrentImpl *const torrent)
 
 void SessionImpl::handleTorrentCategoryChanged(TorrentImpl *const torrent, const QString &oldCategory)
 {
+    updateShareLimitsTimer();
     emit torrentCategoryChanged(torrent, oldCategory);
 }
 


### PR DESCRIPTION
Share limits are enforced by a periodic timer whose state is managed by `updateShareLimitsTimer()`. Changes to category and global share limits do not always update the timer state. Consequently, enabling a limit while the timer is stopped may leave it unenforced until another event starts the timer, such as restarting qBittorrent or adding a torrent with active effective share limits.

- **Category share limits:** the timer state is not updated when categories are added, edited, or removed. Configured category limits are also only detected indirectly through the effective limits of existing torrents. Reproduction: with no global or per-torrent limits enabled, set a ratio limit on the category of a seeding torrent that has already exceeded it. The torrent continues seeding because the timer remains stopped.

- **Global share limits:** `setShareLimits()` changes the global limits without updating the timer state. Before #24029 each global share limit setter updated the timer; this was lost when they were merged into `setShareLimits()`. Reproduction: with the timer stopped, enable a global ratio limit that a seeding torrent has already exceeded. The torrent continues seeding until another event starts the timer.

This change updates the timer state after global share limits, category options, or a torrent's category change. The first issue also exists in released 5.2.x versions.