### PR TITLE
Add RSS Downloader toolbar button

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -90,6 +90,7 @@
 #include "properties/peerlistwidget.h"
 #include "properties/propertieswidget.h"
 #include "properties/proptabbar.h"
+#include "rss/automatedrssdownloader.h"
 #include "rss/rsswidget.h"
 #include "search/searchwidget.h"
 #include "speedlimitdialog.h"
@@ -188,6 +189,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
     m_ui->actionDonateMoney->setIcon(UIThemeManager::instance()->getIcon(u"wallet-open"_s));
     m_ui->actionExit->setIcon(UIThemeManager::instance()->getIcon(u"application-exit"_s));
     m_ui->actionLock->setIcon(UIThemeManager::instance()->getIcon(u"object-locked"_s));
+    m_ui->actionRSSDownloader->setIcon(UIThemeManager::instance()->getIcon(u"application-rss"_s));
     m_ui->actionOptions->setIcon(UIThemeManager::instance()->getIcon(u"configure"_s, u"preferences-system"_s));
     m_ui->actionStart->setIcon(UIThemeManager::instance()->getIcon(u"torrent-start"_s, u"media-playback-start"_s));
     m_ui->actionStop->setIcon(UIThemeManager::instance()->getIcon(u"torrent-stop"_s, u"media-playback-pause"_s));
@@ -1125,6 +1127,13 @@ void MainWindow::on_actionAbout_triggered()
         m_aboutDlg->setAttribute(Qt::WA_DeleteOnClose);
         m_aboutDlg->show();
     }
+}
+
+void MainWindow::on_actionRSSDownloader_triggered()
+{
+    auto *downloader = new AutomatedRssDownloader(this);
+    downloader->setAttribute(Qt::WA_DeleteOnClose);
+    downloader->open();
 }
 
 void MainWindow::on_actionStatistics_triggered()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -165,6 +165,7 @@ private slots:
     void on_actionAutoShutdown_toggled(bool);
     void on_actionAutoReboot_toggled(bool);
     void on_actionAbout_triggered();
+    void on_actionRSSDownloader_triggered();
     void on_actionStatistics_triggered();
     void on_actionCreateTorrent_triggered();
     void on_actionOptions_triggered();

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -81,6 +81,7 @@
     </widget>
     <addaction name="actionCreateTorrent"/>
     <addaction name="separator"/>
+    <addaction name="actionRSSDownloader"/>
     <addaction name="actionManageCookies"/>
     <addaction name="actionOptions"/>
     <addaction name="separator"/>
@@ -172,6 +173,7 @@
    <addaction name="separator"/>
    <addaction name="actionCreateTorrent"/>
    <addaction name="separator"/>
+   <addaction name="actionRSSDownloader"/>
    <addaction name="actionOptions"/>
    <addaction name="actionLock"/>
   </widget>
@@ -513,6 +515,11 @@
    </property>
    <property name="toolTip">
     <string>Manage installed plugins</string>
+   </property>
+  </action>
+  <action name="actionRSSDownloader">
+   <property name="text">
+    <string>RSS Downloader</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Closes #24625

Adds quick access to the RSS Downloader:
- Menu entry `Service → RSS Downloader` — shortcut is attached here, making it configurable through the existing shortcut system
- Toolbar button in the main window

<img width="914" height="592" alt="изображение" src="https://github.com/user-attachments/assets/60592754-235c-4884-b238-4a6180c66502" />

<img width="914" height="591" alt="изображение" src="https://github.com/user-attachments/assets/763318be-71d5-451b-ac74-3e0ab2901430" />
