### PR TITLE
Update `expected-lite` to version `0.10.0`

### DIFF
--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -109,7 +109,7 @@ void FileLogger::deleteOld(const int age, const FileLogAgeType ageType)
         }
         if (modificationDate > date)
             break;
-        Utils::Fs::removeFile(Path(file.absoluteFilePath()));
+        std::ignore = Utils::Fs::removeFile(Path(file.absoluteFilePath()));
     }
 }
 

--- a/src/base/3rdparty/expected.hpp
+++ b/src/base/3rdparty/expected.hpp
@@ -13,7 +13,7 @@
 #define NONSTD_EXPECTED_LITE_HPP
 
 #define expected_lite_MAJOR  0
-#define expected_lite_MINOR  9
+#define expected_lite_MINOR  10
 #define expected_lite_PATCH  0
 
 #define expected_lite_VERSION  expected_STRINGIFY(expected_lite_MAJOR) "." expected_STRINGIFY(expected_lite_MINOR) "." expected_STRINGIFY(expected_lite_PATCH)
@@ -2730,7 +2730,7 @@ private:
 /// class expected, void specialization
 
 template< typename E >
-class expected< void, E >
+class nsel_NODISCARD expected< void, E >
 {
 private:
     template< typename, typename > friend class expected;

--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -492,10 +492,10 @@ void BitTorrent::BencodeResumeDataStorage::Worker::store(const TorrentID &id, co
 void BitTorrent::BencodeResumeDataStorage::Worker::remove(const TorrentID &id) const
 {
     const Path resumeFilename {u"%1.fastresume"_s.arg(id.toString())};
-    Utils::Fs::removeFile(m_resumeDataDir / resumeFilename);
+    std::ignore = Utils::Fs::removeFile(m_resumeDataDir / resumeFilename);
 
     const Path torrentFilename {u"%1.torrent"_s.arg(id.toString())};
-    Utils::Fs::removeFile(m_resumeDataDir / torrentFilename);
+    std::ignore = Utils::Fs::removeFile(m_resumeDataDir / torrentFilename);
 }
 
 void BitTorrent::BencodeResumeDataStorage::Worker::storeQueue(const QList<TorrentID> &queue) const

--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -251,8 +251,8 @@ void CustomDiskIOThread::handleCompleteFiles(lt::storage_index_t storage, const 
             const Path completeFilePath = incompleteFilePath.removedExtension(QB_EXT);
             if (completeFilePath.exists())
             {
-                Utils::Fs::removeFile(incompleteFilePath);
-                Utils::Fs::renameFile(completeFilePath, incompleteFilePath);
+                if (Utils::Fs::removeFile(incompleteFilePath))
+                    Utils::Fs::renameFile(completeFilePath, incompleteFilePath);
             }
         }
     }
@@ -316,8 +316,8 @@ void CustomStorage::handleCompleteFiles(const Path &savePath)
             const Path completeFilePath = incompleteFilePath.removedExtension(QB_EXT);
             if (completeFilePath.exists())
             {
-                Utils::Fs::removeFile(incompleteFilePath);
-                Utils::Fs::renameFile(completeFilePath, incompleteFilePath);
+                if (Utils::Fs::removeFile(incompleteFilePath))
+                    Utils::Fs::renameFile(completeFilePath, incompleteFilePath);
             }
         }
     }

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1659,7 +1659,7 @@ void SessionImpl::endStartup(ResumeSessionContext *context)
         {
             connect(context->startupStorage, &QObject::destroyed, this, [dbPath]
             {
-                Utils::Fs::removeFile(dbPath);
+                std::ignore = Utils::Fs::removeFile(dbPath);
             });
         }
     }
@@ -4048,7 +4048,7 @@ void SessionImpl::setAddTrackersFromURLEnabled(const bool enabled)
             m_updateTrackersFromURLTimer->stop();
             setAdditionalTrackersFromURL({});
             const Path path = specialFolderLocation(SpecialFolder::Data) / Path(ADDITIONAL_TRACKERS_FROM_URL_FILE_NAME);
-            Utils::Fs::removeFile(path);
+            std::ignore = Utils::Fs::removeFile(path);
         }
     }
 }

