### PR TITLE
WebUI: Use enable/disable on torrent content menu items

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -288,7 +288,7 @@
         <li><a href="#Rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li><a href="#Download"><img src="images/download.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li><a href="#CopyPath"><img src="images/edit-copy.svg" alt="QBT_TR(Copy path)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy path)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
-        <li><a href="#CopyURL"><img src="images/edit-copy.svg" alt="QBT_TR(Copy URL)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy URL)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#CopyDownloadURL"><img src="images/edit-copy.svg" alt="QBT_TR(Copy download URL)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy download URL)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li class="separator">
             <a href="#FilePrio" class="arrow-right"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Priority)QBT_TR[CONTEXT=PropertiesWidget]</a>
             <ul>

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -261,13 +261,13 @@ window.qBittorrent.ContextMenu ??= (() => {
 
         // hide an item
         hideItem(item) {
-            this.menu.querySelector(`a[href$="${item}"]`).parentNode.classList.add("invisible");
+            this.menu.querySelector(`a[href$="${item}"]`).parentElement.classList.add("invisible");
             return this;
         }
 
         // show an item
         showItem(item) {
-            this.menu.querySelector(`a[href$="${item}"]`).parentNode.classList.remove("invisible");
+            this.menu.querySelector(`a[href$="${item}"]`).parentElement.classList.remove("invisible");
             return this;
         }
 
@@ -293,6 +293,15 @@ window.qBittorrent.ContextMenu ??= (() => {
         execute(action, element) {
             if (this.options.actions[action])
                 this.options.actions[action](element, this, action);
+            return this;
+        }
+
+        setTooltip(item, text) {
+            const element = this.menu.querySelector(`a[href$="${item}"]`).parentElement;
+            if (text.length > 0)
+                element.title = text;
+            else
+                element.removeAttribute("title");
             return this;
         }
     }

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -371,11 +371,16 @@ window.qBittorrent.Misc ??= (() => {
         }
     };
 
-    const downloadFileStream = async (url, errorMessage = "QBT_TR(Unable to download file)QBT_TR[CONTEXT=HttpServer]") => {
+    const downloadFileStream = async (url) => {
+        const errorMessage = "QBT_TR(Unable to download file)QBT_TR[CONTEXT=HttpServer]";
+
         try {
             // Pre-flight HEAD request to check for errors before triggering download
             // This avoids navigating to an error page on failure
-            const response = await fetch(url, { method: "HEAD" });
+            const response = await fetch(url, {
+                method: "HEAD",
+                cache: "no-store"
+            });
             if (!response.ok) {
                 alert(errorMessage);
                 return;
@@ -385,6 +390,7 @@ window.qBittorrent.Misc ??= (() => {
             const link = document.createElement("a");
             link.href = url;
             link.click();
+            link.remove();
         }
         catch (error) {
             alert(errorMessage);

--- a/src/webui/www/private/scripts/torrent-content.js
+++ b/src/webui/www/private/scripts/torrent-content.js
@@ -466,8 +466,12 @@ window.qBittorrent.TorrentContent ??= (() => {
                     }
                 },
                 Download: async (element, ref) => {
-                    const url = getSelectedFileUrl();
-                    await window.qBittorrent.Misc.downloadFileStream(url);
+                    for (const url of getSelectedFilesURL()) {
+                        await window.qBittorrent.Misc.downloadFileStream(url);
+
+                        // https://stackoverflow.com/questions/53560991/automatic-file-downloads-limited-to-10-files-on-chrome-browser
+                        await window.qBittorrent.Misc.sleep(1000);
+                    }
                 },
                 CopyPath: async (element, ref) => {
                     const torrentID = torrentsTable.getCurrentTorrentID();
@@ -490,11 +494,10 @@ window.qBittorrent.TorrentContent ??= (() => {
 
                     await clipboardCopy(files.join("\n"));
                 },
-                CopyURL: async (element, ref) => {
-                    const url = getSelectedFileUrl();
+                CopyDownloadURL: async (element, ref) => {
+                    const url = getSelectedFilesURL().join("\n");
                     await clipboardCopy(url);
                 },
-
                 FilePrioIgnore: (element, ref) => {
                     filesPriorityMenuClicked(FilePriority.Ignored);
                 },
@@ -513,21 +516,30 @@ window.qBittorrent.TorrentContent ??= (() => {
                 y: 2
             },
             onShow: function() {
-                const selectedFiles = torrentFilesTable.selectedRowsIds();
-                if (selectedFiles.length !== 1) {
-                    this.hideItem("Download");
-                    this.hideItem("CopyURL");
+                let hasFolder = false;
+                let isAllComplete = true;
+                for (const rowID of torrentFilesTable.selectedRowsIds()) {
+                    const node = torrentFilesTable.getNode(rowID);
+                    const isFullyDownloaded = node.progress >= 100;
+
+                    if (node.isFolder)
+                        hasFolder = true;
+                    if (!isFullyDownloaded)
+                        isAllComplete = false;
+                }
+
+                const fileOnlyActions = ["CopyDownloadURL", "Download"];
+                if (hasFolder) {
+                    for (const action of fileOnlyActions) {
+                        this.setEnabled(action, false)
+                            .setTooltip(action, "QBT_TR(Not available for folders)QBT_TR[CONTEXT=TorrentContent]");
+                    }
                 }
                 else {
-                    const node = torrentFilesTable.getNode(selectedFiles[0]);
-                    const isFullyDownloaded = node.progress >= 100;
-                    if (!node.isFolder && isFullyDownloaded) {
-                        this.showItem("Download");
-                        this.showItem("CopyURL");
-                    }
-                    else {
-                        this.hideItem("Download");
-                        this.hideItem("CopyURL");
+                    // only files are selected
+                    for (const action of fileOnlyActions) {
+                        this.setEnabled(action, isAllComplete)
+                            .setTooltip(action, (isAllComplete ? "" : "QBT_TR(Unavailable until all selected files are downloaded)QBT_TR[CONTEXT=TorrentContent]"));
                     }
                 }
             }
@@ -569,22 +581,22 @@ window.qBittorrent.TorrentContent ??= (() => {
         torrentFilesFilterInputTimer = -1;
     };
 
-    const getSelectedFileUrl = () => {
-        const current_hash = torrentsTable.getCurrentTorrentID();
-        if (current_hash.length === 0)
-            return;
+    const getSelectedFilesURL = () => {
+        const torrentID = torrentsTable.getCurrentTorrentID();
+        if (torrentID.length === 0)
+            return [];
 
-        const selectedFiles = torrentFilesTable.selectedRowsIds();
-        if (selectedFiles.length !== 1)
-            return;
-
-        const node = torrentFilesTable.getNode(selectedFiles[0]);
-        const url = new URL("api/v2/torrents/downloadFile", window.location);
-        url.search = new URLSearchParams({
-            hash: current_hash,
-            file: node.fileId
-        });
-        return url;
+        const urls = [];
+        for (const rowId of torrentFilesTable.selectedRowsIds()) {
+            const node = torrentFilesTable.getNode(rowId);
+            const url = new URL("api/v2/torrents/downloadFile", window.location);
+            url.search = new URLSearchParams({
+                hash: torrentID,
+                file: node.fileId
+            });
+            urls.push(url.toString());
+        }
+        return urls;
     };
 
     return exports();


### PR DESCRIPTION
It allows the actions (Copy URL, Download) to be discovered more easily.
Additional changes:
* Rename "Copy URL" menu entry to "Copy download URL".
* Allow 'Download' and 'Copy download URL' actions on multiple selected files. Previously these actions are only available when only one file is selected.

Screenshot:
<img width="421" height="156" alt="screenshot" src="https://github.com/user-attachments/assets/887f1b0a-c9df-47f3-bcb8-28a0fb527af5" />

