### PR TITLE
Properly handle relative path of logs folder

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -477,13 +477,13 @@ void Application::setFileLoggerEnabled(const bool value)
 
 Path Application::fileLoggerPath() const
 {
-    return m_storeFileLoggerPath.get(specialFolderLocation(SpecialFolder::Data) / Path(LOG_FOLDER));
+    return m_storeFileLoggerPath.get(Path(LOG_FOLDER));
 }
 
 void Application::setFileLoggerPath(const Path &path)
 {
     if (m_fileLogger)
-        m_fileLogger->changePath(path);
+        m_fileLogger->setPath(path);
     m_storeFileLoggerPath = path;
 }
 

--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2016  sledgehammer999 <hammered999@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
@@ -37,24 +38,23 @@
 
 #include "base/global.h"
 #include "base/logger.h"
+#include "base/profile.h"
 #include "base/utils/fs.h"
 
-namespace
-{
-    const std::chrono::seconds FLUSH_INTERVAL {2};
-}
+const QString LOG_FILENAME = u"qbittorrent.log"_s;
+const std::chrono::seconds FLUSH_INTERVAL {2};
 
 FileLogger::FileLogger(const Path &path, const bool backup
-                       , const int maxSize, const bool deleteOld, const int age
-                       , const FileLogAgeType ageType)
-    : m_backup(backup)
-    , m_maxSize(maxSize)
+        , const int maxSize, const bool deleteOld, const int age
+        , const FileLogAgeType ageType)
+    : m_backup {backup}
+    , m_maxSize {maxSize}
 {
     m_flusher.setInterval(FLUSH_INTERVAL);
     m_flusher.setSingleShot(true);
     connect(&m_flusher, &QTimer::timeout, this, &FileLogger::flushLog);
 
-    changePath(path);
+    setPath(path);
     if (deleteOld)
         this->deleteOld(age, ageType);
 
@@ -70,26 +70,27 @@ FileLogger::~FileLogger()
     closeLogFile();
 }
 
-void FileLogger::changePath(const Path &newPath)
+void FileLogger::setPath(const Path &newPath)
 {
+    const Path newPathAbs = newPath.isAbsolute() ? newPath : (specialFolderLocation(SpecialFolder::Data) / newPath);
     // compare paths as strings to perform case sensitive comparison on all the platforms
-    if (newPath.data() == m_path.parentPath().data())
+    if (newPathAbs.data() == m_logsFolderPath.data())
         return;
 
     closeLogFile();
 
-    m_path = newPath / Path(u"qbittorrent.log"_s);
-    m_logFile.setFileName(m_path.data());
+    m_logsFolderPath = newPathAbs;
+    m_logFile.setFileName((m_logsFolderPath / Path(LOG_FILENAME)).data());
 
-    Utils::Fs::mkpath(newPath);
+    Utils::Fs::mkpath(m_logsFolderPath);
     openLogFile();
 }
 
 void FileLogger::deleteOld(const int age, const FileLogAgeType ageType)
 {
     const QDateTime date = QDateTime::currentDateTime();
-    const QDir dir {m_path.parentPath().data()};
-    const QFileInfoList fileList = dir.entryInfoList(QStringList(u"qbittorrent.log.bak*"_s)
+    const QDir dir {m_logsFolderPath.data()};
+    const QFileInfoList fileList = dir.entryInfoList(QStringList(LOG_FILENAME + u".bak*")
         , (QDir::Files | QDir::Writable), (QDir::Time | QDir::Reversed));
 
     for (const QFileInfo &file : fileList)
@@ -149,15 +150,16 @@ void FileLogger::addLogMessage(const Log::Msg &msg)
     {
         closeLogFile();
         int counter = 0;
-        Path backupLogFilename = m_path + u".bak";
+        const Path logFilename = m_logsFolderPath / Path(LOG_FILENAME);
+        Path backupLogFilename = logFilename + u".bak";
 
         while (backupLogFilename.exists())
         {
             ++counter;
-            backupLogFilename = m_path + u".bak" + QString::number(counter);
+            backupLogFilename = logFilename + u".bak" + QString::number(counter);
         }
 
-        Utils::Fs::renameFile(m_path, backupLogFilename);
+        Utils::Fs::renameFile(logFilename, backupLogFilename);
         openLogFile();
     }
     else

--- a/src/app/filelogger.h
+++ b/src/app/filelogger.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2016  sledgehammer999 <hammered999@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
@@ -39,7 +40,7 @@ namespace Log
     struct Msg;
 }
 
-class FileLogger : public QObject
+class FileLogger final : public QObject
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(FileLogger)
@@ -53,9 +54,9 @@ public:
     };
 
     FileLogger(const Path &path, bool backup, int maxSize, bool deleteOld, int age, FileLogAgeType ageType);
-    ~FileLogger();
+    ~FileLogger() override;
 
-    void changePath(const Path &newPath);
+    void setPath(const Path &newPath);
     void deleteOld(int age, FileLogAgeType ageType);
     void setBackup(bool value);
     void setMaxSize(int value);
@@ -68,7 +69,7 @@ private:
     void openLogFile();
     void closeLogFile();
 
-    Path m_path;
+    Path m_logsFolderPath;
     bool m_backup;
     int m_maxSize;
     QFile m_logFile;

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2016 Eugene Shalygin
  *
  * This program is free software; you can redistribute it and/or
@@ -39,7 +40,6 @@
 #include <QStyle>
 #include <QToolButton>
 
-#include "base/utils/fs.h"
 #include "fspathedit_p.h"
 
 namespace
