### PR TITLE
GHA CI: allow `npm` to install dependencies from URLs

### DIFF
--- a/.github/workflows/ci_webui.yaml
+++ b/.github/workflows/ci_webui.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install tools
         run: |
-          npm install
+          npm install --allow-remote=root
           npm ls
           echo "::group::npm ls --all"
           npm ls --all


### PR DESCRIPTION
This change is required since `npm` v12 the option will default to `none` and qbt do have one dependency that is from remote URL.
Note that the `root` option only allow *direct* dependencies to be installed from remote URLs.
https://docs.npmjs.com/cli/v12/using-npm/config#allow-remote

ps. this PR should be backported to 5.2.x branch to avoid CI breakage (in the near future).