### PR TITLE
WebUI: Escape translation content that breaks embedded JavaScript

### DIFF
--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -59,6 +59,58 @@ QString Utils::String::fromLocal8Bit(const std::string_view string)
     return QString::fromLocal8Bit(string.data(), string.size());
 }
 
+// Escape a translation for safe embedding in a JavaScript string literal (`"` is escaped by the caller).
+QString Utils::String::escapeJSStringHazards(const QString &str)
+{
+    QString result;
+    result.reserve(str.size());
+    for (qsizetype i = 0; i < str.size(); ++i)
+    {
+        const char16_t c = str[i].unicode();
+        switch (c)
+        {
+        case u'\\':
+            // keep `\n`/`\t` (source strings rely on them), escape any other backslash
+            if (((i + 1) < str.size()) && ((str[i + 1] == u'n') || (str[i + 1] == u't')))
+                result += u'\\';
+            else
+                result += u"\\\\"_s;
+            break;
+        case u'\'':
+            result += u"\\'"_s;
+            break;
+        case u'\n':
+            result += u"\\n"_s;
+            break;
+        case u'\r':
+            result += u"\\r"_s;
+            break;
+        case u'\u2028': // line separator
+            result += u"\\u2028"_s;
+            break;
+        case u'\u2029': // paragraph separator
+            result += u"\\u2029"_s;
+            break;
+        case u'<':
+            result += u"\\u003C"_s;
+            break;
+        case u'`':
+            result += u"\\`"_s;
+            break;
+        case u'$':
+            if (((i + 1) < str.size()) && (str[i + 1] == u'{'))
+                result += u"\\$"_s;
+            else
+                result += u'$';
+            break;
+        default:
+            result += str[i];
+            break;
+        }
+    }
+    return result;
+}
+
 QString Utils::String::wildcardToRegexPattern(const QString &pattern)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 1))

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -71,6 +71,8 @@ namespace Utils::String
     QString fromLatin1(std::string_view string);
     QString fromLocal8Bit(std::string_view string);
 
+    QString escapeJSStringHazards(const QString &str);
+
     template <typename Container>
     QString joinIntoString(const Container &container, const QString &separator)
         requires ExplicitlyConvertibleTo<typename Container::value_type, QString>

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -252,10 +252,14 @@ void WebApplication::sendWebUIFile(const Http::HeaderMap &commonHeaders, Http::R
     sendFile(localPath, commonHeaders, responseWriter);
 }
 