@@ -83,7 +83,6 @@ private:
     QToolButton *m_browseBtn = nullptr;
     QString m_fileNameFilter;
     Mode m_mode = FileSystemPathEdit::Mode::FileOpen;
-    Path m_lastSignaledPath;
     QString m_dialogCaption;
     Private::FileSystemPathValidator *m_validator = nullptr;
 };
@@ -115,10 +114,10 @@ void FileSystemPathEdit::FileSystemPathEditPrivate::browseActionTriggered()
 {
     Q_Q(FileSystemPathEdit);
 
-    const Path currentDirectory = (m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::DirectorySave)
-            ? q->selectedPath()
-            : q->selectedPath().parentPath();
-    const Path initialDirectory = currentDirectory.isAbsolute() ? currentDirectory : (Utils::Fs::homePath() / currentDirectory);
+    const Path currentPath = q->getResolvedPath();
+    const Path initialDirectory = (m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::DirectorySave)
+            ? currentPath
+            : currentPath.parentPath();
 
     QString filter = q->fileNameFilter();
     QString newPath;
@@ -203,16 +202,29 @@ FileSystemPathEdit::~FileSystemPathEdit()
 
 Path FileSystemPathEdit::selectedPath() const
 {
-    return Path(editWidgetText());
+    return m_path;
 }
 
-void FileSystemPathEdit::setSelectedPath(const Path &val)
+void FileSystemPathEdit::setSelectedPath(const Path &path)
 {
-    Q_D(FileSystemPathEdit);
+    if (path != m_path)
+        setEditWidgetText(path.toString());
+}
 
-    const QString nativePath = val.toString();
-    setEditWidgetText(nativePath);
-    d->m_editor->widget()->setToolTip(nativePath);
+Path FileSystemPathEdit::basePath() const
+{
+    return m_basePath;
+}
+
+void FileSystemPathEdit::setBasePath(const Path &basePath)
+{
+    if (basePath == m_basePath)
+        return;
+
+    m_basePath = basePath;
+
+    Q_D(FileSystemPathEdit);
+    d->m_editor->widget()->setToolTip(getResolvedPath().toString());
 }
 
 QString FileSystemPathEdit::fileNameFilter() const
@@ -278,14 +290,15 @@ void FileSystemPathEdit::setBriefBrowseButtonCaption(bool brief)
 
 void FileSystemPathEdit::onPathEdited()
 {
-    Q_D(FileSystemPathEdit);
-
-    const Path newPath = selectedPath();
-    if (newPath != d->m_lastSignaledPath)
+    const Path newPath {editWidgetText()};
+    if (newPath != m_path)
     {
-        emit selectedPathChanged(newPath);
-        d->m_lastSignaledPath = newPath;
-        d->m_editor->widget()->setToolTip(editWidgetText());
+        m_path = newPath;
+
+        Q_D(FileSystemPathEdit);
+        d->m_editor->widget()->setToolTip(getResolvedPath().toString());
+
+        emit selectedPathChanged(m_path);
     }
 }
 
@@ -318,6 +331,11 @@ QWidget *FileSystemPathEdit::editWidgetImpl() const
 {
     Q_D(const FileSystemPathEdit);
     return d->m_editor->widget();
+}
+
+Path FileSystemPathEdit::getResolvedPath() const
+{
+    return m_path.isAbsolute() ? m_path : (m_basePath / m_path);
 }
 
 // ------------------------- FileSystemPathLineEdit ----------------------

--- a/src/gui/fspathedit.h
+++ b/src/gui/fspathedit.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2016 Eugene Shalygin
  *
  * This program is free software; you can redistribute it and/or
@@ -72,7 +73,10 @@ public:
     void setMode(Mode mode);
 
     Path selectedPath() const;
-    void setSelectedPath(const Path &val);
+    void setSelectedPath(const Path &path);
+
+    Path basePath() const;
+    void setBasePath(const Path &basePath);
 
     QString fileNameFilter() const;
     void setFileNameFilter(const QString &val);
@@ -111,8 +115,12 @@ private:
     virtual void setEditWidgetText(const QString &text) = 0;
 
     QWidget *editWidgetImpl() const;
+    Path getResolvedPath() const;
 
     FileSystemPathEditPrivate *d_ptr = nullptr;
+
+    Path m_path;
+    Path m_basePath;
 };
 
 /// Widget which uses QLineEdit for path editing

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -54,6 +54,7 @@
 #include "base/net/smtpclient.h"
 #include "base/path.h"
 #include "base/preferences.h"
+#include "base/profile.h"
 #include "base/rss/rss_autodownloader.h"
 #include "base/rss/rss_session.h"
 #include "base/torrentfileguard.h"
@@ -357,6 +358,7 @@ void OptionsDialog::loadBehaviorTabOptions()
     m_ui->textFileLogPath->setDialogCaption(tr("Choose a save directory"));
     m_ui->textFileLogPath->setMode(FileSystemPathEdit::Mode::DirectorySave);
     m_ui->textFileLogPath->setSelectedPath(app()->fileLoggerPath());
+    m_ui->textFileLogPath->setBasePath(specialFolderLocation(SpecialFolder::Data));
     const bool fileLogBackup = app()->isFileLoggerBackup();
     m_ui->checkFileLogBackup->setChecked(fileLogBackup);
     m_ui->spinFileLogSize->setEnabled(fileLogBackup);


### PR DESCRIPTION
* Use relative path for logs folder by default
* Resolve relative path of logs folder against profile data directory
* Show resolved path in PathEdit tooltip

<img width="486" height="139" alt="000" src="https://github.com/user-attachments/assets/f890b253-6053-4595-93de-b329be15bcf6" />


Closes #17321.