### PR TITLE
WebUI: escape add-torrent window title

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -201,7 +201,7 @@ window.qBittorrent.Client ??= (() => {
         new MochaUI.Window({
             id: id,
             icon: "images/qbittorrent-tray.svg",
-            title: title,
+            title: window.qBittorrent.Misc.escapeHtml(title),
             loadMethod: "iframe",
             contentURL: contentURL.toString(),
             scrollbars: true,


### PR DESCRIPTION
I think I found a XSS bug in the master branch. Luckily they are not in production yet. Better fix'in them now

`createAddTorrentWindow()` in `client.js` passes title into a `MochaUI.Window`, which renders it via `.set("html", …)` (innerHTML). That title comes from attacker-influenced sources — search-result names, RSS article names, dropped URLs, torrent filenames — so markup in a name is parsed as HTML, and the default WebUI CSP (`script-src 'self' 'unsafe-inline'`) lets inline handlers run in the authenticated origin.

**Fix:** escape at the sink with the existing `Misc.escapeHtml()` helper

