### PR TITLE
WebUI: do not select invisible rows in dynamicTable.js

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -833,7 +833,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                         this.selectedRows.push(row.rowId);
                     } else {
                         const tr = this.getTrByRowId(row.rowId);
-                        if (tr !== null && !tr.classList.contains("invisible"))
+                        if ((tr !== null) && !tr.classList.contains("invisible"))
                             this.selectedRows.push(row.rowId);
                     }
                 }

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -829,9 +829,13 @@ window.qBittorrent.DynamicTable ??= (() => {
                     this.selectedRows.push(row.rowId);
                 }
                 else if (select) {
-                    const tr = this.getTrByRowId(row.rowId);
-                    if (tr && !tr.classList.contains("invisible"))
+                    if (this.useVirtualList)
                         this.selectedRows.push(row.rowId);
+                    else {
+                        const tr = this.getTrByRowId(row.rowId);
+                        if (tr && !tr.classList.contains("invisible"))
+                            this.selectedRows.push(row.rowId);
+                    }
                 }
             }
             this.setRowClass();

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -831,7 +831,8 @@ window.qBittorrent.DynamicTable ??= (() => {
                 else if (select) {
                     if (this.useVirtualList) {
                         this.selectedRows.push(row.rowId);
-                    } else {
+                    }
+                    else {
                         const tr = this.getTrByRowId(row.rowId);
                         if ((tr !== null) && !tr.classList.contains("invisible"))
                             this.selectedRows.push(row.rowId);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -829,11 +829,11 @@ window.qBittorrent.DynamicTable ??= (() => {
                     this.selectedRows.push(row.rowId);
                 }
                 else if (select) {
-                    if (this.useVirtualList)
+                    if (this.useVirtualList) {
                         this.selectedRows.push(row.rowId);
-                    else {
+                    } else {
                         const tr = this.getTrByRowId(row.rowId);
-                        if (tr && !tr.classList.contains("invisible"))
+                        if (tr !== null && !tr.classList.contains("invisible"))
                             this.selectedRows.push(row.rowId);
                     }
                 }

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -829,7 +829,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                     this.selectedRows.push(row.rowId);
                 }
                 else if (select) {
-                    this.selectedRows.push(row.rowId);
+                    const tr = this.getTrByRowId(row.rowId);
+                    if (tr && !tr.classList.contains("invisible"))
+                        this.selectedRows.push(row.rowId);
                 }
             }
             this.setRowClass();


### PR DESCRIPTION
Closes #24718

When doing a batch select using Shift key. Do not select invisible rows