--- a/src/base/bittorrent/torrentcontentremover.cpp
+++ b/src/base/bittorrent/torrentcontentremover.cpp
@@ -39,7 +39,7 @@ void BitTorrent::TorrentContentRemover::performJob(const QString &torrentName, c
 
     if (!fileNames.isEmpty())
     {
-        const auto removeFileFn = [&option](const Path &filePath)
+        const auto removeFileFn = [&option](const Path &filePath) -> nonstd::expected<void, QString>
         {
             return ((option == TorrentContentRemoveOption::MoveToTrash)
                     ? Utils::Fs::moveFileToTrash : Utils::Fs::removeFile)(filePath);

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -576,8 +576,8 @@ void Feed::cleanup()
 {
     m_dirty = false;
     m_savingTimer.stop();
-    Utils::Fs::removeFile(m_session->dataFileStorage()->storageDir() / m_dataFileName);
-    Utils::Fs::removeFile(m_iconPath);
+    std::ignore = Utils::Fs::removeFile(m_session->dataFileStorage()->storageDir() / m_dataFileName);
+    std::ignore = Utils::Fs::removeFile(m_iconPath);
 }
 
 void Feed::timerEvent([[maybe_unused]] QTimerEvent *event)

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -467,7 +467,7 @@ void Session::addItem(Item *item, Folder *destFolder)
             if (feed->name() == oldURL)
             {
                 // If feed still use an URL as a name trying to rename it to match new URL...
-                moveItem(feed, Item::joinPath(Item::parentPath(feed->path()), feed->url()));
+                std::ignore = moveItem(feed, Item::joinPath(Item::parentPath(feed->path()), feed->url()));
             }
 
             emit feedURLChanged(feed, oldURL);
@@ -594,7 +594,7 @@ void Session::handleFeedTitleChanged(Feed *feed)
     {
         // Now we have something better than a URL.
         // Trying to rename feed...
-        moveItem(feed, Item::joinPath(Item::parentPath(feed->path()), feed->title()));
+        std::ignore = moveItem(feed, Item::joinPath(Item::parentPath(feed->path()), feed->title()));
     }
 }
 

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -79,7 +79,7 @@ namespace
             while (it.hasNext())
             {
                 const QString filePath = it.next();
-                Utils::Fs::removeFile(Path(filePath));
+                std::ignore = Utils::Fs::removeFile(Path(filePath));
             }
         }
     }
