### PR TITLE
Reference torrent "seed mode" by its exact name

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -2,6 +2,9 @@
 
 ## 2.16.0
 
+* [#24724](https://github.com/qbittorrent/qBittorrent/pull/24724)
+  * `torrents/add` endpoint accepts `seedMode` (bool) parameter
+  * `torrents/add` endpoint no longer accepts `skip_checking` parameter
 * [#24641](https://github.com/qbittorrent/qBittorrent/pull/24641)
   * `app/preferences` and `app/setPreferences` endpoints no longer include `export_dir` and `export_dir_fin` options as they are no longer supported by the core
   * `app/preferences` and `app/setPreferences` endpoints include the following new options:

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -138,7 +138,7 @@ namespace
     const QString PARAM_FIRSTLASTPIECEPRIORITY = u"@firstLastPiecePriority"_s;
     const QString PARAM_SAVEPATH = u"@savePath"_s;
     const QString PARAM_SEQUENTIAL = u"@sequential"_s;
-    const QString PARAM_SKIPCHECKING = u"@skipChecking"_s;
+    const QString PARAM_SEEDMODE = u"@seedMode"_s;
     const QString PARAM_SKIPDIALOG = u"@skipDialog"_s;
 
 #if !defined(DISABLE_GUI) && defined(Q_OS_WIN)
@@ -209,8 +209,8 @@ namespace
         if (addTorrentParams.addStopped.has_value())
             result.append(bindParamValue(PARAM_ADDSTOPPED, (*addTorrentParams.addStopped ? u"1" : u"0")));
 
-        if (addTorrentParams.skipChecking)
-            result.append(PARAM_SKIPCHECKING);
+        if (addTorrentParams.seedMode)
+            result.append(PARAM_SEEDMODE);
 
         if (!addTorrentParams.category.isEmpty())
             result.append(bindParamValue(PARAM_CATEGORY, addTorrentParams.category));
@@ -253,9 +253,9 @@ namespace
                 continue;
             }
 
-            if (paramName == PARAM_SKIPCHECKING)
+            if (paramName == PARAM_SEEDMODE)
             {
-                addTorrentParams.skipChecking = true;
+                addTorrentParams.seedMode = true;
                 continue;
             }
 

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -322,7 +322,7 @@ namespace
     constexpr const BoolOption RELATIVE_FASTRESUME {u"relative-fastresume"};
     constexpr const StringOption SAVE_PATH_OPTION {u"save-path"};
     constexpr const TriStateBoolOption STOPPED_OPTION {u"add-stopped", true};
-    constexpr const BoolOption SKIP_HASH_CHECK_OPTION {u"skip-hash-check"};
+    constexpr const BoolOption SEED_MODE_OPTION {u"seed-mode"};
     constexpr const StringOption CATEGORY_OPTION {u"category"};
     constexpr const BoolOption SEQUENTIAL_OPTION {u"sequential"};
     constexpr const BoolOption FIRST_AND_LAST_OPTION {u"first-and-last"};
@@ -398,7 +398,7 @@ namespace
             + wrapText(QCoreApplication::translate("CMD Options", "Options when adding new torrents:"), 0) + u'\n'
             + SAVE_PATH_OPTION.usage(QCoreApplication::translate("CMD Options", "path")) + wrapText(QCoreApplication::translate("CMD Options", "Torrent save path")) + u'\n'
                              + STOPPED_OPTION.usage() + wrapText(QCoreApplication::translate("CMD Options", "Add torrents as running or stopped")) + u'\n'
-            + SKIP_HASH_CHECK_OPTION.usage() + wrapText(QCoreApplication::translate("CMD Options", "Skip hash check")) + u'\n'
+            + SEED_MODE_OPTION.usage() + wrapText(QCoreApplication::translate("CMD Options", "Seed mode")) + u'\n'
             + CATEGORY_OPTION.usage(QCoreApplication::translate("CMD Options", "name"))
             + wrapText(QCoreApplication::translate("CMD Options", "Assign torrents to category. If the category doesn't exist, it will be "
                                     "created.")) + u'\n'
@@ -437,7 +437,7 @@ QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &en
 {
     addTorrentParams.savePath = Path(SAVE_PATH_OPTION.value(env));
     addTorrentParams.category = CATEGORY_OPTION.value(env);
-    addTorrentParams.skipChecking = SKIP_HASH_CHECK_OPTION.value(env);
+    addTorrentParams.seedMode = SEED_MODE_OPTION.value(env);
     addTorrentParams.sequential = SEQUENTIAL_OPTION.value(env);
     addTorrentParams.firstLastPiecePriority = FIRST_AND_LAST_OPTION.value(env);
     addTorrentParams.addStopped = STOPPED_OPTION.value(env);
@@ -514,9 +514,9 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
             {
                 result.addTorrentParams.addStopped = STOPPED_OPTION.value(arg);
             }
-            else if (arg == SKIP_HASH_CHECK_OPTION)
+            else if (arg == SEED_MODE_OPTION)
             {
-                result.addTorrentParams.skipChecking = true;
+                result.addTorrentParams.seedMode = true;
             }
             else if (arg == CATEGORY_OPTION)
             {

--- a/src/base/bittorrent/addtorrentparams.cpp
+++ b/src/base/bittorrent/addtorrentparams.cpp
@@ -44,7 +44,7 @@ const QString PARAM_OPERATINGMODE = u"operating_mode"_s;
 const QString PARAM_QUEUETOP = u"add_to_top_of_queue"_s;
 const QString PARAM_STOPPED = u"stopped"_s;
 const QString PARAM_STOPCONDITION = u"stop_condition"_s;
-const QString PARAM_SKIPCHECKING = u"skip_checking"_s;
+const QString PARAM_SEEDMODE = u"seed_mode"_s;
 const QString PARAM_CONTENTLAYOUT = u"content_layout"_s;
 const QString PARAM_AUTOTMM = u"use_auto_tmm"_s;
 const QString PARAM_UPLOADLIMIT = u"upload_limit"_s;
@@ -57,6 +57,8 @@ const QString PARAM_SHARELIMITSMODE = u"share_limits_mode"_s;
 const QString PARAM_SSL_CERTIFICATE = u"ssl_certificate"_s;
 const QString PARAM_SSL_PRIVATEKEY = u"ssl_private_key"_s;
 const QString PARAM_SSL_DHPARAMS = u"ssl_dh_params"_s;
+
+const QString DEPRECATED_PARAM_SKIP_CHECKING = u"skip_checking"_s;
 
 namespace
 {
@@ -107,6 +109,8 @@ namespace
 
 BitTorrent::AddTorrentParams BitTorrent::parseAddTorrentParams(const QJsonObject &jsonObj)
 {
+    const QJsonValue seedModeValue = jsonObj.value(PARAM_SEEDMODE);
+
     const AddTorrentParams params
     {
         .name = {},
@@ -121,7 +125,7 @@ BitTorrent::AddTorrentParams BitTorrent::parseAddTorrentParams(const QJsonObject
         .stopCondition = getOptionalEnum<Torrent::StopCondition>(jsonObj, PARAM_STOPCONDITION),
         .filePaths = {},
         .filePriorities = {},
-        .skipChecking = jsonObj.value(PARAM_SKIPCHECKING).toBool(),
+        .seedMode = seedModeValue.toBool(jsonObj.value(DEPRECATED_PARAM_SKIP_CHECKING).toBool()),
         .contentLayout = getOptionalEnum<TorrentContentLayout>(jsonObj, PARAM_CONTENTLAYOUT),
         .useAutoTMM = getOptionalBool(jsonObj, PARAM_AUTOTMM),
         .uploadLimit = jsonObj.value(PARAM_UPLOADLIMIT).toInt(-1),
@@ -154,7 +158,7 @@ QJsonObject BitTorrent::serializeAddTorrentParams(const AddTorrentParams &params
         {PARAM_DOWNLOADPATH, params.downloadPath.data()},
         {PARAM_OPERATINGMODE, Utils::String::fromEnum(params.addForced
                 ? TorrentOperatingMode::Forced : TorrentOperatingMode::AutoManaged)},
-        {PARAM_SKIPCHECKING, params.skipChecking},
+        {PARAM_SEEDMODE, params.seedMode},
         {PARAM_UPLOADLIMIT, params.uploadLimit},
         {PARAM_DOWNLOADLIMIT, params.downloadLimit},
         {PARAM_RATIOLIMIT, params.shareLimits.ratioLimit},

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -63,7 +63,7 @@ namespace BitTorrent
         std::optional<Torrent::StopCondition> stopCondition;
         PathList filePaths; // used if TorrentInfo is set
         QList<DownloadPriority> filePriorities; // used if TorrentInfo is set
-        bool skipChecking = false;
+        bool seedMode = false;
         std::optional<BitTorrent::TorrentContentLayout> contentLayout;
         std::optional<bool> useAutoTMM;
         int uploadLimit = -1;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2787,7 +2787,7 @@ LoadTorrentParams SessionImpl::initLoadTorrentParams(const AddTorrentParams &add
 
     loadTorrentParams.name = addTorrentParams.name;
     loadTorrentParams.firstLastPiecePriority = addTorrentParams.firstLastPiecePriority;
-    loadTorrentParams.hasFinishedStatus = addTorrentParams.skipChecking; // do not react on 'torrent_finished_alert' when skipping
+    loadTorrentParams.hasFinishedStatus = addTorrentParams.seedMode; // do not react on 'torrent_finished_alert' when skipping
     loadTorrentParams.contentLayout = addTorrentParams.contentLayout.value_or(torrentContentLayout());
     loadTorrentParams.operatingMode = (addTorrentParams.addForced ? TorrentOperatingMode::Forced : TorrentOperatingMode::AutoManaged);
     loadTorrentParams.stopped = addTorrentParams.addStopped.value_or(isAddTorrentStopped());
@@ -3042,7 +3042,7 @@ bool SessionImpl::addTorrent_impl(const TorrentDescriptor &torrentDescr, const A
 
     // Seeding mode
     // Skip checking and directly start seeding
-    if (addTorrentParams.skipChecking)
+    if (addTorrentParams.seedMode)
         p.flags |= lt::torrent_flags::seed_mode;
     else
         p.flags &= ~lt::torrent_flags::seed_mode;

--- a/src/base/bittorrent/torrentcreationtask.cpp
+++ b/src/base/bittorrent/torrentcreationtask.cpp
@@ -67,7 +67,7 @@ BitTorrent::TorrentCreationTask::TorrentCreationTask(IApplication *app, const QS
         params.addStopped = false;
         params.contentLayout = BitTorrent::TorrentContentLayout::Original;
         params.savePath = result.savePath;
-        params.skipChecking = true;
+        params.seedMode = true;
         params.stopCondition = BitTorrent::Torrent::StopCondition::None;
         params.useAutoTMM = false;  // otherwise if it is on by default, it will overwrite `savePath` to the default save path
         params.useDownloadPath = false;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -352,7 +352,7 @@ void AddNewTorrentDialog::setCurrentContext(const std::shared_ptr<Context> conte
             static_cast<int>(addTorrentParams.contentLayout.value_or(session->torrentContentLayout())));
     m_ui->sequentialCheckBox->setChecked(addTorrentParams.sequential);
     m_ui->firstLastCheckBox->setChecked(addTorrentParams.firstLastPiecePriority);
-    m_ui->skipCheckingCheckBox->setChecked(addTorrentParams.skipChecking);
+    m_ui->seedModeCheckBox->setChecked(addTorrentParams.seedMode);
     m_ui->tagsLineEdit->setText(Utils::String::joinIntoString(addTorrentParams.tags, u", "_s));
 
     // Load categories
@@ -434,7 +434,7 @@ void AddNewTorrentDialog::updateCurrentContext()
 
     BitTorrent::AddTorrentParams &addTorrentParams = m_currentContext->torrentParams;
 
-    addTorrentParams.skipChecking = m_ui->skipCheckingCheckBox->isChecked();
+    addTorrentParams.seedMode = m_ui->seedModeCheckBox->isChecked();
 
     // Category
     addTorrentParams.category = m_ui->categoryComboBox->currentText();

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -285,9 +285,12 @@
                  </widget>
                 </item>
                 <item row="1" column="1">
-                 <widget class="QCheckBox" name="skipCheckingCheckBox">
+                 <widget class="QCheckBox" name="seedModeCheckBox">
                   <property name="text">
-                   <string>Skip hash check</string>
+                   <string>Seed mode</string>
+                  </property>
+                  <property name="toolTip">
+                   <string>&lt;p&gt;If set, qBittorrent will assume that all files are present for this torrent and that they all match the hashes in the torrent file. The use case for this mode is if a torrent is created and seeded, or if the user already knows that all the files are complete, this is a way to perform only basic file checks and skip initial hash checks.&lt;/p&gt;&lt;p&gt;The piece hash will be checked when it is requested for the first time by a peer. If a hash check fails, all files in this torrent will be rechecked.&lt;/p&gt;</string>
                   </property>
                  </widget>
                 </item>

--- a/src/gui/addtorrentparamswidget.cpp
+++ b/src/gui/addtorrentparamswidget.cpp
@@ -121,8 +121,8 @@ AddTorrentParamsWidget::AddTorrentParamsWidget(BitTorrent::AddTorrentParams addT
     auto *miscParamsLayout = new FlowLayout(m_ui->miscParamsWidget);
     miscParamsLayout->setContentsMargins(0, 0, 0, 0);
     miscParamsLayout->addWidget(m_ui->contentLayoutWidget);
-    miscParamsLayout->addWidget(m_ui->skipCheckingCheckBox);
-    miscParamsLayout->setAlignment(m_ui->skipCheckingCheckBox, Qt::AlignVCenter);
+    miscParamsLayout->addWidget(m_ui->seedModeCheckBox);
+    miscParamsLayout->setAlignment(m_ui->seedModeCheckBox, Qt::AlignVCenter);
     miscParamsLayout->addWidget(m_ui->startTorrentWidget);
     miscParamsLayout->addWidget(m_ui->stopConditionWidget);
     miscParamsLayout->addWidget(m_ui->addToQueueTopWidget);
@@ -253,11 +253,11 @@ void AddTorrentParamsWidget::populate()
             m_addTorrentParams.addStopped = !data.toBool();
     });
 
-    m_ui->skipCheckingCheckBox->disconnect(this);
-    m_ui->skipCheckingCheckBox->setChecked(m_addTorrentParams.skipChecking);
-    connect(m_ui->skipCheckingCheckBox, &QCheckBox::toggled, this, [this]
+    m_ui->seedModeCheckBox->disconnect(this);
+    m_ui->seedModeCheckBox->setChecked(m_addTorrentParams.seedMode);
+    connect(m_ui->seedModeCheckBox, &QCheckBox::toggled, this, [this]
     {
-        m_addTorrentParams.skipChecking = m_ui->skipCheckingCheckBox->isChecked();
+        m_addTorrentParams.seedMode = m_ui->seedModeCheckBox->isChecked();
     });
 
     m_ui->addToQueueTopComboBox->disconnect(this);

--- a/src/gui/addtorrentparamswidget.ui
+++ b/src/gui/addtorrentparamswidget.ui
@@ -333,7 +333,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QCheckBox" name="skipCheckingCheckBox">
+     <widget class="QCheckBox" name="seedModeCheckBox">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -343,7 +343,10 @@
        </rect>
       </property>
       <property name="text">
-       <string>Skip hash check</string>
+       <string>Seed mode</string>
+      </property>
+      <property name="toolTip">
+       <string>&lt;p&gt;If set, qBittorrent will assume that all files are present for this torrent and that they all match the hashes in the torrent file. The use case for this mode is if a torrent is created and seeded, or if the user already knows that all the files are complete, this is a way to perform only basic file checks and skip initial hash checks.&lt;/p&gt;&lt;p&gt;The piece hash will be checked when it is requested for the first time by a peer. If a hash check fails, all files in this torrent will be rechecked.&lt;/p&gt;</string>
       </property>
      </widget>
     </widget>

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -360,7 +360,7 @@ void TorrentCreatorDialog::handleCreationSuccess(const BitTorrent::TorrentCreato
             params.addStopped = false;
             params.contentLayout = BitTorrent::TorrentContentLayout::Original;
             params.savePath = result.savePath;
-            params.skipChecking = true;
+            params.seedMode = true;
             params.stopCondition = BitTorrent::Torrent::StopCondition::None;
             params.useAutoTMM = false;  // otherwise if it is on by default, it will overwrite `savePath` to the default save path
             params.useDownloadPath = false;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1082,7 +1082,7 @@ void TorrentsController::addAction()
 {
     const QStringList urls = params()[u"urls"_s].split(u'\n', Qt::SkipEmptyParts);
 
-    const bool skipChecking = parseBool(params()[u"skip_checking"_s]).value_or(false);
+    const bool seedMode = parseBool(params()[u"seedMode"_s]).value_or(false);
     const bool seqDownload = parseBool(params()[u"sequentialDownload"_s]).value_or(false);
     const bool firstLastPiece = parseBool(params()[u"firstLastPiecePrio"_s]).value_or(false);
     const bool addForced = parseBool(params()[u"forced"_s]).value_or(false);
@@ -1154,7 +1154,7 @@ void TorrentsController::addAction()
         .stopCondition = stopCondition,
         .filePaths = {},
         .filePriorities = {},
-        .skipChecking = skipChecking,
+        .seedMode = seedMode,
         .contentLayout = contentLayout,
         .useAutoTMM = autoTMM,
         .uploadLimit = upLimit,

--- a/src/webui/www/private/addtorrent.html
+++ b/src/webui/www/private/addtorrent.html
@@ -269,12 +269,13 @@
                                     <input type="checkbox" id="addToTopOfQueue" name="addToTopOfQueue" value="true">
                                 </td>
                             </tr>
-                            <tr>
+                            <tr title="QBT_TR(If set, qBittorrent will assume that all files are present for this torrent and that they all match the hashes in the torrent file. The use case for this mode is if a torrent is created and seeded, or if the user already knows that all the files are complete, this is a way to perform only basic file checks and skip initial hash checks.
+The piece hash will be checked when it is requested for the first time by a peer. If a hash check fails, all files in this torrent will be rechecked.)QBT_TR[CONTEXT=AddNewTorrentDialog]">
                                 <td class="noWrap">
-                                    <label for="skip_checking">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                                    <label for="seedMode">QBT_TR(Seed mode)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                                 </td>
                                 <td class="fullWidth">
-                                    <input type="checkbox" id="skip_checking" name="skip_checking" value="true">
+                                    <input type="checkbox" id="seedMode" name="seedMode" value="true">
                                 </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
The old name could have created a false impression about it, as "seed mode" is more than just "skip the hash check".

Also adds a tooltip to corresponding options in GUI.

<img width="853" height="208" alt="000" src="https://github.com/user-attachments/assets/26bd571a-9ddd-45b7-8cbb-16147b5fcca9" />
