### PR TITLE
Fix redefined signal

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -270,7 +270,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
         });
         dlg->open();
     });
-    connect(m_filterLine, &LineEdit::textChanged, this, &AddNewTorrentDialog::setContentFilterPattern);
+    connect(m_filterLine, &LineEdit::textUpdated, this, &AddNewTorrentDialog::setContentFilterPattern);
     connect(m_ui->buttonSelectAll, &QPushButton::clicked, m_ui->contentTreeView, &TorrentContentWidget::checkAll);
     connect(m_ui->buttonSelectNone, &QPushButton::clicked, m_ui->contentTreeView, &TorrentContentWidget::checkNone);
     connect(Preferences::instance(), &Preferences::changed, this, []

--- a/src/gui/lineedit.cpp
+++ b/src/gui/lineedit.cpp
@@ -65,7 +65,7 @@ LineEdit::LineEdit(QWidget *parent)
     m_delayedTextChangedTimer->setSingleShot(true);
     connect(m_delayedTextChangedTimer, &QTimer::timeout, this, [this]
     {
-        emit textChanged(text());
+        emit textUpdated(text());
     });
     connect(this, &QLineEdit::textChanged, this, [this]
     {

--- a/src/gui/lineedit.h
+++ b/src/gui/lineedit.h
@@ -43,7 +43,7 @@ public:
     explicit LineEdit(QWidget *parent = nullptr);
 
 signals:
-    void textChanged(const QString &text);
+    void textUpdated(const QString &text);
 
 private:
     void keyPressEvent(QKeyEvent *event) override;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -289,7 +289,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
         m_columnFilterComboBox->addItem(typeName, type);
     }
     connect(m_columnFilterComboBox, &QComboBox::currentIndexChanged, this, &MainWindow::applyTransferListFilter);
-    connect(m_columnFilterEdit, &LineEdit::textChanged, this, &MainWindow::applyTransferListFilter);
+    connect(m_columnFilterEdit, &LineEdit::textUpdated, this, &MainWindow::applyTransferListFilter);
     connect(hSplitter, &QSplitter::splitterMoved, this, &MainWindow::saveSettings);
     connect(m_splitter, &QSplitter::splitterMoved, this, &MainWindow::saveSplitterSettings);
 

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -83,7 +83,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     m_contentFilterLine->setFixedWidth(300);
     m_contentFilterLine->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_contentFilterLine, &QWidget::customContextMenuRequested, this, &PropertiesWidget::showContentFilterContextMenu);
-    connect(m_contentFilterLine, &LineEdit::textChanged, this, &PropertiesWidget::setContentFilterPattern);
+    connect(m_contentFilterLine, &LineEdit::textUpdated, this, &PropertiesWidget::setContentFilterPattern);
     m_ui->contentFilterLayout->insertWidget(3, m_contentFilterLine);
 
     m_ui->filesList->setContentDragAllowed(true);

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -169,7 +169,7 @@ SearchJobWidget::SearchJobWidget(const QString &id, IGUIApplication *app, QWidge
     m_lineEditSearchResultsFilter->setPlaceholderText(tr("Filter search results..."));
     m_lineEditSearchResultsFilter->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_lineEditSearchResultsFilter, &QWidget::customContextMenuRequested, this, &SearchJobWidget::showFilterContextMenu);
-    connect(m_lineEditSearchResultsFilter, &LineEdit::textChanged, this, &SearchJobWidget::filterSearchResults);
+    connect(m_lineEditSearchResultsFilter, &LineEdit::textUpdated, this, &SearchJobWidget::filterSearchResults);
     m_ui->horizontalLayout->insertWidget(0, m_lineEditSearchResultsFilter);
 
     connect(m_ui->filterMode, qOverload<int>(&QComboBox::currentIndexChanged), this, &SearchJobWidget::updateNameFilter);


### PR DESCRIPTION
Rename `LineEdit::textChanged` signal in order to not redefine `QLineEdit::textChanged` signal. Otherwise there is warning shown in the terminal at runtime:
>QMetaObject::indexOfSignal: signal textChanged(QString) from QLineEdit redefined in LineEdit