-void WebApplication::translateDocument(QString &data) const
+void WebApplication::translateDocument(QString &data, const bool isJavaScript) const
 {
     data.replace(u"${LANG}"_s, m_currentLocale.left(2));
     data.replace(u"${CACHEID}"_s, m_cacheID);
+
+    // translations inside a <script> block (or a .js file) are JS-escaped below. See issue #23488
+    bool inScript = isJavaScript;
+    qsizetype scannedPos = 0;
 
     qsizetype i = 0;
     bool found = true;
@@ -265,6 +269,22 @@ void WebApplication::translateDocument(QString &data) const
         i = data.indexOf(m_trRegex, i, &regexMatch);
         if (i >= 0)
         {
+            // advance the <script> scan up to this match (scannedPos only moves forward: O(n) total)
+            if (!isJavaScript)
+            {
+                for (; scannedPos < i; ++scannedPos)
+                {
+                    if (data[scannedPos] != u'<')
+                        continue;
+
+                    const QStringView rest = QStringView(data).sliced(scannedPos);
+                    if (rest.startsWith(u"<script", Qt::CaseInsensitive))
+                        inScript = true;
+                    else if (rest.startsWith(u"</script", Qt::CaseInsensitive))
+                        inScript = false;
+                }
+            }
+
             const QStringView sourceText = regexMatch.capturedView(1);
             const QStringView context = regexMatch.capturedView(3);
 
@@ -281,8 +301,12 @@ void WebApplication::translateDocument(QString &data) const
             // 2. The escaped quote/string is wrong for JS. JS use backslash to escape the quote: "\""
             translation.replace(u'"', u"&#34;"_s);
 
+            if (inScript)
+                translation = Utils::String::escapeJSStringHazards(translation);
+
             data.replace(i, regexMatch.capturedLength(), translation);
             i += translation.length();
+            scannedPos = i; // don't rescan the substituted translation
         }
         else
         {
@@ -663,7 +687,7 @@ void WebApplication::sendFile(const Path &path, const Http::HeaderMap &commonHea
     {
         auto dataStr = QString::fromUtf8(data);
         // Translate the file
-        translateDocument(dataStr);
+        translateDocument(dataStr, path.hasExtension(u".js"_s));
 
         // Add the language options
         if (path == (m_rootFolder / Path(PRIVATE_FOLDER) / Path(u"views/preferences.html"_s)))

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -107,7 +107,7 @@ private:
     void sendFile(const Path &path, const Http::HeaderMap &commonHeaders, Http::ResponseWriter &responseWriter);
     void sendWebUIFile(const Http::HeaderMap &commonHeaders, Http::ResponseWriter &responseWriter);
 
-    void translateDocument(QString &data) const;
+    void translateDocument(QString &data, bool isJavaScript) const;
 
     // Session management
     QString generateSid() const;

--- a/test/testutilsstring.cpp
+++ b/test/testutilsstring.cpp
@@ -90,6 +90,66 @@ private slots:
         QCOMPARE(Utils::String::splitCommand(u"   cmd.exe /d --arg2 \"arg3\" \"\" arg5 \"\"arg6 \"arg7 "_s)
             , QStringList({u"cmd.exe"_s, u"/d"_s, u"--arg2"_s, u"\"arg3\""_s, u"\"\""_s, u"arg5"_s, u"\"\"arg6"_s, u"\"arg7 "_s}));
     }
+
+    void testEscapeJSStringHazards() const
+    {
+        using Utils::String::escapeJSStringHazards;
+
+        // unchanged: plain text, non-ASCII, raw tab (legal in JS)
+        QCOMPARE(escapeJSStringHazards(u""_s), u""_s);
+        QCOMPARE(escapeJSStringHazards(u"Hello world"_s), u"Hello world"_s);
+        QCOMPARE(escapeJSStringHazards(u"café 中文"_s), u"café 中文"_s);
+        QCOMPARE(escapeJSStringHazards(u"a\tb"_s), u"a\tb"_s);
+
+        // raw line terminators escaped (the #23488 fix)
+        QCOMPARE(escapeJSStringHazards(u"a\nb"_s), u"a\\nb"_s);
+        QCOMPARE(escapeJSStringHazards(u"a\rb"_s), u"a\\rb"_s);
+        QCOMPARE(escapeJSStringHazards(u"a\r\nb"_s), u"a\\r\\nb"_s);
+        QCOMPARE(escapeJSStringHazards(u"trailing\n"_s), u"trailing\\n"_s);
+        QCOMPARE(escapeJSStringHazards(QString(QChar(0x2028))), u"\\u2028"_s);
+        QCOMPARE(escapeJSStringHazards(QString(QChar(0x2029))), u"\\u2029"_s);
+
+        // `<` escaped, so a "</script>" can't end the element
+        QCOMPARE(escapeJSStringHazards(u"</script>"_s), u"\\u003C/script>"_s);
+        QCOMPARE(escapeJSStringHazards(u"a<br>b"_s), u"a\\u003Cbr>b"_s);
+        QCOMPARE(escapeJSStringHazards(u"</script><script>x</script>"_s),
+            u"\\u003C/script>\\u003Cscript>x\\u003C/script>"_s);
+
+        // template literals: backtick and "${" escaped; lone '$' not
+        QCOMPARE(escapeJSStringHazards(u"a`b"_s), u"a\\`b"_s);
+        QCOMPARE(escapeJSStringHazards(u"`"_s), u"\\`"_s);
+        QCOMPARE(escapeJSStringHazards(u"${x}"_s), u"\\${x}"_s);
+        QCOMPARE(escapeJSStringHazards(u"a${b}c${d}"_s), u"a\\${b}c\\${d}"_s);
+        QCOMPARE(escapeJSStringHazards(u"5$ each"_s), u"5$ each"_s);
+        QCOMPARE(escapeJSStringHazards(u"ends$"_s), u"ends$"_s);
+        QCOMPARE(escapeJSStringHazards(u"$var"_s), u"$var"_s);
+
+        // single quote escaped
+        QCOMPARE(escapeJSStringHazards(u"it's"_s), u"it\\'s"_s);
+        QCOMPARE(escapeJSStringHazards(u"''"_s), u"\\'\\'"_s);
+
+        // `\n`/`\t` escapes pass through
+        QCOMPARE(escapeJSStringHazards(uR"(line1\nline2)"_s), uR"(line1\nline2)"_s);
+        QCOMPARE(escapeJSStringHazards(uR"(col1\tcol2)"_s), uR"(col1\tcol2)"_s);
+        QCOMPARE(escapeJSStringHazards(uR"(\n\t)"_s), uR"(\n\t)"_s);
+
+        // any other backslash escaped (trailing, or invalid \x/\u)
+        QCOMPARE(escapeJSStringHazards(uR"(path\)"_s), uR"(path\\)"_s);
+        QCOMPARE(escapeJSStringHazards(uR"(\\)"_s), uR"(\\\\)"_s);
+        QCOMPARE(escapeJSStringHazards(uR"(\x41)"_s), uR"(\\x41)"_s);
+        QCOMPARE(escapeJSStringHazards(uR"(\u12)"_s), uR"(\\u12)"_s);
+        QCOMPARE(escapeJSStringHazards(uR"(a\rb)"_s), uR"(a\\rb)"_s);
+        QCOMPARE(escapeJSStringHazards(uR"(\0)"_s), uR"(\\0)"_s);
+
+        // double quote is left to the caller
+        QCOMPARE(escapeJSStringHazards(uR"(say "hi")"_s), uR"(say "hi")"_s);
+
+        // combinations
+        QCOMPARE(escapeJSStringHazards(u"a\n\\nb"_s), u"a\\n\\nb"_s); // raw newline next to a `\n` escape
+        QCOMPARE(escapeJSStringHazards(u"c'est\nfini"_s), u"c\\'est\\nfini"_s);
+        QCOMPARE(escapeJSStringHazards(u"${fetch('/x')}"_s), u"\\${fetch(\\'/x\\')}"_s);
+        QCOMPARE(escapeJSStringHazards(u"'`<${\n"_s), u"\\'\\`\\u003C\\${\\n"_s);
+    }
 };
 
 QTEST_APPLESS_MAIN(TestUtilsString)


### PR DESCRIPTION
Translations are substituted verbatim into served files, including into JavaScript string literals. A raw newline, `</script>`, stray backtick, `${`, quote, or backslash breaks the whole `<script>`. We now escape those characters when the substitution target is JavaScript, leaving the `\n` and `\t` escapes that source strings rely on intact.

Closes #23488.
Closes #24648.