### PR TITLE
Expand tilde in torrent save paths

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -574,8 +574,10 @@ SessionImpl::SessionImpl(QObject *parent)
         , [](const ShareLimitAction action) { return (action == ShareLimitAction::Default) ? ShareLimitAction::Stop : action; })
     , m_shareLimitsMode(BITTORRENT_SESSION_KEY(u"ShareLimitsMode"_s), ShareLimitsMode::MatchAny
         , [](const ShareLimitsMode mode) { return (mode == ShareLimitsMode::Default) ? ShareLimitsMode::MatchAny : mode; })
-    , m_savePath(BITTORRENT_SESSION_KEY(u"DefaultSavePath"_s), specialFolderLocation(SpecialFolder::Downloads))
-    , m_downloadPath(BITTORRENT_SESSION_KEY(u"TempPath"_s), (savePath() / Path(u"temp"_s)))
+    , m_savePath(BITTORRENT_SESSION_KEY(u"DefaultSavePath"_s), specialFolderLocation(SpecialFolder::Downloads)
+        , Utils::Fs::expandTilde)
+    , m_downloadPath(BITTORRENT_SESSION_KEY(u"TempPath"_s), (savePath() / Path(u"temp"_s))
+        , Utils::Fs::expandTilde)
     , m_isDownloadPathEnabled(BITTORRENT_SESSION_KEY(u"TempPathEnabled"_s), false)
     , m_useCategoryPathsInManualMode(BITTORRENT_SESSION_KEY(u"UseCategoryPathsInManualMode"_s), false)
     , m_isAutoTMMDisabledByDefault(BITTORRENT_SESSION_KEY(u"DisableAutoTMMByDefault"_s), true)
