### PR TITLE
Construct WebAPI controller instances on demand

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -889,20 +889,30 @@ void WebApplication::sessionStartImpl(const QString &sessionId, const WebSession
     m_sessions[m_currentSession->id()] = m_currentSession;
     m_sessionStateChange = SessionStateChange::Start;
 
-    m_currentSession->registerAPIController(u"app"_s, new AppController(app(), m_currentSession));
-    m_currentSession->registerAPIController(u"clientdata"_s, new ClientDataController(m_clientDataStorage, app(), m_currentSession));
-    m_currentSession->registerAPIController(u"log"_s, new LogController(app(), m_currentSession));
-    m_currentSession->registerAPIController(u"torrentcreator"_s, new TorrentCreatorController(m_torrentCreationManager, app(), m_currentSession));
-    m_currentSession->registerAPIController(u"rss"_s, new RSSController(app(), m_currentSession));
-    m_currentSession->registerAPIController(u"search"_s, new SearchController(app(), m_currentSession));
-    m_currentSession->registerAPIController(u"torrents"_s, new TorrentsController(app(), m_currentSession));
-    m_currentSession->registerAPIController(u"transfer"_s, new TransferController(app(), m_currentSession));
-
-    const auto *btSession = BitTorrent::Session::instance();
-    auto *syncController = new SyncController(app(), m_currentSession);
-    syncController->updateFreeDiskSpace(btSession->freeDiskSpace());
-    connect(btSession, &BitTorrent::Session::freeDiskSpaceChecked, syncController, &SyncController::updateFreeDiskSpace);
-    m_currentSession->registerAPIController(u"sync"_s, syncController);
+    m_currentSession->registerAPIController(u"app"_s, [app = app(), parent = m_currentSession] { return new AppController(app, parent); });
+    m_currentSession->registerAPIController(u"log"_s, [app = app(), parent = m_currentSession] { return new LogController(app, parent); });
+    m_currentSession->registerAPIController(u"rss"_s, [app = app(), parent = m_currentSession] { return new RSSController(app, parent); });
+    m_currentSession->registerAPIController(u"search"_s, [app = app(), parent = m_currentSession] { return new SearchController(app, parent); });
+    m_currentSession->registerAPIController(u"torrents"_s, [app = app(), parent = m_currentSession] { return new TorrentsController(app, parent); });
+    m_currentSession->registerAPIController(u"transfer"_s, [app = app(), parent = m_currentSession] { return new TransferController(app, parent); });
+    m_currentSession->registerAPIController(u"clientdata"_s
+            , [app = app(), parent = m_currentSession, clientDataStorage = m_clientDataStorage]
+    {
+        return new ClientDataController(clientDataStorage, app, parent);
+    });
+    m_currentSession->registerAPIController(u"torrentcreator"_s
+            , [app = app(), parent = m_currentSession, torrentCreationManager = m_torrentCreationManager]
+    {
+        return new TorrentCreatorController(torrentCreationManager, app, parent);
+    });
+    m_currentSession->registerAPIController(u"sync"_s
+            , [app = app(), parent = m_currentSession, btSession = BitTorrent::Session::instance()]
+    {
+        auto *syncController = new SyncController(app, parent);
+        syncController->updateFreeDiskSpace(btSession->freeDiskSpace());
+        connect(btSession, &BitTorrent::Session::freeDiskSpaceChecked, syncController, &SyncController::updateFreeDiskSpace);
+        return syncController;
+    });
 }
 
 void WebApplication::sessionEnd()

--- a/src/webui/websession.cpp
+++ b/src/webui/websession.cpp
@@ -66,15 +66,22 @@ void WebSession::updateTimestamp()
     m_timestamp.start();
 }
 
-void WebSession::registerAPIController(const QString &scope, APIController *controller)
+void WebSession::registerAPIController(const QString &scope, CreateAPIControllerFunc createAPIController)
 {
-    Q_ASSERT(controller);
-    m_apiControllers[scope] = controller;
+    Q_ASSERT(createAPIController);
+    m_apiControllers.insert(scope, {.create = std::move(createAPIController), .instance = nullptr});
 }
 
 APIController *WebSession::getAPIController(const QString &scope) const
 {
-    return m_apiControllers.value(scope);
+    const auto iter = m_apiControllers.find(scope);
+    if (iter == m_apiControllers.end())
+        return nullptr;
+
+    if (!iter->instance)
+        iter->instance = std::invoke(iter->create);
+
+    return iter->instance;
 }
 
 WebSessionType CookieBasedWebSession::type() const

--- a/src/webui/websession.h
+++ b/src/webui/websession.h
@@ -76,7 +76,7 @@ private:
     struct APIControllerEntry
     {
         CreateAPIControllerFunc create;
-        APIController *instance;
+        APIController *instance = nullptr;
     };
 
     const QString m_sid;

--- a/src/webui/websession.h
+++ b/src/webui/websession.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 
 #include <QDeadlineTimer>
 #include <QElapsedTimer>
@@ -42,6 +43,7 @@
 using namespace std::chrono_literals;
 
 class APIController;
+using CreateAPIControllerFunc = std::function<APIController *()>;
 
 enum class WebSessionType : qint8
 {
@@ -67,13 +69,19 @@ public:
     QElapsedTimer timestamp() const;
     void updateTimestamp();
 
-    void registerAPIController(const QString &scope, APIController *controller);
+    void registerAPIController(const QString &scope, CreateAPIControllerFunc createAPIController);
     APIController *getAPIController(const QString &scope) const;
 
 private:
+    struct APIControllerEntry
+    {
+        CreateAPIControllerFunc create;
+        APIController *instance;
+    };
+
     const QString m_sid;
     QElapsedTimer m_timestamp;
-    QMap<QString, APIController *> m_apiControllers;
+    mutable QMap<QString, APIControllerEntry> m_apiControllers;
 };
 
 class CookieBasedWebSession final : public WebSession


### PR DESCRIPTION
This is one of the fixes related to #24695.
There is a chance that some controllers will never be used (i.e. requested by client) within the session so we now construct WebAPI controller instance only when it is requested for the first time.