### PR TITLE
Avoid torrent payload path collisions

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(qbt_base STATIC
     bittorrent/torrentdescriptor.h
     bittorrent/torrentimpl.h
     bittorrent/torrentinfo.h
+    bittorrent/toplevelpayload.h
     bittorrent/tracker.h
     bittorrent/trackerentry.h
     bittorrent/trackerentrystatus.h
@@ -164,6 +165,7 @@ add_library(qbt_base STATIC
     bittorrent/torrentdescriptor.cpp
     bittorrent/torrentimpl.cpp
     bittorrent/torrentinfo.cpp
+    bittorrent/toplevelpayload.cpp
     bittorrent/tracker.cpp
     bittorrent/trackerentry.cpp
     bittorrent/trackerentrystatus.cpp

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -97,7 +97,9 @@
 #include "base/version.h"
 #include "bandwidthscheduler.h"
 #include "bencoderesumedatastorage.h"
+#include "common.h"
 #include "customstorage.h"
+#include "toplevelpayload.h"
 #include "dbresumedatastorage.h"
 #include "downloadpriority.h"
 #include "extensiondata.h"
@@ -2539,6 +2541,12 @@ bool SessionImpl::removeTorrent(const TorrentID &id, const TorrentRemoveOption d
 
     const TorrentID torrentID = torrent->id();
     const QString torrentName = torrent->name();
+    // Absolute top-level payload keys stay occupied until handleRemovedTorrent.
+    // Current location + final save path (+ incomplete path when set) so future move targets stay reserved.
+    const QSet<Path> physicalPayloadPaths = torrent->hasMetadata()
+            ? payloadClaimPaths(uniqueStorageRoots({
+                    torrent->actualStorageLocation(), torrent->savePath(), torrent->downloadPath()}), torrent->filePaths())
+            : QSet<Path> {};
 
     qDebug("Deleting torrent with ID: %s", qUtf8Printable(torrentID.toString()));
     emit torrentAboutToBeRemoved(torrent);
@@ -2549,7 +2557,7 @@ bool SessionImpl::removeTorrent(const TorrentID &id, const TorrentRemoveOption d
     // Remove it from session
     if (deleteOption == TorrentRemoveOption::KeepContent)
     {
-        m_removingTorrents[torrentID] = {torrentName, torrent->actualStorageLocation(), {}, deleteOption};
+        m_removingTorrents[torrentID] = {torrentName, torrent->actualStorageLocation(), {}, physicalPayloadPaths, deleteOption};
 
         const lt::torrent_handle nativeHandle {torrent->nativeHandle()};
         const auto iter = std::ranges::find_if(asConst(m_moveStorageQueue)
@@ -2571,7 +2579,8 @@ bool SessionImpl::removeTorrent(const TorrentID &id, const TorrentRemoveOption d
     }
     else
     {
-        m_removingTorrents[torrentID] = {torrentName, torrent->actualStorageLocation(), torrent->actualFilePaths(), deleteOption};
+        m_removingTorrents[torrentID] = {torrentName, torrent->actualStorageLocation(), torrent->actualFilePaths()
+                , physicalPayloadPaths, deleteOption};
 
         if (m_moveStorageQueue.size() > 1)
         {
@@ -2826,6 +2835,8 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
 
     const bool useAutoTMM = loadTorrentParams.useAutoTMM;
     const Path actualSavePath = useAutoTMM ? categorySavePath(loadTorrentParams.category) : loadTorrentParams.savePath;
+    const Path actualDownloadPath = useAutoTMM
+            ? categoryDownloadPath(loadTorrentParams.category) : loadTorrentParams.downloadPath;
 
     bool needFindIncompleteFiles = false;
     PathList filePaths;
@@ -2992,29 +3003,84 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
         if (!needFindIncompleteFiles)
             return QtFuture::makeReadyValueFuture(FileSearchResult {.savePath = actualSavePath, .fileNames = filePaths});
 
-        const Path actualDownloadPath = loadTorrentParams.useAutoTMM
-                ? categoryDownloadPath(loadTorrentParams.category) : loadTorrentParams.downloadPath;
         return findIncompleteFiles(actualSavePath, actualDownloadPath, filePaths);
     };
 
-    resolveFileNames().then(this, [this, id, loadTorrentParams = std::move(loadTorrentParams)](const FileSearchResult &result) mutable
+    const bool allowPayloadRename = !addTorrentParams.skipChecking;
+    const InfoHash addInfoHash = infoHash;
+    // Per-torrent final and incomplete roots (not only the path FileSearcher ends up using).
+    const Path finalSaveRoot = actualSavePath;
+    const Path incompleteRoot = actualDownloadPath;
+
+    resolveFileNames().then(this, [this, id, addInfoHash, allowPayloadRename, finalSaveRoot, incompleteRoot
+            , loadTorrentParams = std::move(loadTorrentParams)](const FileSearchResult &result) mutable
     {
         lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;
+
+        PathList resolvedFilePaths;
+        if (p.ti)
+        {
+            // Strip incomplete-extension before uniqueness so claims use user payload names.
+            PathList userFilePaths;
+            userFilePaths.reserve(result.fileNames.size());
+            QList<bool> hadIncompleteExt;
+            hadIncompleteExt.reserve(result.fileNames.size());
+            for (const Path &fileName : asConst(result.fileNames))
+            {
+                const bool incomplete = fileName.hasExtension(QB_EXT);
+                hadIncompleteExt.append(incomplete);
+                userFilePaths.append(incomplete ? fileName.removedExtension(QB_EXT) : fileName);
+            }
+
+            // Name must be free under the chosen root, the final save path, and incomplete path.
+            const PathList storageRoots = uniqueStorageRoots(
+                    {result.savePath, finalSaveRoot, incompleteRoot});
+
+            const auto isTaken = [this, &id](const Path &physicalPath) -> bool
+            {
+                return isPhysicalPayloadPathTaken(physicalPath, id);
+            };
+            const auto resolveResult = uniquifyPayloadPaths(
+                    storageRoots, std::move(userFilePaths), allowPayloadRename, isTaken);
+            if (!resolveResult)
+            {
+                LogMsg(tr("Failed to add torrent. Reason: \"%1\"").arg(resolveResult.error()), Log::WARNING);
+                emit addTorrentFailed(addInfoHash, resolveResult.error());
+                return;
+            }
+
+            resolvedFilePaths = resolveResult.value();
+            // Reserve under every root this torrent may write to (current + final + incomplete).
+            reservePendingAddPayload(id, storageRoots, resolvedFilePaths);
+
+            // Restore incomplete extension when FileSearcher requested it.
+            for (qsizetype i = 0; i < resolvedFilePaths.size(); ++i)
+            {
+                if (hadIncompleteExt.at(i))
+                    resolvedFilePaths[i] += QB_EXT;
+            }
+        }
+        else
+        {
+            resolvedFilePaths = result.fileNames;
+        }
 
         p.save_path = result.savePath.toString().toStdString();
         if (p.ti)
         {
             const TorrentInfo torrentInfo {*p.ti};
             const auto nativeIndexes = torrentInfo.nativeIndexes();
-            for (qsizetype i = 0; i < result.fileNames.size(); ++i)
-                p.renamed_files[nativeIndexes[i]] = result.fileNames[i].toString().toStdString();
+            for (qsizetype i = 0; i < resolvedFilePaths.size(); ++i)
+                p.renamed_files[nativeIndexes[i]] = resolvedFilePaths[i].toString().toStdString();
         }
 
         m_nativeSession->async_add_torrent(p);
-        m_addTorrentAlertHandlers.append([this, loadTorrentParams = std::move(loadTorrentParams)](const lt::add_torrent_alert *alert) mutable
+        m_addTorrentAlertHandlers.append([this, id, loadTorrentParams = std::move(loadTorrentParams)](const lt::add_torrent_alert *alert) mutable
         {
             if (alert->error)
             {
+                clearPendingAddPayload(id);
+
                 const QString msg = QString::fromStdString(alert->message());
                 const InfoHash infoHash = getInfoHash(alert->params);
                 if (Torrent *torrent = findTorrent(infoHash); (alert->error == lt::errors::duplicate_torrent) && torrent)
@@ -3035,6 +3101,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &source, const AddTorr
                     alert->handle.queue_position_top();
 
                 TorrentImpl *torrent = createTorrent(alert->handle, std::move(loadTorrentParams));
+                clearPendingAddPayload(id);
                 m_loadedTorrents.append(torrent);
 
                 torrent->requestResumeData(lt::torrent_handle::save_info_dict);
@@ -5447,6 +5514,15 @@ void SessionImpl::handleTorrentInfoHashChanged(TorrentImpl *torrent, const InfoH
     {
         m_torrents[torrent->id()] = m_torrents.take(prevID);
         m_changedTorrentIDs[torrent->id()] = prevID;
+
+        if (const auto pending = m_pendingAddPayloadReservations.take(prevID); !pending.isEmpty())
+            m_pendingAddPayloadReservations.insert(currentID, pending);
+
+        for (PendingPayloadReservation &reservation : m_pendingRenamePayloadReservations)
+        {
+            if (reservation.torrentID == prevID)
+                reservation.torrentID = currentID;
+        }
     }
 }
 
@@ -5999,6 +6075,9 @@ TorrentImpl *SessionImpl::createTorrent(const lt::torrent_handle &nativeHandle, 
     if (const InfoHash infoHash = torrent->infoHash(); infoHash.isHybrid())
         m_hybridTorrentsByAltID.insert(TorrentID::fromSHA1Hash(infoHash.v1()), torrent);
 
+    // Occupied top-level names are derived from m_torrents (and removing/pending sets).
+    // No permanent ownership map is kept for loaded torrents.
+
     const ShareLimits torrentShareLimits = torrent->effectiveShareLimits();
     if (!m_seedingLimitTimer->isActive()
         && ((torrentShareLimits.ratioLimit >= 0)
@@ -6013,6 +6092,83 @@ TorrentImpl *SessionImpl::createTorrent(const lt::torrent_handle &nativeHandle, 
         LogMsg(tr("Torrent errored. Torrent: \"%1\". Error: \"%2\"").arg(torrent->name(), torrent->error()), Log::WARNING);
 
     return torrent;
+}
+
+bool SessionImpl::isPhysicalPayloadPathTaken(const Path &physicalPath, const TorrentID &exceptID) const
+{
+    for (const TorrentImpl *torrent : asConst(m_torrents))
+    {
+        if ((torrent->id() == exceptID) || !torrent->hasMetadata())
+            continue;
+        // Claim both current location and configured final/incomplete roots.
+        const QSet<Path> claims = payloadClaimPaths(
+                uniqueStorageRoots({torrent->actualStorageLocation(), torrent->savePath(), torrent->downloadPath()})
+                , torrent->filePaths());
+        if (isPayloadPathTaken(physicalPath, claims))
+            return true;
+    }
+
+    for (auto it = m_removingTorrents.cbegin(); it != m_removingTorrents.cend(); ++it)
+    {
+        if (it.key() == exceptID)
+            continue;
+        if (isPayloadPathTaken(physicalPath, it.value().physicalPayloadPaths))
+            return true;
+    }
+
+    for (auto it = m_pendingAddPayloadReservations.cbegin(); it != m_pendingAddPayloadReservations.cend(); ++it)
+    {
+        if (it.key() == exceptID)
+            continue;
+        if (isPayloadPathTaken(physicalPath, it.value()))
+            return true;
+    }
+
+    // Pending renames from *any* torrent, including exceptID, stay visible so two renames
+    // on the same torrent cannot both reserve the same destination path.
+    for (const PendingPayloadReservation &reservation : asConst(m_pendingRenamePayloadReservations))
+    {
+        if (isPayloadPathTaken(physicalPath, reservation.physicalPaths))
+            return true;
+    }
+
+    return false;
+}
+
+void SessionImpl::reservePendingAddPayload(const TorrentID &id, const PathList &storageRoots, const PathList &filePaths)
+{
+    m_pendingAddPayloadReservations.insert(id, payloadClaimPaths(storageRoots, filePaths));
+}
+
+void SessionImpl::clearPendingAddPayload(const TorrentID &id)
+{
+    m_pendingAddPayloadReservations.remove(id);
+}
+
+std::optional<qint64> SessionImpl::beginPayloadRenameReservation(const TorrentID &id, const PathList &storageRoots
+        , const PathList &currentFilePaths, const PathList &proposedFilePaths)
+{
+    const PathList roots = uniqueStorageRoots(storageRoots);
+    const QSet<Path> currentPaths = payloadClaimPaths(roots, currentFilePaths);
+    const QSet<Path> proposedPaths = payloadClaimPaths(roots, proposedFilePaths);
+
+    for (const Path &path : asConst(proposedPaths))
+    {
+        if (isPayloadPathTaken(path, currentPaths))
+            continue; // still owned by this torrent's current layout
+        if (isPhysicalPayloadPathTaken(path, id))
+            return std::nullopt;
+    }
+
+    const qint64 token = m_nextPayloadReservationToken++;
+    m_pendingRenamePayloadReservations.insert(token
+            , PendingPayloadReservation {.torrentID = id, .physicalPaths = proposedPaths});
+    return token;
+}
+
+void SessionImpl::endPayloadRenameReservation(const qint64 token)
+{
+    m_pendingRenamePayloadReservations.remove(token);
 }
 
 TorrentImpl *SessionImpl::getTorrent(const lt::torrent_handle &nativeHandle) const
@@ -6747,6 +6903,7 @@ void SessionImpl::handleRemovedTorrent(const TorrentID &torrentID, const QString
         });
     }
 
+    // Dropping this entry also frees its topLevelPayloadKeys for new adds.
     m_removingTorrents.erase(removingTorrentDataIter);
 }
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -31,6 +31,7 @@
 
 #include <chrono>
 #include <functional>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -54,9 +55,11 @@
 #include "addtorrentparams.h"
 #include "cachestatus.h"
 #include "categoryoptions.h"
+#include "infohash.h"
 #include "session.h"
 #include "sessionstatus.h"
 #include "torrentinfo.h"
+#include "toplevelpayload.h"
 
 class QString;
 class QTimer;
@@ -489,6 +492,16 @@ namespace BitTorrent
                 , const QHash<int, Path> &renamedFiles, const QList<int> &failedFileIndexes);
         void handleTorrentStorageMovingStateChanged(TorrentImpl *torrent);
 
+        // Physical top-level payload uniqueness (session-known torrents only; not unowned disk files).
+        // Occupied absolute paths: active torrents + removing + pending adds + pending renames.
+        bool isPhysicalPayloadPathTaken(const Path &physicalPath, const TorrentID &exceptID) const;
+        void reservePendingAddPayload(const TorrentID &id, const PathList &storageRoots, const PathList &filePaths);
+        void clearPendingAddPayload(const TorrentID &id);
+        // Returns reservation token; empty optional if the rename would collide.
+        std::optional<qint64> beginPayloadRenameReservation(const TorrentID &id, const PathList &storageRoots
+                , const PathList &currentFilePaths, const PathList &proposedFilePaths);
+        void endPayloadRenameReservation(qint64 token);
+
         bool addMoveTorrentStorageJob(TorrentImpl *torrent, const Path &newPath, MoveStorageMode mode, MoveStorageContext context);
 
         lt::torrent_handle reloadTorrent(const lt::torrent_handle &currentHandle, lt::add_torrent_params params);
@@ -546,7 +559,15 @@ namespace BitTorrent
             QString name;
             Path contentStoragePath;
             PathList fileNames;
+            // Absolute top-level payload paths; occupied until handleRemovedTorrent finishes.
+            QSet<Path> physicalPayloadPaths;
             TorrentRemoveOption removeOption {};
+        };
+
+        struct PendingPayloadReservation
+        {
+            TorrentID torrentID;
+            QSet<Path> physicalPaths;
         };
 
         explicit SessionImpl(QObject *parent = nullptr);
@@ -843,6 +864,11 @@ namespace BitTorrent
         QHash<TorrentID, TorrentImpl *> m_hybridTorrentsByAltID;
         QHash<TorrentID, RemovingTorrentData> m_removingTorrents;
         QHash<TorrentID, TorrentID> m_changedTorrentIDs;
+        // Temporary absolute payload reservations for in-flight adds (including seed/skip-check).
+        QHash<TorrentID, QSet<Path>> m_pendingAddPayloadReservations;
+        // Temporary absolute payload reservations for in-flight content renames.
+        QHash<qint64, PendingPayloadReservation> m_pendingRenamePayloadReservations;
+        qint64 m_nextPayloadReservationToken = 1;
         QMap<QString, CategoryOptions> m_categories;
         TagSet m_tags;
 

--- a/src/base/bittorrent/toplevelpayload.cpp
+++ b/src/base/bittorrent/toplevelpayload.cpp
@@ -1,0 +1,309 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  The qBittorrent project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "toplevelpayload.h"
+
+#include <algorithm>
+#include <ranges>
+
+#include <QSet>
+
+#include "base/global.h"
+
+namespace
+{
+    constexpr int MAX_SUFFIX = 9999;
+
+    QString withNumericSuffix(const QString &name, const bool isFile, const int n)
+    {
+        const QString mark = u" ("_s + QString::number(n) + u')';
+        if (isFile)
+        {
+            const Path p {name};
+            const QString ext = p.extension();
+            if (!ext.isEmpty())
+                return p.removedExtension().toString() + mark + ext;
+        }
+        return name + mark;
+    }
+
+    Path absClaim(const Path &storageRoot, const QString &topName)
+    {
+        return storageRoot.isEmpty() ? Path(topName) : (storageRoot / Path(topName));
+    }
+
+    QStringList rootlessTopNames(const PathList &filePaths)
+    {
+        QSet<QString> seen;
+        QStringList names;
+        for (const Path &filePath : filePaths)
+        {
+            const Path root = filePath.rootItem();
+            if (root.isEmpty())
+                continue;
+            const QString name = root.toString();
+            if (seen.contains(name))
+                continue;
+            seen.insert(name);
+            names.append(name);
+        }
+        return names;
+    }
+
+    // True if topName is free under every storage root.
+    bool nameFreeEverywhere(const PathList &storageRoots, const QString &topName
+            , const std::function<bool (const Path &)> &isTaken)
+    {
+        for (const Path &root : storageRoots)
+        {
+            if (isTaken(absClaim(root, topName)))
+                return false;
+        }
+        return true;
+    }
+
+    // True if any top name is taken under any root.
+    bool anyNameTakenSomewhere(const PathList &storageRoots, const QStringList &topNames
+            , const std::function<bool (const Path &)> &isTaken)
+    {
+        for (const QString &name : topNames)
+        {
+            if (!nameFreeEverywhere(storageRoots, name, isTaken))
+                return true;
+        }
+        return false;
+    }
+
+    QString findFreeName(const PathList &storageRoots, const QString &baseName, const bool isFile
+            , const std::function<bool (const Path &)> &isTaken)
+    {
+        if (nameFreeEverywhere(storageRoots, baseName, isTaken))
+            return baseName;
+
+        for (int n = 1; n <= MAX_SUFFIX; ++n)
+        {
+            const QString candidate = withNumericSuffix(baseName, isFile, n);
+            if (nameFreeEverywhere(storageRoots, candidate, isTaken))
+                return candidate;
+        }
+        return {};
+    }
+
+    PathList renameRootFolder(PathList filePaths, const QString &oldName, const QString &newName)
+    {
+        const Path oldRoot {oldName};
+        const Path newRoot {newName};
+        for (Path &filePath : filePaths)
+        {
+            if (filePath == oldRoot)
+                filePath = newRoot;
+            else if (filePath.hasAncestor(oldRoot))
+                filePath = newRoot / oldRoot.relativePathOf(filePath);
+        }
+        return filePaths;
+    }
+}
+
+PathList BitTorrent::uniqueStorageRoots(const PathList &roots)
+{
+    PathList unique;
+    for (const Path &root : roots)
+    {
+        if (root.isEmpty())
+            continue;
+        if (std::ranges::find(unique, root) != unique.cend())
+            continue;
+        unique.append(root);
+    }
+    return unique;
+}
+
+QSet<Path> BitTorrent::payloadClaimPaths(const Path &storageRoot, const PathList &filePaths)
+{
+    QSet<Path> claims;
+    if (filePaths.isEmpty())
+        return claims;
+
+    const Path rootFolder = Path::findRootFolder(filePaths);
+    if (!rootFolder.isEmpty())
+    {
+        claims.insert(absClaim(storageRoot, rootFolder.toString()));
+        return claims;
+    }
+
+    if (filePaths.size() == 1)
+    {
+        claims.insert(absClaim(storageRoot, filePaths.at(0).toString()));
+        return claims;
+    }
+
+    for (const QString &name : asConst(rootlessTopNames(filePaths)))
+        claims.insert(absClaim(storageRoot, name));
+    return claims;
+}
+
+QSet<Path> BitTorrent::payloadClaimPaths(const PathList &storageRoots, const PathList &filePaths)
+{
+    QSet<Path> claims;
+    for (const Path &root : asConst(uniqueStorageRoots(storageRoots)))
+        claims.unite(payloadClaimPaths(root, filePaths));
+    return claims;
+}
+
+bool BitTorrent::payloadPathsConflict(const Path &left, const Path &right)
+{
+    if (left.isEmpty() || right.isEmpty())
+        return false;
+    return (left == right) || left.hasAncestor(right) || right.hasAncestor(left);
+}
+
+bool BitTorrent::isPayloadPathTaken(const Path &path, const QSet<Path> &occupied)
+{
+    for (const Path &other : occupied)
+    {
+        if (payloadPathsConflict(path, other))
+            return true;
+    }
+    return false;
+}
+
+PathList BitTorrent::applyContentRename(const PathList &filePaths, const Path &oldPath, const Path &newPath)
+{
+    if (oldPath.isEmpty() || (oldPath == newPath))
+        return filePaths;
+
+    PathList result;
+    result.reserve(filePaths.size());
+    for (const Path &filePath : filePaths)
+    {
+        if (filePath == oldPath)
+            result.append(newPath);
+        else if (filePath.hasAncestor(oldPath))
+            result.append(newPath / oldPath.relativePathOf(filePath));
+        else
+            result.append(filePath);
+    }
+    return result;
+}
+
+nonstd::expected<PathList, QString> BitTorrent::uniquifyPayloadPaths(
+        const PathList &storageRootsIn, PathList filePaths, const bool allowRename
+        , const std::function<bool (const Path &absolutePath)> &isTaken)
+{
+    Q_ASSERT(isTaken);
+
+    if (filePaths.isEmpty())
+        return filePaths;
+
+    const PathList storageRoots = uniqueStorageRoots(storageRootsIn);
+    // No usable roots → nothing to uniquify against; keep layout.
+    if (storageRoots.isEmpty())
+        return filePaths;
+
+    const Path rootFolder = Path::findRootFolder(filePaths);
+
+    // --- Shared root folder ---
+    if (!rootFolder.isEmpty())
+    {
+        const QString rootName = rootFolder.toString();
+        if (nameFreeEverywhere(storageRoots, rootName, isTaken))
+            return filePaths;
+
+        if (!allowRename)
+        {
+            return nonstd::make_unexpected(
+                    QStringLiteral("Payload path is already used by another torrent: '%1'")
+                            .arg(absClaim(storageRoots.constFirst(), rootName).toString()));
+        }
+
+        const QString freeName = findFreeName(storageRoots, rootName, false, isTaken);
+        if (freeName.isEmpty())
+        {
+            return nonstd::make_unexpected(
+                    QStringLiteral("Could not find a free payload folder name for: '%1'").arg(rootName));
+        }
+        return renameRootFolder(std::move(filePaths), rootName, freeName);
+    }
+
+    // --- Single file ---
+    if (filePaths.size() == 1)
+    {
+        const QString fileName = filePaths.at(0).toString();
+        if (nameFreeEverywhere(storageRoots, fileName, isTaken))
+            return filePaths;
+
+        if (!allowRename)
+        {
+            return nonstd::make_unexpected(
+                    QStringLiteral("Payload path is already used by another torrent: '%1'")
+                            .arg(absClaim(storageRoots.constFirst(), fileName).toString()));
+        }
+
+        const QString freeName = findFreeName(storageRoots, fileName, true, isTaken);
+        if (freeName.isEmpty())
+        {
+            return nonstd::make_unexpected(
+                    QStringLiteral("Could not find a free payload file name for: '%1'").arg(fileName));
+        }
+        return PathList {Path(freeName)};
+    }
+
+    // --- Rootless multi-file ---
+    const QStringList tops = rootlessTopNames(filePaths);
+    if (!anyNameTakenSomewhere(storageRoots, tops, isTaken))
+        return filePaths;
+
+    if (!allowRename)
+    {
+        return nonstd::make_unexpected(
+                QStringLiteral("Payload path is already used by another torrent under one of the storage paths"));
+    }
+
+    QString folderBase = filePaths.at(0).removedExtension().toString();
+    if (folderBase.isEmpty() || folderBase.contains(u'/'))
+        folderBase = filePaths.at(0).rootItem().toString();
+    if (folderBase.isEmpty())
+        folderBase = u"Torrent"_s;
+
+    const QString freeFolder = findFreeName(storageRoots, folderBase, false, isTaken);
+    if (freeFolder.isEmpty())
+    {
+        return nonstd::make_unexpected(
+                QStringLiteral("Could not find a free payload folder name for: '%1'").arg(folderBase));
+    }
+
+    Path::addRootFolder(filePaths, Path(freeFolder));
+    return filePaths;
+}
+
+nonstd::expected<PathList, QString> BitTorrent::uniquifyPayloadPaths(
+        const Path &storageRoot, PathList filePaths, const bool allowRename
+        , const std::function<bool (const Path &absolutePath)> &isTaken)
+{
+    return uniquifyPayloadPaths(PathList {storageRoot}, std::move(filePaths), allowRename, isTaken);
+}

--- a/src/base/bittorrent/toplevelpayload.h
+++ b/src/base/bittorrent/toplevelpayload.h
@@ -1,0 +1,72 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  The qBittorrent project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <functional>
+
+#include <QSet>
+#include <QString>
+
+#include "base/3rdparty/expected.hpp"
+#include "base/path.h"
+
+namespace BitTorrent
+{
+    // Absolute payload path(s) a layout claims under one storage root.
+    QSet<Path> payloadClaimPaths(const Path &storageRoot, const PathList &filePaths);
+
+    // Claims under every storage root (final save, incomplete, current, …).
+    QSet<Path> payloadClaimPaths(const PathList &storageRoots, const PathList &filePaths);
+
+    // Deduplicate roots (skips empties).
+    PathList uniqueStorageRoots(const PathList &roots);
+
+    bool payloadPathsConflict(const Path &left, const Path &right);
+    bool isPayloadPathTaken(const Path &path, const QSet<Path> &occupied);
+
+    PathList applyContentRename(const PathList &filePaths, const Path &oldPath, const Path &newPath);
+
+    // Uniquify relative paths so the chosen payload name is free under *every* storage root.
+    // Example: incomplete=/tmp/qbit final=/disk2/anime → both /tmp/qbit/Show and /disk2/anime/Show
+    // must be free for "Show" to be accepted; otherwise try "Show (1)", etc.
+    //
+    // 1) Shared root folder → rename folder
+    // 2) Single file → rename file (suffix before extension)
+    // 3) Rootless multi → on any collision, wrap in a unique folder
+    //
+    // allowRename=false → error on collision. Session-known torrents only (no disk scan).
+    nonstd::expected<PathList, QString> uniquifyPayloadPaths(
+            const PathList &storageRoots, PathList filePaths, bool allowRename
+            , const std::function<bool (const Path &absolutePath)> &isTaken);
+
+    // Convenience: single storage root.
+    nonstd::expected<PathList, QString> uniquifyPayloadPaths(
+            const Path &storageRoot, PathList filePaths, bool allowRename
+            , const std::function<bool (const Path &absolutePath)> &isTaken);
+}

--- a/src/base/bittorrent/torrentcontenthandler.cpp
+++ b/src/base/bittorrent/torrentcontenthandler.cpp
@@ -58,6 +58,9 @@ void BitTorrent::TorrentContentHandler::renameFile(const Path &oldPath, const Pa
     if (renamingFileIndex < 0)
         throw RuntimeError(tr("No such file: '%1'.").arg(oldPath.toString()));
 
+    // Any rename can change the torrent's set of physical top-level payload claims.
+    prepareContentRename(oldPath, newPath);
+
     renameFile(renamingFileIndex, newPath);
 }
 
@@ -84,5 +87,13 @@ void BitTorrent::TorrentContentHandler::renameFolder(const Path &oldFolderPath, 
     if (!oldFolderExists)
         throw RuntimeError(tr("No such folder: '%1'.").arg(oldFolderPath.toString()));
 
+    // Any folder rename can change the torrent's set of physical top-level payload claims.
+    prepareContentRename(oldFolderPath, newFolderPath);
+
     doRenameFolder(oldFolderPath, newFolderPath);
+}
+
+void BitTorrent::TorrentContentHandler::prepareContentRename(
+        [[maybe_unused]] const Path &oldPath, [[maybe_unused]] const Path &newPath)
+{
 }

--- a/src/base/bittorrent/torrentcontenthandler.h
+++ b/src/base/bittorrent/torrentcontenthandler.h
@@ -77,5 +77,7 @@ namespace BitTorrent
 
     protected:
         virtual void doRenameFolder(const Path &oldFolderPath, const Path &newFolderPath) = 0;
+        // Called before any content rename. May throw RuntimeError if payload paths collide.
+        virtual void prepareContentRename(const Path &oldPath, const Path &newPath);
     };
 }

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -76,6 +76,7 @@
 #include "peeraddress.h"
 #include "peerinfo.h"
 #include "sessionimpl.h"
+#include "toplevelpayload.h"
 #include "trackerentry.h"
 
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
@@ -1863,6 +1864,23 @@ void TorrentImpl::doRenameFolder(const Path &oldFolderPath, const Path &newFolde
     }
 }
 
+void TorrentImpl::prepareContentRename(const Path &oldPath, const Path &newPath)
+{
+    const PathList currentPaths = filePaths();
+    const PathList proposedPaths = applyContentRename(currentPaths, oldPath, newPath);
+    const Path currentRoot = actualStorageLocation().isEmpty() ? savePath() : actualStorageLocation();
+    const PathList storageRoots = uniqueStorageRoots({currentRoot, savePath(), downloadPath()});
+
+    const std::optional<qint64> token = m_session->beginPayloadRenameReservation(
+            id(), storageRoots, currentPaths, proposedPaths);
+    if (!token)
+    {
+        throw RuntimeError(tr("The resulting top-level payload path is already used by another torrent."));
+    }
+
+    m_payloadRenameReservationTokens.enqueue(*token);
+}
+
 std::shared_ptr<const libtorrent::torrent_info> TorrentImpl::nativeTorrentInfo() const
 {
     Q_ASSERT(!m_nativeStatus.torrent_file.expired());
@@ -1913,6 +1931,9 @@ void TorrentImpl::endReceivedMetadataHandling(const Path &savePath, const PathLi
 
     p.save_path = savePath.toString().toStdString();
     p.ti = metadata;
+
+    // Paths are now on this torrent object; pending add reservation is no longer needed.
+    m_session->clearPendingAddPayload(id());
 
     if (stopCondition() == StopCondition::MetadataReceived)
     {
@@ -2251,6 +2272,28 @@ void TorrentImpl::handleSaveResumeData(lt::add_torrent_params params)
                 filePaths[i] = Path(it->second);
         }
 
+        // Uniquify under current + final + incomplete roots (including existing renames).
+        // Match add-path policy: skip-checking / seed-mode must not silently rename.
+        const bool allowPayloadRename = !static_cast<bool>(m_ltAddTorrentParams.flags & lt::torrent_flags::seed_mode);
+        const Path currentRoot = actualStorageLocation().isEmpty()
+                ? ((downloadPath().isEmpty() || isFinished() || m_hasFinishedStatus) ? savePath() : downloadPath())
+                : actualStorageLocation();
+        const PathList storageRoots = uniqueStorageRoots({currentRoot, savePath(), downloadPath()});
+        const auto isTaken = [this](const Path &physicalPath) -> bool
+        {
+            return m_session->isPhysicalPayloadPathTaken(physicalPath, id());
+        };
+        const auto resolveResult = uniquifyPayloadPaths(storageRoots, std::move(filePaths), allowPayloadRename, isTaken);
+        if (!resolveResult)
+        {
+            LogMsg(tr("Failed to apply torrent metadata. Torrent: \"%1\". Reason: \"%2\".")
+                    .arg(name(), resolveResult.error()), Log::WARNING);
+            m_maintenanceJob = MaintenanceJob::None;
+            return;
+        }
+        filePaths = resolveResult.value();
+        m_session->reservePendingAddPayload(id(), storageRoots, filePaths);
+
         m_session->findIncompleteFiles(savePath(), downloadPath(), filePaths).then(this
                 , [this](const FileSearchResult &result)
         {
@@ -2415,6 +2458,9 @@ void TorrentImpl::handleFileRenamed(const lt::file_index_t nativeFileIndex, cons
                     m_session->handleTorrentContentFolderRenamingFailed(this, folderRenameInfo.newFolderPath
                             , folderRenameInfo.oldFolderPath, folderRenameInfo.renamedFiles, folderRenameInfo.failedFileIndexes);
                 }
+
+                if (!m_payloadRenameReservationTokens.isEmpty())
+                    m_session->endPayloadRenameReservation(m_payloadRenameReservationTokens.dequeue());
             }
         }
         else
@@ -2422,6 +2468,9 @@ void TorrentImpl::handleFileRenamed(const lt::file_index_t nativeFileIndex, cons
             emit fileRenamed(fileIndex, oldFilePath);
 
             m_session->handleTorrentContentFileRenamed(this, fileIndex, oldFilePath);
+
+            if (!m_payloadRenameReservationTokens.isEmpty())
+                m_session->endPayloadRenameReservation(m_payloadRenameReservationTokens.dequeue());
         }
     }
 
@@ -2452,7 +2501,14 @@ void TorrentImpl::handleFileRenameFailed(const lt::file_index_t nativeFileIndex)
 
             m_session->handleTorrentContentFolderRenamingFailed(this, folderRenameInfo.newFolderPath
                     , folderRenameInfo.oldFolderPath, folderRenameInfo.renamedFiles, folderRenameInfo.failedFileIndexes);
+
+            if (!m_payloadRenameReservationTokens.isEmpty())
+                m_session->endPayloadRenameReservation(m_payloadRenameReservationTokens.dequeue());
         }
+    }
+    else if (!m_payloadRenameReservationTokens.isEmpty())
+    {
+        m_session->endPayloadRenameReservation(m_payloadRenameReservationTokens.dequeue());
     }
 
     while (!isMoveInProgress() && m_renamingFiles.isEmpty() && !m_moveFinishedTriggers.isEmpty())

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -310,6 +310,7 @@ namespace BitTorrent
 
         void doRenameFile(int index, const Path &path, int folderRenameJobID = -1);
         void doRenameFolder(const Path &oldFolderPath, const Path &newFolderPath) override;
+        void prepareContentRename(const Path &oldPath, const Path &newPath) override;
 
         Path makeActualPath(int index, const Path &path) const;
         Path makeUserPath(const Path &path) const;
@@ -356,6 +357,8 @@ namespace BitTorrent
         QQueue<FileRenameInfo> m_renamingFiles;
         QQueue<FolderRenameInfo> m_renamingFolders;
         int m_nextFolderRenameJobID = 0;
+        // Pending physical payload reservations for in-flight renames (session tokens).
+        QQueue<qint64> m_payloadRenameReservationTokens;
 
         QQueue<EventTrigger> m_statusUpdatedTriggers;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(testFiles
     testglobal.cpp
     testorderedset.cpp
     testpath.cpp
+    testtoplevelpayload.cpp
     testutilsbytearray.cpp
     testutilscompare.cpp
     testutilsdatetime.cpp

--- a/test/testtoplevelpayload.cpp
+++ b/test/testtoplevelpayload.cpp
@@ -1,0 +1,226 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  The qBittorrent project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QObject>
+#include <QSet>
+#include <QTest>
+
+#include "base/bittorrent/toplevelpayload.h"
+#include "base/global.h"
+#include "base/path.h"
+
+using namespace BitTorrent;
+
+namespace
+{
+    class Occupied final
+    {
+    public:
+        void add(const PathList &roots, const PathList &files)
+        {
+            m_paths.unite(payloadClaimPaths(roots, files));
+        }
+
+        void add(const Path &root, const PathList &files)
+        {
+            add(PathList {root}, files);
+        }
+
+        bool taken(const Path &path) const
+        {
+            return isPayloadPathTaken(path, m_paths);
+        }
+
+        nonstd::expected<PathList, QString> uniquify(const PathList &roots, PathList files, const bool allowRename) const
+        {
+            return uniquifyPayloadPaths(roots, std::move(files), allowRename
+                    , [this](const Path &p) { return taken(p); });
+        }
+
+    private:
+        QSet<Path> m_paths;
+    };
+}
+
+class TestTopLevelPayload final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestTopLevelPayload)
+
+public:
+    TestTopLevelPayload() = default;
+
+private slots:
+    void testIncompleteAndFinalBothReserved() const
+    {
+        // Torrent A downloading in /tmp/qbit with final /disk2/anime
+        Occupied occ;
+        const PathList aRoots {Path(u"/tmp/qbit"_s), Path(u"/disk2/anime"_s)};
+        const PathList layout {Path(u"Show/ep.mkv"_s)};
+        occ.add(aRoots, layout);
+
+        // Second torrent targets final path /disk2/anime/Show → must rename
+        const auto r = occ.uniquify({Path(u"/disk2/anime"_s)}, layout, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(Path::findRootFolder(r.value()).toString(), u"Show (1)"_s);
+    }
+
+    void testDifferentFinalAndIncompleteNoRename() const
+    {
+        Occupied occ;
+        occ.add({Path(u"/tmp/a"_s), Path(u"/disk/a"_s)}, {Path(u"Show/x.mkv"_s)});
+
+        // Different incomplete + different final → no collision
+        const auto r = occ.uniquify({Path(u"/tmp/b"_s), Path(u"/disk/b"_s)}, {Path(u"Show/x.mkv"_s)}, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(Path::findRootFolder(r.value()).toString(), u"Show"_s);
+    }
+
+    void testSharedIncompleteForcesRename() const
+    {
+        // Same incomplete dir, different finals — incomplete still collides
+        Occupied occ;
+        occ.add({Path(u"/tmp/qbit"_s), Path(u"/disk/a"_s)}, {Path(u"Show/x.mkv"_s)});
+
+        const auto r = occ.uniquify({Path(u"/tmp/qbit"_s), Path(u"/disk/b"_s)}, {Path(u"Show/y.mkv"_s)}, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(Path::findRootFolder(r.value()).toString(), u"Show (1)"_s);
+    }
+
+    void testNameMustBeFreeUnderAllRoots() const
+    {
+        Occupied occ;
+        // Only final path has Show (1); incomplete is free for Show (1)
+        occ.add(Path(u"/disk2/anime"_s), {Path(u"Show (1)/a.mkv"_s)});
+
+        // First torrent wants free "Show" under both roots
+        const PathList roots {Path(u"/tmp/qbit"_s), Path(u"/disk2/anime"_s)};
+        // Occupied has Show free at both? Show free. Good.
+        // Candidate Show (1) taken on final only → findFreeName for rename from Show when Show taken...
+
+        occ.add(Path(u"/tmp/qbit"_s), {Path(u"Show/a.mkv"_s)});
+        // Now Show taken on incomplete; final Show free. uniquify must rename.
+        // Show (1) taken on final → need Show (2)
+        const auto r = occ.uniquify(roots, {Path(u"Show/b.mkv"_s)}, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(Path::findRootFolder(r.value()).toString(), u"Show (2)"_s);
+    }
+
+    void testRootFolderRename() const
+    {
+        Occupied occ;
+        occ.add(Path(u"/d"_s), {Path(u"Show/a.mkv"_s)});
+        const auto r = occ.uniquify({Path(u"/d"_s)}, {Path(u"Show/b.mkv"_s)}, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(Path::findRootFolder(r.value()).toString(), u"Show (1)"_s);
+    }
+
+    void testSingleFile() const
+    {
+        Occupied occ;
+        occ.add(Path(u"/d"_s), {Path(u"movie.mkv"_s)});
+        const auto r = occ.uniquify({Path(u"/d"_s)}, {Path(u"movie.mkv"_s)}, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(r.value().at(0), Path(u"movie (1).mkv"_s));
+    }
+
+    void testRootlessWrap() const
+    {
+        Occupied occ;
+        occ.add(Path(u"/d"_s), {Path(u"episode.mkv"_s)});
+        const auto r = occ.uniquify({Path(u"/d"_s)}, {
+            Path(u"episode.mkv"_s), Path(u"sub.srt"_s)
+        }, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(Path::findRootFolder(r.value()).toString(), u"episode"_s);
+    }
+
+    void testSkipCheckRejects() const
+    {
+        Occupied occ;
+        occ.add(Path(u"/d"_s), {Path(u"Show/a.mkv"_s)});
+        QVERIFY(!occ.uniquify({Path(u"/d"_s)}, {Path(u"Show/b.mkv"_s)}, false).has_value());
+    }
+
+    void testMagnetSkipCheckingMetadataRejectsOccupiedPath() const
+    {
+        // Magnet added with skip-checking/seed-mode: allowRename=false when metadata arrives.
+        Occupied occ;
+        occ.add(Path(u"/d"_s), {Path(u"Show/existing.mkv"_s)});
+
+        const auto renamed = occ.uniquify({Path(u"/d"_s)}, {Path(u"Show/from-magnet.mkv"_s)}, true);
+        QVERIFY(renamed.has_value());
+        QCOMPARE(Path::findRootFolder(renamed.value()).toString(), u"Show (1)"_s);
+
+        const auto seedMode = occ.uniquify({Path(u"/d"_s)}, {Path(u"Show/from-magnet.mkv"_s)}, false);
+        QVERIFY(!seedMode.has_value());
+    }
+
+    void testSameTorrentPendingRenamesCannotShareDestination() const
+    {
+        // Simulates isPhysicalPayloadPathTaken without skipping same-torrent pending renames.
+        Occupied occ;
+        const Path root {u"/d"_s};
+        // First rename reserved the proposed layout claiming result.mkv
+        occ.add(root, {Path(u"result.mkv"_s), Path(u"b.mkv"_s)});
+
+        // Second rename from the same torrent also wants result.mkv as a new claim.
+        // Newly introduced path must still see the pending reservation as occupied.
+        QVERIFY(occ.taken(Path(u"/d/result.mkv"_s)));
+
+        const PathList current {Path(u"a.mkv"_s), Path(u"b.mkv"_s)};
+        const PathList proposed = applyContentRename(current, Path(u"b.mkv"_s), Path(u"result.mkv"_s));
+        const QSet<Path> currentClaims = payloadClaimPaths(root, current);
+        const QSet<Path> proposedClaims = payloadClaimPaths(root, proposed);
+
+        bool canReserve = true;
+        for (const Path &path : asConst(proposedClaims))
+        {
+            if (isPayloadPathTaken(path, currentClaims))
+                continue;
+            if (occ.taken(path))
+            {
+                canReserve = false;
+                break;
+            }
+        }
+        QVERIFY(!canReserve);
+    }
+
+    void testNestedLayoutCollision() const
+    {
+        Occupied occ;
+        occ.add(Path(u"/d/Show"_s), {Path(u"episode.mkv"_s)});
+        const auto r = occ.uniquify({Path(u"/d"_s)}, {Path(u"Show/episode.mkv"_s)}, true);
+        QVERIFY(r.has_value());
+        QCOMPARE(Path::findRootFolder(r.value()).toString(), u"Show (1)"_s);
+    }
+};
+
+QTEST_APPLESS_MAIN(TestTopLevelPayload)
+#include "testtoplevelpayload.moc"


### PR DESCRIPTION
Closes #12842.

## Problem

Different torrents can resolve their contents to the same physical path. This can mix or overwrite their files, causing data loss and repeated downloads.

For example, two torrents may both try to use:

/downloads/Show/

## Solution

Before adding a torrent, qBittorrent checks whether its top-level payload path is already reserved.

When a collision is found:

a shared root folder is renamed: Show/ → Show (1)/
a single file is renamed while preserving its extension: movie.mkv → movie (1).mkv
a rootless multi-file torrent is placed inside a uniquely named wrapper folder

The selected name is checked against the torrent's current, incomplete, and final save locations.

Paths remain reserved while asynchronous add, rename, removal, or content-deletion operations are pending.

Seed-mode and skip-check torrents are not automatically renamed when their existing data path conflicts.

## Tests

Added coverage for:

shared-root torrents
single-file torrents
rootless multi-file torrents
separate incomplete and final locations
pending additions and removals
payload renames