### PR TITLE
WebUI: Handle non-torrent RSS link

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -2231,6 +2231,11 @@ void TorrentsController::fetchMetadataAction()
     // http(s) url
     else if (Net::DownloadManager::hasSupportedScheme(source))
     {
+        if (m_invalidTorrentSource.contains(source))
+        {
+            throw APIError(APIErrorType::BadData, tr("'%1' is not a valid torrent file.").arg(source));
+        }
+
         if (!m_requestedTorrentSource.contains(source))
         {
             if (!downloaderParam.isEmpty())
@@ -2444,10 +2449,12 @@ void TorrentsController::cacheTorrentFile(const QString &source, const QByteArra
         const BitTorrent::InfoHash infoHash = torrentDescr.infoHash();
         m_torrentSourceCache.insert(source, infoHash);
         m_torrentMetadataCache.insert(infoHash.toTorrentID(), torrentDescr);
+        m_invalidTorrentSource.remove(source);
     }
     else
     {
         LogMsg(tr("Parse torrent failed. URL: \"%1\". Error: \"%2\".").arg(source, loadResult.error()), Log::WARNING);
+        m_invalidTorrentSource.insert(source);
         m_torrentSourceCache.remove(source);
     }
 }

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -130,4 +130,5 @@ private:
     QHash<QString, BitTorrent::InfoHash> m_torrentSourceCache;
     QHash<BitTorrent::TorrentID, BitTorrent::TorrentDescriptor> m_torrentMetadataCache;
     QSet<QString> m_requestedTorrentSource;
+    QSet<QString> m_invalidTorrentSource;
 };

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -278,9 +278,8 @@ window.qBittorrent.AddTorrent ??= (() => {
             .then(async (response) => {
                 if (!response.ok) {
                     metadataFailed();
-                    if (response.status === 415) {
+                    if (response.status === 415)
                         alert(await response.text());
-                    }
                     return;
                 }
 

--- a/src/webui/www/private/scripts/addtorrent.js
+++ b/src/webui/www/private/scripts/addtorrent.js
@@ -278,6 +278,9 @@ window.qBittorrent.AddTorrent ??= (() => {
             .then(async (response) => {
                 if (!response.ok) {
                     metadataFailed();
+                    if (response.status === 415) {
+                        alert(await response.text());
+                    }
                     return;
                 }
 


### PR DESCRIPTION
Related issue: #24685

Handle case when attempting to add a invalid torrent from a RSS link via WebUI.

A user can add a RSS url that doesn't contain valid torrent links, for example: https://fosstorrents.com/feed/rss.xml

The desktop can handle it properly by prompting an alert:

<img width="455" height="104" alt="image" src="https://github.com/user-attachments/assets/6cae8cbe-41fb-4d64-a3e2-20b4c2d6e0cf" />


The WebUI cannot handle the error and will constantly call `fetchMetadata` api for the given url until the add torrent dialog is closed.

The Add Torrent Dialog will also keep saying `Retrieving Metadata...` giving the user false hope since it will NEVER resolve since the url is not a valid torrent. At the same time, the backend will continuously download the file, keep on failing and will keep logging this error on the Logs tab:

https://github.com/qbittorrent/qBittorrent/blob/52d3a960a95627d980b0dadaa4d33dd7fb59cf68/src/webui/api/torrentscontroller.cpp#L2450

This PR keeps a cache of invalid URL and would alert the user if the RSS link they are trying to download is invalid. Also pops and alert saying that url is not a valid torrent file