### PR TITLE
Add button to open Default Apps settings on Windows

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -45,6 +45,10 @@
 #include <QStyleFactory>
 #include <QSystemTrayIcon>
 
+#ifdef Q_OS_WIN
+#include <QProcess>
+#endif
+
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/sharelimits.h"
 #include "base/exceptions.h"
@@ -86,6 +90,10 @@
 
 #ifdef Q_OS_MACOS
 #include "macutilities.h"
+#endif
+
+#ifdef Q_OS_WIN
+#include "base/utils/os.h"
 #endif
 
 #define SETTINGS_KEY(name) u"OptionsDialog/" name
@@ -303,12 +311,13 @@ void OptionsDialog::loadBehaviorTabOptions()
 
     m_ui->checkTorrentContentDrag->setChecked(pref->isTorrentContentDragEnabled());
 
-#ifndef Q_OS_WIN
+#ifdef Q_OS_WIN
+    m_ui->checkStartup->setChecked(pref->WinStartup());
+#else
     m_ui->checkStartup->setVisible(false);
 #endif
+
     m_ui->checkShowSplash->setChecked(!pref->isSplashScreenDisabled());
-    m_ui->checkProgramExitConfirm->setChecked(pref->confirmOnExit());
-    m_ui->checkProgramAutoExitConfirm->setChecked(!pref->dontConfirmAutoExit());
 
     m_ui->windowStateComboBox->addItem(tr("Normal"), QVariant::fromValue(WindowState::Normal));
     m_ui->windowStateComboBox->addItem(tr("Minimized"), QVariant::fromValue(WindowState::Minimized));
@@ -317,12 +326,12 @@ void OptionsDialog::loadBehaviorTabOptions()
 #endif
     m_ui->windowStateComboBox->setCurrentIndex(m_ui->windowStateComboBox->findData(QVariant::fromValue(app()->startUpWindowState())));
 
-#if !(defined(Q_OS_WIN) || defined(Q_OS_MACOS))
-    m_ui->groupFileAssociation->setVisible(false);
-    m_ui->checkProgramUpdates->setVisible(false);
-#endif
+    m_ui->checkProgramExitConfirm->setChecked(pref->confirmOnExit());
+    m_ui->checkProgramAutoExitConfirm->setChecked(!pref->dontConfirmAutoExit());
 
-#ifndef Q_OS_MACOS
+#ifdef Q_OS_MACOS
+    m_ui->checkShowSystray->setVisible(false);
+#else
     // Disable systray integration if it is not supported by the system
     if (!QSystemTrayIcon::isSystemTrayAvailable())
     {
@@ -336,20 +345,26 @@ void OptionsDialog::loadBehaviorTabOptions()
     m_ui->comboTrayIcon->setCurrentIndex(static_cast<int>(UIThemeManager::instance()->trayIconStyle()));
 #endif
 
-#ifdef Q_OS_WIN
-    m_ui->checkStartup->setChecked(pref->WinStartup());
-#endif
-
-#ifdef Q_OS_MACOS
-    m_ui->checkShowSystray->setVisible(false);
+#if defined(Q_OS_WIN)
+    connect(m_ui->buttonOpenDefaultApps, &QPushButton::clicked, this, [](bool)
+    {
+        const Path explorer = Utils::OS::windowsSystemPath().parentPath() / Path(u"explorer.exe"_s);
+        QProcess::startDetached(explorer.data(), {u"ms-settings:defaultapps"_s});
+    });
+#elif defined(Q_OS_MACOS)
     m_ui->checkAssociateTorrents->setChecked(MacUtils::isTorrentFileAssocSet());
     m_ui->checkAssociateTorrents->setEnabled(!m_ui->checkAssociateTorrents->isChecked());
     m_ui->checkAssociateMagnetLinks->setChecked(MacUtils::isMagnetLinkAssocSet());
     m_ui->checkAssociateMagnetLinks->setEnabled(!m_ui->checkAssociateMagnetLinks->isChecked());
+    m_ui->defaultProgramPanel->hide();
+#else
+    m_ui->groupFileAssociation->setVisible(false);
 #endif
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     m_ui->checkProgramUpdates->setChecked(pref->isUpdateCheckEnabled());
+#else
+    m_ui->checkProgramUpdates->setVisible(false);
 #endif
 
     m_ui->checkPreventFromSuspendWhenDownloading->setChecked(pref->preventFromSuspendWhenDownloading());
@@ -441,10 +456,6 @@ void OptionsDialog::loadBehaviorTabOptions()
 
 #ifdef Q_OS_WIN
     m_ui->assocPanel->hide();
-#endif
-
-#ifdef Q_OS_MACOS
-    m_ui->defaultProgramPanel->hide();
 #endif
 
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && !defined(QBT_USES_DBUS)

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -717,7 +717,23 @@
                      <item>
                       <widget class="QLabel" name="labelSetAssoc">
                        <property name="text">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To set qBittorrent as default program for .torrent files and/or Magnet links&lt;br/&gt;you can use &lt;span style=&quot; font-weight:600;&quot;&gt;Default Programs&lt;/span&gt; dialog from &lt;span style=&quot; font-weight:600;&quot;&gt;Control Panel&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        <string>To set qBittorrent as the default program for .torrent files and Magnet links, click the button below and add them manually:</string>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="buttonOpenDefaultApps">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="text">
+                        <string>Open Windows Default Apps settings page</string>
                        </property>
                       </widget>
                      </item>


### PR DESCRIPTION
Note that Windows 11 calls it 'Default Apps' not 'Default programs'.
Also I took the liberty of cleaning up surrounding code.

Before:
<img width="444" height="78" alt="before" src="https://github.com/user-attachments/assets/44655fc8-2de1-4f03-9de2-d41b01b42f52" />

After: 
<img width="569" height="101" alt="screenshot" src="https://github.com/user-attachments/assets/d2aa4736-33f7-4f3d-8e87-44dc85d08752" />