@@ -959,7 +961,7 @@ Path SessionImpl::categorySavePath(const QString &categoryName, const CategoryOp
     if (categoryName.isEmpty())
         return basePath;
 
-    Path path = options.savePath;
+    Path path = Utils::Fs::expandTilde(options.savePath);
     if (path.isEmpty())
     {
         // use implicit save path
@@ -987,7 +989,7 @@ Path SessionImpl::categoryDownloadPath(const QString &categoryName, const Catego
     if (categoryName.isEmpty())
         return downloadPath();
 
-    Path path = downloadPathOption.path;
+    Path path = Utils::Fs::expandTilde(downloadPathOption.path);
     if (path.isEmpty())
     {
         // use implicit download path
@@ -3349,7 +3351,9 @@ void SessionImpl::removeTorrentsQueue()
 
 void SessionImpl::setSavePath(const Path &path)
 {
-    const auto newPath = (path.isAbsolute() ? path : (specialFolderLocation(SpecialFolder::Downloads) / path));
+    const Path expandedPath = Utils::Fs::expandTilde(path);
+    const Path newPath = (expandedPath.isAbsolute()
+            ? expandedPath : (specialFolderLocation(SpecialFolder::Downloads) / expandedPath));
     if (newPath == m_savePath)
         return;
 
@@ -3363,7 +3367,7 @@ void SessionImpl::setSavePath(const Path &path)
         {
             const QString &categoryName = it.key();
             const CategoryOptions &categoryOptions = it.value();
-            if (categoryOptions.savePath.isRelative())
+            if (Utils::Fs::expandTilde(categoryOptions.savePath).isRelative())
                 affectedCatogories.insert(categoryName);
         }
 
@@ -3389,7 +3393,9 @@ void SessionImpl::setSavePath(const Path &path)
 
 void SessionImpl::setDownloadPath(const Path &path)
 {
-    const Path newPath = (path.isAbsolute() ? path : (savePath() / Path(u"temp"_s) / path));
+    const Path expandedPath = Utils::Fs::expandTilde(path);
+    const Path newPath = (expandedPath.isAbsolute()
+            ? expandedPath : (savePath() / Path(u"temp"_s) / expandedPath));
     if (newPath == m_downloadPath)
         return;
 
@@ -3405,7 +3411,7 @@ void SessionImpl::setDownloadPath(const Path &path)
             const CategoryOptions &categoryOptions = it.value();
             const DownloadPathOption downloadPathOption =
                     categoryOptions.downloadPath.value_or(DownloadPathOption {isDownloadPathEnabled(), downloadPath()});
-            if (downloadPathOption.enabled && downloadPathOption.path.isRelative())
+            if (downloadPathOption.enabled && Utils::Fs::expandTilde(downloadPathOption.path).isRelative())
                 affectedCatogories.insert(categoryName);
         }
 

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -477,6 +477,16 @@ Path Utils::Fs::toCanonicalPath(const Path &path)
     return Path(QFileInfo(path.data()).canonicalFilePath());
 }
 
+Path Utils::Fs::expandTilde(const Path &path)
+{
+    const QString pathStr = path.data();
+    if (pathStr == u"~")
+        return homePath();
+    if (pathStr.startsWith(u"~/"))
+        return (homePath() / Path(pathStr.sliced(2)));
+    return path;
+}
+
 Path Utils::Fs::homePath()
 {
     return Path(QDir::homePath());

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -70,6 +70,7 @@ namespace Utils::Fs
     void removeDirRecursively(const Path &path);
     bool smartRemoveEmptyFolderTree(const Path &path);
 
+    Path expandTilde(const Path &path);
     Path homePath();
     Path tempPath();
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(testFiles
     testutilsbytearray.cpp
     testutilscompare.cpp
     testutilsdatetime.cpp
+    testutilsfs.cpp
     testutilsgzip.cpp
     testutilshashvalue.cpp
     testutilsio.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,3 +37,16 @@ foreach(testFile ${testFiles})
 
     add_dependencies(check "${testFilename}")
 endforeach()
+
+if (GUI AND (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+    add_test(NAME testsessionpaths
+        COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/testsessionpaths.py"
+            "$<TARGET_FILE:qbt_app>")
+    set_tests_properties(testsessionpaths PROPERTIES
+        RUN_SERIAL TRUE
+        TIMEOUT 120
+    )
+    add_dependencies(check qbt_app)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,14 +39,16 @@ foreach(testFile ${testFiles})
 endforeach()
 
 if (GUI AND (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
-    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    if (WEBUI)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-    add_test(NAME testsessionpaths
-        COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/testsessionpaths.py"
-            "$<TARGET_FILE:qbt_app>")
-    set_tests_properties(testsessionpaths PROPERTIES
-        RUN_SERIAL TRUE
-        TIMEOUT 120
-    )
-    add_dependencies(check qbt_app)
+        add_test(NAME testsessionpaths
+            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/testsessionpaths.py"
+                "$<TARGET_FILE:qbt_app>")
+        set_tests_properties(testsessionpaths PROPERTIES
+            RUN_SERIAL TRUE
+            TIMEOUT 120
+        )
+        add_dependencies(check qbt_app)
+    endif()
 endif()

--- a/test/testsessionpaths.py
+++ b/test/testsessionpaths.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+TIMEOUT = 15
+
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_until(predicate, message):
+    deadline = time.monotonic() + TIMEOUT
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            result = predicate()
+            if result:
+                return result
+        except (OSError, URLError, ValueError) as error:
+            last_error = error
+        time.sleep(0.1)
+    detail = f": {last_error}" if last_error else ""
+    raise AssertionError(f"{message}{detail}")
+
+
+class QBittorrent:
+    def __init__(self, executable, profile):
+        self.executable = executable
+        self.profile = profile
+        self.webui_port = free_port()
+        self.torrenting_port = free_port()
+        self.process = None
+
+    @property
+    def base_url(self):
+        return f"http://127.0.0.1:{self.webui_port}/api/v2"
+
+    def start(self):
+        environment = os.environ.copy()
+        environment.setdefault("QT_QPA_PLATFORM", "offscreen")
+        if "QT_PLUGIN_PATH" not in environment:
+            qmake = shutil.which("qmake")
+            if qmake:
+                plugin_path = subprocess.check_output(
+                    [qmake, "-query", "QT_INSTALL_PLUGINS"], text=True).strip()
+                if plugin_path:
+                    environment["QT_PLUGIN_PATH"] = plugin_path
+
+        self.process = subprocess.Popen(
+            [
+                self.executable,
+                f"--profile={self.profile}",
+                f"--webui-port={self.webui_port}",
+                f"--torrenting-port={self.torrenting_port}",
+                "--confirm-legal-notice",
+                "--no-splash",
+            ],
+            env=environment,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        def is_ready():
+            if self.process.poll() is not None:
+                raise AssertionError(
+                    f"qBittorrent exited early with code {self.process.returncode}")
+            return self.get_text("/app/version")
+
+        wait_until(is_ready, "WebUI did not become ready")
+
+    def stop(self):
+        if not self.process:
+            return
+        if self.process.poll() is None:
+            self.process.send_signal(signal.SIGINT)
+            try:
+                self.process.wait(timeout=TIMEOUT)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+                raise AssertionError("qBittorrent did not stop after SIGINT")
+        if self.process.returncode != 0:
+            raise AssertionError(
+                f"qBittorrent exited with code {self.process.returncode}")
+        self.process = None
+
+    def request(self, path, data=None):
+        encoded = None
+        if data is not None:
+            encoded = urlencode(data).encode()
+        request = Request(
+            self.base_url + path,
+            data=encoded,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        with urlopen(request, timeout=5) as response:
+            if response.status != 200:
+                raise AssertionError(
+                    f"{path} returned HTTP {response.status}")
+            return response.read()
+
+    def get_text(self, path):
+        return self.request(path).decode()
+
+    def get_json(self, path):
+        return json.loads(self.request(path))
+
+    def post(self, path, data):
+        self.request(path, data)
+
+
+def assert_equal(actual, expected, message):
+    if actual != expected:
+        raise AssertionError(f"{message}: expected {expected!r}, got {actual!r}")
+
+
+def set_preferences(app, **values):
+    app.post("/app/setPreferences", {"json": json.dumps(values)})
+
+
+def create_category(app, name, save_path, download_path):
+    app.post(
+        "/torrents/createCategory",
+        {
+            "category": name,
+            "savePath": save_path,
+            "downloadPathEnabled": "true",
+            "downloadPath": download_path,
+        },
+    )
+
+
+def add_magnet(app, info_hash, category):
+    app.post(
+        "/torrents/add",
+        {
+            "urls": f"magnet:?xt=urn:btih:{info_hash}&dn={category}",
+            "category": category,
+            "stopped": "true",
+            "autoTMM": "true",
+        },
+    )
+
+
+def torrent_info(app, info_hash):
+    def find_torrent():
+        torrents = app.get_json(
+            f"/torrents/info?hashes={info_hash}")
+        return torrents[0] if torrents else None
+
+    return wait_until(find_torrent, f"torrent {info_hash} was not added")
+
+
+def wait_for_auto_tmm(app, info_hash, expected):
+    def has_expected_state():
+        return torrent_info(app, info_hash)["auto_tmm"] is expected
+
+    wait_until(
+        has_expected_state,
+        f"torrent {info_hash} auto_tmm did not become {expected}")
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {sys.argv[0]} /path/to/qbittorrent")
+
+    executable = os.path.abspath(sys.argv[1])
+    home = Path.home()
+
+    with tempfile.TemporaryDirectory(prefix="qbt-session-paths-") as temp_dir:
+        profile = Path(temp_dir)
+        config_dir = profile / "qBittorrent" / "config"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "qBittorrent.ini"
+        config_file.write_text(
+            "[LegalNotice]\n"
+            "Accepted=true\n\n"
+            "[Preferences]\n"
+            "WebUI\\Enabled=true\n"
+            "WebUI\\LocalHostAuth=false\n"
+            "WebUI\\Password_PBKDF2=test\n\n"
+            "[BitTorrent]\n"
+            "Session\\DefaultSavePath=~/read-save\n"
+            "Session\\TempPath=~/read-temp\n"
+            "Session\\TempPathEnabled=true\n",
+            encoding="utf-8",
+        )
+
+        app = QBittorrent(executable, profile)
+        try:
+            app.start()
+
+            preferences = app.get_json("/app/preferences")
+            assert_equal(
+                preferences["save_path"],
+                str(home / "read-save"),
+                "default save path was not expanded while loading settings",
+            )
+            assert_equal(
+                preferences["temp_path"],
+                str(home / "read-temp"),
+                "temporary path was not expanded while loading settings",
+            )
+
+            set_preferences(
+                app,
+                save_path="~/set-save",
+                temp_path="~/set-temp",
+                temp_path_enabled=True,
+                save_path_changed_tmm_enabled=False,
+            )
+            preferences = app.get_json("/app/preferences")
+            assert_equal(
+                preferences["save_path"],
+                str(home / "set-save"),
+                "save-path setter did not expand tilde",
+            )
+            assert_equal(
+                preferences["temp_path"],
+                str(home / "set-temp"),
+                "temporary-path setter did not expand tilde",
+            )
+
+            categories = {
+                "tilde": ("~/category-save", "~/category-temp"),
+                "relative-save": ("relative-save", "~/relative-save-temp"),
+                "relative-temp": ("~/relative-temp-save", "relative-temp"),
+            }
+            for name, (save_path, download_path) in categories.items():
+                create_category(app, name, save_path, download_path)
+
+            hashes = {
+                "tilde": "1111111111111111111111111111111111111111",
+                "relative-save": "2222222222222222222222222222222222222222",
+                "relative-temp": "3333333333333333333333333333333333333333",
+            }
+            for category, info_hash in hashes.items():
+                add_magnet(app, info_hash, category)
+
+            tilde_torrent = torrent_info(app, hashes["tilde"])
+            assert_equal(
+                tilde_torrent["save_path"],
+                str(home / "category-save"),
+                "category save path was not expanded",
+            )
+            assert_equal(
+                tilde_torrent["download_path"],
+                str(home / "category-temp"),
+                "category download path was not expanded",
+            )
+
+            for info_hash in hashes.values():
+                wait_for_auto_tmm(app, info_hash, True)
+
+            set_preferences(app, save_path="~/changed-save")
+            wait_for_auto_tmm(app, hashes["relative-save"], False)
+            wait_for_auto_tmm(app, hashes["tilde"], True)
+            wait_for_auto_tmm(app, hashes["relative-temp"], True)
+
+            set_preferences(app, temp_path="~/changed-temp")
+            wait_for_auto_tmm(app, hashes["relative-temp"], False)
+            wait_for_auto_tmm(app, hashes["tilde"], True)
+
+            set_preferences(app, refresh_interval=1601)
+            app.stop()
+
+            categories_file = config_dir / "categories.json"
+            persisted_categories = json.loads(
+                categories_file.read_text(encoding="utf-8"))
+            assert_equal(
+                persisted_categories["tilde"]["save_path"],
+                "~/category-save",
+                "category save path was rewritten while persisting",
+            )
+            assert_equal(
+                persisted_categories["tilde"]["download_path"],
+                "~/category-temp",
+                "category download path was rewritten while persisting",
+            )
+
+            app = QBittorrent(executable, profile)
+            app.start()
+            categories_after_restart = app.get_json("/torrents/categories")
+            assert_equal(
+                categories_after_restart["tilde"]["savePath"],
+                "~/category-save",
+                "category save path changed after restart",
+            )
+            assert_equal(
+                categories_after_restart["tilde"]["download_path"],
+                "~/category-temp",
+                "category download path changed after restart",
+            )
+
+            tilde_after_restart = torrent_info(app, hashes["tilde"])
+            assert_equal(
+                tilde_after_restart["save_path"],
+                str(home / "category-save"),
+                "category save path was not expanded after restart",
+            )
+            assert_equal(
+                tilde_after_restart["download_path"],
+                str(home / "category-temp"),
+                "category download path was not expanded after restart",
+            )
+            app.stop()
+        finally:
+            if app.process and app.process.poll() is None:
+                app.process.kill()
+                app.process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/testutilsfs.cpp
+++ b/test/testutilsfs.cpp
@@ -1,0 +1,69 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  qBittorrent contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QObject>
+#include <QTest>
+
+#include "base/path.h"
+#include "base/utils/fs.h"
+
+class TestUtilsFs final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestUtilsFs)
+
+public:
+    TestUtilsFs() = default;
+
+private slots:
+    void testExpandTilde_data() const
+    {
+        QTest::addColumn<Path>("path");
+        QTest::addColumn<Path>("expected");
+
+        QTest::newRow("empty") << Path() << Path();
+        QTest::newRow("home") << Path(u"~"_s) << Utils::Fs::homePath();
+        QTest::newRow("home child") << Path(u"~/Downloads"_s)
+                                   << (Utils::Fs::homePath() / Path(u"Downloads"_s));
+        QTest::newRow("absolute") << Path(u"/var/tmp"_s) << Path(u"/var/tmp"_s);
+        QTest::newRow("relative") << Path(u"Downloads"_s) << Path(u"Downloads"_s);
+        QTest::newRow("other user") << Path(u"~alice/x"_s) << Path(u"~alice/x"_s);
+        QTest::newRow("embedded") << Path(u"foo/~/x"_s) << Path(u"foo/~/x"_s);
+    }
+
+    void testExpandTilde() const
+    {
+        QFETCH(Path, path);
+        QFETCH(Path, expected);
+
+        QCOMPARE(Utils::Fs::expandTilde(path), expected);
+    }
+};
+
+QTEST_APPLESS_MAIN(TestUtilsFs)
+#include "testutilsfs.moc"


### PR DESCRIPTION

## Problem

Save paths beginning with `~/` are currently treated as ordinary relative paths. This makes a portable configuration such as `~/Downloads/Torrents` resolve below qBittorrent's default directory instead of the current user's home directory.

## Changes

- Add `Utils::Fs::expandTilde()` for the exact `~` and `~/...` forms.
- Apply it when loading and setting the default save and temporary paths.
- Apply it when resolving category save and temporary paths.
- Use the expanded form when deciding whether a category path is relative for automatic torrent management.
- Keep category settings in their original portable `~/...` form when they are persisted.

## Safety and scope

Expansion is deliberately limited to the current user's home directory. Absolute paths, ordinary relative paths, `~other-user`, and embedded tildes are unchanged. No shell expansion or environment-variable expansion is introduced.

The integration test covers settings loaded from disk, Web API setters, category paths, restart persistence, and the automatic torrent-management behavior for relative versus tilde-prefixed paths.

## Tests

```sh
cmake -S . -B build-gui -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTING=ON -DWEBUI=ON -DGUI=ON
cmake --build build-gui --target check -j6
ctest --test-dir build-gui/test --output-on-failure -R '^(testutilsfs|testsessionpaths)$'
```

On the combined ten-fix integration branch, the full macOS GUI validation completed with 29/29 tests passing.

Closes #17583.