@@ -267,21 +267,21 @@ void SearchPluginManager::installPlugin_impl(const QString &name, const Path &sr
         if (hasExistingPlugin)
         {
             hasBackup = Utils::Fs::copyFile(destPath, backupPath);
-            Utils::Fs::removeFile(destPath);
+            std::ignore = Utils::Fs::removeFile(destPath);
         }
 
         // Copy the plugin to dest path
         if (!Utils::Fs::copyFile(srcPath, destPath))
         {
             // Roll back
-            Utils::Fs::removeFile(destPath);
+            std::ignore = Utils::Fs::removeFile(destPath);
             if (hasBackup)
             {
                 // restore backup
                 if (Utils::Fs::copyFile(backupPath, destPath))
-                    Utils::Fs::removeFile(backupPath);
+                    std::ignore = Utils::Fs::removeFile(backupPath);
                 else
-                    Utils::Fs::removeFile(destPath);
+                    std::ignore = Utils::Fs::removeFile(destPath);
             }
 
             const QString errMsg = tr("Search plugin installation failed.");
@@ -304,25 +304,25 @@ void SearchPluginManager::installPlugin_impl(const QString &name, const Path &sr
         LogMsg(tr("Search plugin has been updated. Plugin name: \"%1\". Version: %2.").arg(name, incomingVersion.toString()), Log::INFO);
 
         if (hasBackup)
-            Utils::Fs::removeFile(backupPath);
+            std::ignore = Utils::Fs::removeFile(backupPath);
     }
     else
     {
         LogMsg(tr("Search plugin installation failed. Plugin name: \"%1\"").arg(name), Log::INFO);
 
         // Roll back
-        Utils::Fs::removeFile(destPath);
+        std::ignore = Utils::Fs::removeFile(destPath);
         if (hasBackup)
         {
             // restore backup
             if (Utils::Fs::copyFile(backupPath, destPath))
             {
-                Utils::Fs::removeFile(backupPath);
+                std::ignore = Utils::Fs::removeFile(backupPath);
                 update();  // Update supported plugins
             }
             else
             {
-                Utils::Fs::removeFile(destPath);
+                std::ignore = Utils::Fs::removeFile(destPath);
             }
         }
 
@@ -343,7 +343,7 @@ bool SearchPluginManager::uninstallPlugin(const QString &name)
     while (iter.hasNext())
     {
         const QString filePath = iter.next();
-        Utils::Fs::removeFile(Path(filePath));
+        std::ignore = Utils::Fs::removeFile(Path(filePath));
     }
 
     // Remove it from supported engines
@@ -521,7 +521,7 @@ void SearchPluginManager::pluginDownloadFinished(const Net::DownloadResult &resu
 
         const auto pluginPath = Path(QUrl(result.url).path()).removedExtension();
         installPlugin_impl(pluginPath.filename(), filePath);
-        Utils::Fs::removeFile(filePath);
+        std::ignore = Utils::Fs::removeFile(filePath);
     }
     else
     {
@@ -561,8 +561,8 @@ void SearchPluginManager::updateNova()
         if (getPluginVersion(filePathBundled) <= getPluginVersion(filePathDisk))
             return;
 
-        Utils::Fs::removeFile(filePathDisk);
-        Utils::Fs::copyFile(filePathBundled, filePathDisk);
+        if (Utils::Fs::removeFile(filePathDisk))
+            Utils::Fs::copyFile(filePathBundled, filePathDisk);
     };
 
     updateFile(Path(u"helpers.py"_s));

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -154,8 +154,8 @@ void SettingsStorage::readNativeSettings()
         finalPathStr.remove(index, 4);
 
         const Path finalPath {finalPathStr};
-        Utils::Fs::removeFile(finalPath);
-        Utils::Fs::renameFile(newPath, finalPath);
+        if (Utils::Fs::removeFile(finalPath))
+            Utils::Fs::renameFile(newPath, finalPath);
     }
     else
     {
@@ -207,7 +207,7 @@ bool SettingsStorage::writeNativeSettings() const
 
     if (status != QSettings::NoError)
     {
-        Utils::Fs::removeFile(newPath);
+        std::ignore = Utils::Fs::removeFile(newPath);
         return false;
     }
 
@@ -216,7 +216,7 @@ bool SettingsStorage::writeNativeSettings() const
     finalPathStr.remove(index, 4);
 
     const Path finalPath {finalPathStr};
-    Utils::Fs::removeFile(finalPath);
+    std::ignore = Utils::Fs::removeFile(finalPath);
     return Utils::Fs::renameFile(newPath, finalPath);
 }
 

--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -53,7 +53,7 @@ void FileGuard::setAutoRemove(const bool remove) noexcept
 FileGuard::~FileGuard()
 {
     if (m_remove && !m_path.isEmpty())
-        Utils::Fs::removeFile(m_path); // removeFile() checks for file existence
+        std::ignore = Utils::Fs::removeFile(m_path); // removeFile() checks for file existence
 }
 
 TorrentFileGuard::TorrentFileGuard(const Path &path, const TorrentFileGuard::AutoDeleteMode mode)

--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -413,7 +413,7 @@ void TorrentFilesWatcher::Worker::processFolder(const Path &path, const Path &wa
                     }
 
                     file.close();
-                    Utils::Fs::removeFile(filePath);
+                    std::ignore = Utils::Fs::removeFile(filePath);
                 }
                 else
                 {
@@ -430,7 +430,7 @@ void TorrentFilesWatcher::Worker::processFolder(const Path &path, const Path &wa
             if (const auto loadResult = BitTorrent::TorrentDescriptor::loadFromFile(filePath))
             {
                 emit torrentFound(loadResult.value(), addTorrentParams);
-                Utils::Fs::removeFile(filePath);
+                std::ignore = Utils::Fs::removeFile(filePath);
             }
             else
             {
@@ -485,7 +485,7 @@ void TorrentFilesWatcher::Worker::processFailedTorrents()
                 }
 
                 emit torrentFound(loadResult.value(), addTorrentParams);
-                Utils::Fs::removeFile(torrentPath);
+                std::ignore = Utils::Fs::removeFile(torrentPath);
 
                 return true;
             }

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -162,7 +162,7 @@ bool Utils::Fs::smartRemoveEmptyFolderTree(const Path &path)
             continue;
 
         for (const QString &f : tmpFileList)
-            removeFile(Path(p + f));
+            std::ignore = removeFile(Path(p + f));
 
         // remove directory if empty
         dir.rmdir(p);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2019,7 +2019,7 @@ void MainWindow::pythonDownloadFinished(const Net::DownloadResult &result)
             LogMsg(tr("Python installation success."), Log::INFO);
 
             // Delete installer
-            Utils::Fs::removeFile(exePath);
+            std::ignore = Utils::Fs::removeFile(exePath);
 
             // Reload search engine
             if (Utils::ForeignApps::pythonInfo().isSupportedVersion())

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -294,7 +294,7 @@ void FeedListWidget::dropEvent(QDropEvent *event)
     for (QTreeWidgetItem *srcItem : asConst(selectedItems()))
     {
         auto *rssItem = getRSSItem(srcItem);
-        RSS::Session::instance()->moveItem(rssItem, RSS::Item::joinPath(destFolder->path(), rssItem->name()));
+        std::ignore = RSS::Session::instance()->moveItem(rssItem, RSS::Item::joinPath(destFolder->path(), rssItem->name()));
     }
 
     QTreeWidget::dropEvent(event);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -409,7 +409,7 @@ void RSSWidget::deleteSelectedItems()
     for (QTreeWidgetItem *item : selectedItems)
     {
         if (!m_ui->feedListWidget->isStickyItem(item))
-            RSS::Session::instance()->removeItem(m_ui->feedListWidget->itemPath(item));
+            std::ignore = RSS::Session::instance()->removeItem(m_ui->feedListWidget->itemPath(item));
     }
 }
 

--- a/src/gui/search/searchpluginselectdialog.cpp
+++ b/src/gui/search/searchpluginselectdialog.cpp
@@ -427,7 +427,7 @@ void SearchPluginSelectDialog::iconDownloadFinished(const Net::DownloadResult &r
                 bool invalidExt = (sizesExt.isEmpty() || iconWithExt.pixmap(sizesExt.first()).isNull());
                 if (invalidExt)
                 {
-                    Utils::Fs::removeFile(iconPath);
+                    std::ignore = Utils::Fs::removeFile(iconPath);
                     continue;
                 }
 
@@ -437,7 +437,7 @@ void SearchPluginSelectDialog::iconDownloadFinished(const Net::DownloadResult &r
         }
     }
     // Delete tmp file
-    Utils::Fs::removeFile(filePath);
+    std::ignore = Utils::Fs::removeFile(filePath);
 }
 
 void SearchPluginSelectDialog::checkForUpdatesFinished(const QHash<QString, SearchPluginVersion> &updateInfo)

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -1038,7 +1038,7 @@ void SearchWidget::DataStorage::storeSession(const SessionData &sessionData)
 
 void SearchWidget::DataStorage::removeSession()
 {
-    Utils::Fs::removeFile(makeDataFilePath(SESSION_FILE_NAME));
+    std::ignore = Utils::Fs::removeFile(makeDataFilePath(SESSION_FILE_NAME));
 }
 
 void SearchWidget::DataStorage::storeTab(const QString &tabID, const QList<SearchResult> &searchResults)
