### PR TITLE
Allow to edit common path of torrent content items

### DIFF
--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -30,6 +30,7 @@
 #include "path.h"
 
 #include <algorithm>
+#include <ranges>
 
 #include <QDataStream>
 #include <QDir>
@@ -310,6 +311,22 @@ Path Path::commonPath(const Path &left, const Path &right)
         commonPathSize += (commonItemsCount - 1); // size of intermediate separators
 
     return Path::createUnchecked(left.m_pathStr.first(commonPathSize));
+}
+
+Path Path::commonPath(const PathList &filePaths)
+{
+    if (filePaths.isEmpty())
+        return {};
+
+    Path commonPath = filePaths.at(0);
+    for (const Path &filePath : std::views::drop(filePaths, 1))
+    {
+        commonPath = Path::commonPath(commonPath, filePath);
+        if (commonPath.isEmpty())
+            return commonPath;
+    }
+
+    return commonPath;
 }
 
 Path Path::findRootFolder(const PathList &filePaths)

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -82,6 +82,7 @@ public:
     Iterator end() const;
 
     static Path commonPath(const Path &left, const Path &right);
+    static Path commonPath(const PathList &filePaths);
 
     static Path findRootFolder(const PathList &filePaths);
     static void stripRootFolder(PathList &filePaths);

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006-2012  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -56,6 +56,11 @@ TorrentContentModelItem::ItemType TorrentContentFilterModel::itemType(const QMod
 int TorrentContentFilterModel::getFileIndex(const QModelIndex &index) const
 {
     return m_model->getFileIndex(mapToSource(index));
+}
+
+QSet<int> TorrentContentFilterModel::getFileIndexes(const QModelIndex &itemIndex) const
+{
+    return m_model->getFileIndexes(mapToSource(itemIndex));
 }
 
 QModelIndex TorrentContentFilterModel::parent(const QModelIndex &child) const

--- a/src/gui/torrentcontentfiltermodel.h
+++ b/src/gui/torrentcontentfiltermodel.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006-2012  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QtContainerFwd>
 #include <QSortFilterProxyModel>
 
 #include "base/utils/compare.h"
@@ -47,6 +48,7 @@ public:
     void setSourceModel(TorrentContentModel *model);
     TorrentContentModelItem::ItemType itemType(const QModelIndex &index) const;
     int getFileIndex(const QModelIndex &index) const;
+    QSet<int> getFileIndexes(const QModelIndex &itemIndex) const;
     QModelIndex parent(const QModelIndex &child) const override;
 
 private:

--- a/src/gui/torrentcontentlayoutdialog.cpp
+++ b/src/gui/torrentcontentlayoutdialog.cpp
@@ -62,6 +62,11 @@ public:
 };
 
 TorrentContentLayoutDialog::TorrentContentLayoutDialog(BitTorrent::TorrentContentHandler *contentHandler, QWidget *parent)
+    : TorrentContentLayoutDialog(contentHandler, {}, parent)
+{
+}
+
+TorrentContentLayoutDialog::TorrentContentLayoutDialog(BitTorrent::TorrentContentHandler *contentHandler, const QSet<int> &selectedIndexes, QWidget *parent)
     : QDialog(parent)
     , m_ui {new Ui::TorrentContentLayoutDialog}
     , m_storeDialogSize {SETTINGS_KEY(u"Size"_s)}
