### PR TITLE
WebUI: add 'Copy path' action to torrent content menu

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -287,6 +287,7 @@
     <ul id="torrentFilesMenu" class="contextMenu">
         <li><a href="#Rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li><a href="#Download"><img src="images/download.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#CopyPath"><img src="images/edit-copy.svg" alt="QBT_TR(Copy path)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy path)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li><a href="#CopyURL"><img src="images/edit-copy.svg" alt="QBT_TR(Copy URL)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy URL)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li class="separator">
             <a href="#FilePrio" class="arrow-right"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Priority)QBT_TR[CONTEXT=PropertiesWidget]</a>

--- a/src/webui/www/private/scripts/filesystem.js
+++ b/src/webui/www/private/scripts/filesystem.js
@@ -35,6 +35,7 @@ window.qBittorrent.Filesystem ??= (() => {
     const exports = () => {
         return {
             PathSeparator: PathSeparator,
+            ServerPathSeparator: ServerPathSeparator,
             fileExtension: fileExtension,
             fileName: fileName,
             folderName: folderName
@@ -42,6 +43,12 @@ window.qBittorrent.Filesystem ??= (() => {
     };
 
     const PathSeparator = "/";
+
+    /**
+     * The native path separator used on the server
+     */
+    const ServerPathSeparator = (window.qBittorrent?.Cache.buildInfo.get().platform === "windows")
+        ? "\\" : PathSeparator;
 
     /**
      * Returns the file extension part of a file name.

--- a/src/webui/www/private/scripts/torrent-content.js
+++ b/src/webui/www/private/scripts/torrent-content.js
@@ -469,6 +469,27 @@ window.qBittorrent.TorrentContent ??= (() => {
                     const url = getSelectedFileUrl();
                     await window.qBittorrent.Misc.downloadFileStream(url);
                 },
+                CopyPath: async (element, ref) => {
+                    const torrentID = torrentsTable.getCurrentTorrentID();
+                    const torrentRow = torrentsTable.getRow(torrentID);
+                    const savePath = torrentsTable.getRowData(torrentRow, true).save_path;
+
+                    const files = [];
+                    for (const rowID of torrentFilesTable.selectedRowsIds()) {
+                        const names = [];
+                        for (let node = torrentFilesTable.getNode(rowID);; node = node.parent) {
+                            names.push(node.name);
+                            if (node.depth <= 0)
+                                break;
+                        }
+                        names.push(savePath);
+                        names.reverse();
+
+                        files.push(names.join(window.qBittorrent.Filesystem.ServerPathSeparator));
+                    }
+
+                    await clipboardCopy(files.join("\n"));
+                },
                 CopyURL: async (element, ref) => {
                     const url = getSelectedFileUrl();
                     await clipboardCopy(url);


### PR DESCRIPTION
Supersedes #23934.

Screenshot:
<img width="119" height="87" alt="screenshot" src="https://github.com/user-attachments/assets/747e4cdc-e8ae-4c67-8b81-92e307dc5596" />