@@ -1070,7 +1070,7 @@ void SearchWidget::DataStorage::storeTab(const QString &tabID, const QList<Searc
 
 void SearchWidget::DataStorage::removeTab(const QString &tabID)
 {
-    Utils::Fs::removeFile(makeDataFilePath(tabID + u".json"));
+    std::ignore = Utils::Fs::removeFile(makeDataFilePath(tabID + u".json"));
 }
 
 void SearchWidget::DataStorage::loadHistory()
@@ -1100,7 +1100,7 @@ void SearchWidget::DataStorage::storeHistory(const QStringList &history)
 
 void SearchWidget::DataStorage::removeHistory()
 {
-    Utils::Fs::removeFile(makeDataFilePath(HISTORY_FILE_NAME));
+    std::ignore = Utils::Fs::removeFile(makeDataFilePath(HISTORY_FILE_NAME));
 }
 
 #include "searchwidget.moc"

--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -183,7 +183,7 @@ TrackersFilterWidget::TrackersFilterWidget(QWidget *parent, TransferListWidget *
 TrackersFilterWidget::~TrackersFilterWidget()
 {
     for (const Path &iconPath : asConst(m_iconPaths))
-        Utils::Fs::removeFile(iconPath);
+        std::ignore = Utils::Fs::removeFile(iconPath);
 }
 
 void TrackersFilterWidget::handleTorrentTrackersAdded(const BitTorrent::Torrent *torrent, const QList<BitTorrent::TrackerEntry> &trackers)
@@ -494,7 +494,7 @@ void TrackersFilterWidget::handleFavicoDownloadFinished(const Net::DownloadResul
         const bool invalid = (sizes.isEmpty() || icon.pixmap(sizes.first()).isNull());
         if (invalid)
         {
-            Utils::Fs::removeFile(result.filePath);
+            std::ignore = Utils::Fs::removeFile(result.filePath);
             failed = true;
         }
     }
@@ -533,7 +533,7 @@ void TrackersFilterWidget::handleFavicoDownloadFinished(const Net::DownloadResul
     if (matchedTrackerFound)
         m_iconPaths.append(result.filePath);
     else
-        Utils::Fs::removeFile(result.filePath);
+        std::ignore = Utils::Fs::removeFile(result.filePath);
 }
 
 void TrackersFilterWidget::showMenu()


### PR DESCRIPTION
https://github.com/nonstd-lite/expected-lite/releases/tag/v0.10.0

More `std::expected` implementations now mark it as `[[nodiscard]]` so qbt must ignore it explicitly.
See: https://www.reddit.com/r/cpp/comments/1h9u4us/should_stdexpected_be_nodiscard/

Closes #23562.