@@ -80,12 +85,26 @@ TorrentContentLayoutDialog::TorrentContentLayoutDialog(BitTorrent::TorrentConten
     setWindowIcon(UIThemeManager::instance()->getIcon(u"edit-rename"_s));
 
     m_model = new TorrentContentLayoutModel(contentHandler, this);
-    m_ui->treeView->setModel(m_model);
+    m_ui->pathListView->setModel(m_model);
     if (m_model->rowCount() > 0)
     {
-        m_ui->treeView->selectionModel()->setCurrentIndex(m_model->index(0, 0)
-                , (QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
+        if (!selectedIndexes.isEmpty())
+        {
+            for (const int fileIndex : selectedIndexes)
+            {
+                const QModelIndex itemIndex = m_model->index(fileIndex, 0);
+                m_ui->pathListView->selectionModel()->select(itemIndex
+                        , (QItemSelectionModel::Select | QItemSelectionModel::Rows));
+            }
+        }
+        else
+        {
+            m_ui->pathListView->selectionModel()->setCurrentIndex(m_model->index(0, 0)
+                    , (QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
+        }
     }
+
+    populateCommonPath();
 
     connect(m_model, &QAbstractItemModel::dataChanged, this, [this]
     {
@@ -105,19 +124,71 @@ TorrentContentLayoutDialog::TorrentContentLayoutDialog(BitTorrent::TorrentConten
         RaisedMessageBox::warning(this, tr("Rename error"), errorMessage, QMessageBox::Ok);
     });
 
-    m_ui->treeView->setItemDelegate(new TorrentContentLayoutItemDelegate(this));
+    m_ui->pathListView->setItemDelegate(new TorrentContentLayoutItemDelegate(this));
+
+    connect(m_ui->pathListView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &TorrentContentLayoutDialog::populateCommonPath);
+    connect(m_ui->commonPathEdit, &QLineEdit::textEdited, this, &TorrentContentLayoutDialog::onCommonPathEdited);
 
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
         resize(dialogSize);
 
-    m_ui->treeView->header()->restoreState(m_storeViewState);
+    m_ui->pathListView->header()->restoreState(m_storeViewState);
 }
 
 TorrentContentLayoutDialog::~TorrentContentLayoutDialog()
 {
     m_storeDialogSize = size();
-    m_storeViewState = m_ui->treeView->header()->saveState();
+    m_storeViewState = m_ui->pathListView->header()->saveState();
     delete m_ui;
+}
+
+PathList TorrentContentLayoutDialog::selectedPaths() const
+{
+    const QModelIndexList selectedRows = m_ui->pathListView->selectionModel()->selectedRows(TorrentContentLayoutModel::COL_PATH);
+    if (selectedRows.isEmpty())
+        return {};
+
+    PathList selectedPaths;
+    selectedPaths.reserve(selectedRows.size());
+    for (const QModelIndex &rowIndex : selectedRows)
+        selectedPaths.append(Path(rowIndex.data().toString()));
+
+    return selectedPaths;
+}
+
+void TorrentContentLayoutDialog::populateCommonPath()
+{
+    if (const PathList paths = selectedPaths(); !paths.isEmpty())
+    {
+        m_commonPath = Path::commonPath(paths);
+        m_ui->commonPathEdit->setText(m_commonPath.toString());
+        m_ui->commonPathLabel->setEnabled(true);
+        m_ui->commonPathEdit->setEnabled(true);
+    }
+    else
+    {
+        m_commonPath = {};
+        m_ui->commonPathEdit->clear();
+        m_ui->commonPathLabel->setEnabled(false);
+        m_ui->commonPathEdit->setEnabled(false);
+    }
+}
+
+void TorrentContentLayoutDialog::onCommonPathEdited(const QString &pathStr)
+{
+    const Path oldCommonPath = m_commonPath;
+    m_commonPath = Path(pathStr);
+
+    const QModelIndexList selectedRows = m_ui->pathListView->selectionModel()->selectedRows(TorrentContentLayoutModel::COL_PATH);
+    if (selectedRows.isEmpty())
+        return;
+
+    for (const QModelIndex &rowIndex : selectedRows)
+    {
+        const Path oldPath {rowIndex.data().toString()};
+        const Path newPath = m_commonPath / oldCommonPath.relativePathOf(oldPath);
+        m_model->setData(rowIndex, newPath.toString());
+    }
 }
 
 void TorrentContentLayoutDialog::apply()

--- a/src/gui/torrentcontentlayoutdialog.h
+++ b/src/gui/torrentcontentlayoutdialog.h
@@ -28,8 +28,10 @@
 
 #pragma once
 
+#include <QtContainerFwd>
 #include <QDialog>
 
+#include "base/path.h"
 #include "base/settingvalue.h"
 
 class TorrentContentLayoutModel;
@@ -51,9 +53,13 @@ class TorrentContentLayoutDialog final : public QDialog
 
 public:
     explicit TorrentContentLayoutDialog(BitTorrent::TorrentContentHandler *contentHandler, QWidget *parent = nullptr);
-    ~TorrentContentLayoutDialog();
+    TorrentContentLayoutDialog(BitTorrent::TorrentContentHandler *contentHandler, const QSet<int> &selectedIndexes, QWidget *parent = nullptr);
+    ~TorrentContentLayoutDialog() override;
 
 private:
+    PathList selectedPaths() const;
+    void populateCommonPath();
+    void onCommonPathEdited(const QString &pathStr);
     void apply();
 
     Ui::TorrentContentLayoutDialog *m_ui = nullptr;
@@ -62,4 +68,6 @@ private:
 
     SettingValue<QSize> m_storeDialogSize;
     SettingValue<QByteArray> m_storeViewState;
+
+    Path m_commonPath;
 };

--- a/src/gui/torrentcontentlayoutdialog.ui
+++ b/src/gui/torrentcontentlayoutdialog.ui
@@ -13,21 +13,31 @@
   <property name="windowTitle">
    <string>Manage Torrent Content</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="dialogLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <widget class="QTreeView" name="pathListView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditTrigger::AllEditTriggers</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="commonPathLayout">
      <item>
-      <widget class="QTreeView" name="treeView">
-       <property name="editTriggers">
-        <set>QAbstractItemView::EditTrigger::AllEditTriggers</set>
-       </property>
-       <property name="alternatingRowColors">
-        <bool>true</bool>
-       </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+      <widget class="QLabel" name="commonPathLabel">
+       <property name="text">
+        <string>Common path:</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="commonPathEdit"/>
      </item>
     </layout>
    </item>

--- a/src/gui/torrentcontentlayoutmodel.h
+++ b/src/gui/torrentcontentlayoutmodel.h
@@ -69,7 +69,7 @@ public:
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
     bool haveChangedFilePaths() const;
     void applyChangedFilePaths();

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -38,6 +38,7 @@
 #include <QMimeData>
 #include <QPointer>
 #include <QScopeGuard>
+#include <QSet>
 #include <QUrl>
 
 #if defined(Q_OS_MACOS)
@@ -360,6 +361,23 @@ int TorrentContentModel::getFileIndex(const QModelIndex &index) const
         return static_cast<TorrentContentModelFile *>(item)->fileIndex();
 
     return -1;
+}
+
+QSet<int> TorrentContentModel::getFileIndexes(const QModelIndex &itemIndex) const
+{
+    const auto *item = static_cast<TorrentContentModelItem *>(itemIndex.internalPointer());
+    if (item->itemType() == TorrentContentModelItem::FileType)
+        return {static_cast<const TorrentContentModelFile *>(item)->fileIndex()};
+
+    QSet<int> fileIndexes;
+    const int numRows = rowCount(itemIndex);
+    for (int row = 0; row < numRows; ++row)
+    {
+        const QModelIndex childIndex = index(row, itemIndex.column(), itemIndex);
+        fileIndexes.unite(getFileIndexes(childIndex));
+    }
+
+    return fileIndexes;
 }
 
 Path TorrentContentModel::getItemPath(const QModelIndex &index) const
@@ -706,6 +724,7 @@ void TorrentContentModel::onFileRenamed(const int fileIndex, const Path &oldFile
     const int fileItemRow = fileItem->row();
     beginRemoveRows(index(parentFolderItem), fileItemRow, fileItemRow);
     parentFolderItem->removeChild(fileItem);
+    parentFolderItem->updatePriority();
     m_itemByPath.remove(oldFilePath);
     endRemoveRows();
 
@@ -719,6 +738,7 @@ void TorrentContentModel::onFileRenamed(const int fileIndex, const Path &oldFile
     const int row = newParentFolderItem->childCount();
     beginInsertRows(index(newParentFolderItem), row, row);
     newParentFolderItem->appendChild(fileItem);
+    newParentFolderItem->updatePriority();
     m_itemByPath.insert(newFilePath, fileItem);
     endInsertRows();
 }
@@ -740,6 +760,7 @@ void TorrentContentModel::onFolderRenamed(const Path &newFolderPath, const Path 
     const int folderItemRow = folderItem->row();
     beginRemoveRows(index(parentFolderItem), folderItemRow, folderItemRow);
     parentFolderItem->removeChild(folderItem);
+    parentFolderItem->updatePriority();
     m_itemByPath.remove(oldFolderPath);
     endRemoveRows();
 
@@ -753,6 +774,7 @@ void TorrentContentModel::onFolderRenamed(const Path &newFolderPath, const Path 
     const int row = newParentFolderItem->childCount();
     beginInsertRows(index(newParentFolderItem), row, row);
     newParentFolderItem->appendChild(folderItem);
+    newParentFolderItem->updatePriority();
     m_itemByPath.insert(newFolderPath, folderItem);
     endInsertRows();
 }

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QtContainerFwd>
 #include <QAbstractItemModel>
 #include <QList>
 
@@ -70,6 +71,7 @@ public:
     QList<BitTorrent::DownloadPriority> getFilePriorities() const;
     TorrentContentModelItem::ItemType itemType(const QModelIndex &index) const;
     int getFileIndex(const QModelIndex &index) const;
+    QSet<int> getFileIndexes(const QModelIndex &itemIndex) const;
     Path getItemPath(const QModelIndex &index) const;
 
     int columnCount(const QModelIndex &parent = {}) const override;

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -110,7 +110,8 @@ void TorrentContentModelFolder::updatePriority()
     if (isRootItem())
         return;
 
-    Q_ASSERT(!m_childItems.isEmpty());
+    if (m_childItems.isEmpty())
+        return;
 
     // If all children have the same priority
     // then the folder should have the same

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -38,6 +38,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QModelIndexList>
+#include <QSet>
 #include <QShortcut>
 #include <QWheelEvent>
 
@@ -295,7 +296,12 @@ void TorrentContentWidget::renameSelectedFile()
 
 void TorrentContentWidget::batchRenameFiles()
 {
-    auto *dialog = new TorrentContentLayoutDialog(m_model->contentHandler(), this);
+    const QModelIndexList selectedRows = selectionModel()->selectedRows();
+    QSet<int> fileIndexes;
+    for (const QModelIndex &rowIndex : selectedRows)
+        fileIndexes.unite(m_filterModel->getFileIndexes(rowIndex));
+
+    auto *dialog = new TorrentContentLayoutDialog(m_model->contentHandler(), fileIndexes, this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(m_model->contentHandler(), &QObject::destroyed, dialog, &QDialog::reject);
     dialog->open();
@@ -438,52 +444,31 @@ void TorrentContentWidget::displayContextMenu()
         }
         menu->addAction(UIThemeManager::instance()->getIcon(u"edit-rename"_s), tr("Rename...")
                 , this, &TorrentContentWidget::renameSelectedFile);
-        menu->addAction(UIThemeManager::instance()->getIcon(u"edit-rename"_s), tr("Batch rename...")
-                , this, &TorrentContentWidget::batchRenameFiles);
-        menu->addSeparator();
-
-        QMenu *subMenu = menu->addMenu(tr("Priority"));
-
-        subMenu->addAction(tr("Do not download"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Ignored);
-        });
-        subMenu->addAction(tr("Normal"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Normal);
-        });
-        subMenu->addAction(tr("High"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::High);
-        });
-        subMenu->addAction(tr("Maximum"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Maximum);
-        });
-        subMenu->addSeparator();
-        subMenu->addAction(tr("By shown file order"), this, &TorrentContentWidget::applyPrioritiesByOrder);
     }
-    else
+
+    menu->addAction(UIThemeManager::instance()->getIcon(u"edit-rename"_s), tr("Batch rename...")
+            , this, &TorrentContentWidget::batchRenameFiles);
+    menu->addSeparator();
+
+    QMenu *subMenu = menu->addMenu(tr("Priority"));
+    subMenu->addAction(tr("Do not download"), this, [this]
     {
-        menu->addAction(tr("Do not download"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Ignored);
-        });
-        menu->addAction(tr("Normal priority"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Normal);
-        });
-        menu->addAction(tr("High priority"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::High);
-        });
-        menu->addAction(tr("Maximum priority"), this, [this]
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Maximum);
-        });
-        menu->addSeparator();
-        menu->addAction(tr("Priority by shown file order"), this, &TorrentContentWidget::applyPrioritiesByOrder);
-    }
+        applyPriorities(BitTorrent::DownloadPriority::Ignored);
+    });
+    subMenu->addAction(tr("Normal"), this, [this]
+    {
+        applyPriorities(BitTorrent::DownloadPriority::Normal);
+    });
+    subMenu->addAction(tr("High"), this, [this]
+    {
+        applyPriorities(BitTorrent::DownloadPriority::High);
+    });
+    subMenu->addAction(tr("Maximum"), this, [this]
+    {
+        applyPriorities(BitTorrent::DownloadPriority::Maximum);
+    });
+    subMenu->addSeparator();
+    subMenu->addAction(tr("By shown file order"), this, &TorrentContentWidget::applyPrioritiesByOrder);
 
     // The selected torrent might have disappeared during exec()
     // so we just close menu when an appropriate model is reset


### PR DESCRIPTION
So now it's quite simple to do batch renames (like, for example, add a new subfolder, rename or delete some).

<img width="556" height="328" alt="000" src="https://github.com/user-attachments/assets/8c6718f6-2ddf-4d54-a5eb-370ddd22c5f5" />