### PR TITLE
Replace the deprecated daemon call on macOS

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build qBittorrent
         run: |
-          CXXFLAGS="$CXXFLAGS -DQT_FORCE_ASSERTS -Werror -Wno-error=deprecated-declarations -Wno-error=deprecated-literal-operator" \
+          CXXFLAGS="$CXXFLAGS -DQT_FORCE_ASSERTS -Werror -Wno-error=deprecated-literal-operator" \
           LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \
@@ -138,6 +138,10 @@ jobs:
           else
             build/qbittorrent-nox.app/Contents/MacOS/qbittorrent-nox -v
           fi
+
+      - name: Test daemon mode
+        if: matrix.qbt_gui == 'GUI=OFF' && matrix.libtorrent.version == '2.1.0'
+        run: python3 .github/workflows/helper/test_macos_daemon.py build/qbittorrent-nox.app/Contents/MacOS/qbittorrent-nox
 
       - name: Prepare build artifacts
         run: |

--- a/.github/workflows/helper/test_macos_daemon.py
+++ b/.github/workflows/helper/test_macos_daemon.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+TIMEOUT = 30
+
+
+def wait_until(predicate, description, timeout=TIMEOUT):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"Timed out waiting for {description}")
+
+
+def reserve_ports(count):
+    sockets = []
+    try:
+        for _ in range(count):
+            sock = socket.socket()
+            sock.bind(("127.0.0.1", 0))
+            sockets.append(sock)
+        return [sock.getsockname()[1] for sock in sockets]
+    finally:
+        for sock in sockets:
+            sock.close()
+
+
+def profile_processes(binary, profile):
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,command="],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    profile_arg = f"--profile={profile}"
+    processes = []
+    for line in result.stdout.splitlines():
+        fields = line.strip().split(maxsplit=1)
+        if len(fields) == 2 and str(binary) in fields[1] and profile_arg in fields[1]:
+            processes.append(int(fields[0]))
+    return processes
+
+
+def process_exists(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+def webui_status(port):
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=0.5) as response:
+            return response.status
+    except urllib.error.HTTPError as error:
+        return error.code
+    except (OSError, urllib.error.URLError):
+        return None
+
+
+def file_descriptors(pid):
+    result = subprocess.run(
+        ["lsof", "-a", "-p", str(pid), "-d", "0,1,2", "-Ffn"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    descriptors = {}
+    current_fd = None
+    for line in result.stdout.splitlines():
+        if line.startswith("f"):
+            current_fd = int(line[1:])
+        elif line.startswith("n") and current_fd is not None:
+            descriptors[current_fd] = line[1:]
+    return descriptors
+
+
+def stop_processes(pids):
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+    deadline = time.monotonic() + 5
+    while any(process_exists(pid) for pid in pids) and time.monotonic() < deadline:
+        time.sleep(0.1)
+
+    for pid in pids:
+        if process_exists(pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def run_mode(binary, mode):
+    launcher = None
+    with tempfile.TemporaryDirectory(prefix=f"qbt-daemon-{mode}-") as temp_dir:
+        profile = Path(temp_dir)
+        webui_port, torrent_port = reserve_ports(2)
+        args = [
+            str(binary),
+            "--confirm-legal-notice",
+            f"--profile={profile}",
+            f"--webui-port={webui_port}",
+            f"--torrenting-port={torrent_port}",
+        ]
+        env = os.environ.copy()
+        env.pop("QBT_DAEMON", None)
+        env.pop("QBT_DAEMONIZED", None)
+        env["LANG"] = "C"
+        env["LC_ALL"] = "C"
+        if mode == "cli":
+            args.append("-d")
+        else:
+            env["QBT_DAEMON"] = "1"
+
+        try:
+            launcher = subprocess.Popen(
+                args,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            stdout, stderr = launcher.communicate(timeout=5)
+            assert launcher.returncode == 0, (
+                f"{mode}: launcher exited with {launcher.returncode}\n"
+                f"stdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+
+            wait_until(
+                lambda: len(profile_processes(binary, profile)) == 1,
+                f"{mode} daemon child",
+                timeout=5,
+            )
+            processes = profile_processes(binary, profile)
+            assert len(processes) == 1, f"{mode}: expected one child, found {processes}"
+            child_pid = processes[0]
+            assert child_pid != launcher.pid, f"{mode}: daemon did not start a child process"
+            assert os.getsid(child_pid) == child_pid, f"{mode}: child did not create a new session"
+
+            wait_until(
+                lambda: webui_status(webui_port) in (200, 401),
+                f"{mode} WebUI",
+            )
+            descriptors = file_descriptors(child_pid)
+            assert descriptors == {0: "/dev/null", 1: "/dev/null", 2: "/dev/null"}, (
+                f"{mode}: unexpected standard descriptors: {descriptors}"
+            )
+
+            duplicate = subprocess.run(
+                args,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            assert duplicate.returncode != 0, f"{mode}: duplicate daemon unexpectedly succeeded"
+            assert "already running" in duplicate.stderr, (
+                f"{mode}: duplicate did not hit the single-instance check:\n{duplicate.stderr}"
+            )
+            assert profile_processes(binary, profile) == [child_pid], (
+                f"{mode}: duplicate daemon created another process"
+            )
+
+            log_path = profile / "qBittorrent" / "data" / "logs" / "qbittorrent.log"
+            wait_until(log_path.exists, f"{mode} log file")
+            log_size = log_path.stat().st_size
+
+            os.kill(child_pid, signal.SIGTERM)
+            wait_until(lambda: not process_exists(child_pid), f"{mode} child termination")
+            wait_until(
+                lambda: not profile_processes(binary, profile),
+                f"{mode} profile process cleanup",
+            )
+            wait_until(lambda: webui_status(webui_port) is None, f"{mode} WebUI shutdown")
+
+            log_tail = log_path.read_text(errors="replace")[log_size:]
+            assert "qBittorrent termination initiated" in log_tail, (
+                f"{mode}: clean termination missing from log tail:\n{log_tail}"
+            )
+            print(f"PASS: {mode} daemon mode")
+        finally:
+            if launcher is not None and launcher.poll() is None:
+                launcher.kill()
+                launcher.wait()
+            stop_processes(profile_processes(binary, profile))
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit(f"Usage: {sys.argv[0]} /path/to/qbittorrent-nox")
+
+    binary = Path(sys.argv[1]).resolve()
+    if not binary.is_file():
+        raise SystemExit(f"Executable not found: {binary}")
+
+    run_mode(binary, "cli")
+    run_mode(binary, "env")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -29,9 +29,16 @@
 
 #include <QtSystemDetection>
 
+#include <cerrno>
 #include <chrono>
 #include <cstdlib>
 #include <memory>
+
+#if defined(Q_OS_MACOS) && defined(DISABLE_GUI)
+#include <crt_externs.h>
+#include <fcntl.h>
+#include <spawn.h>
+#endif
 
 #ifdef Q_OS_UNIX
 #include <sys/resource.h>
@@ -89,6 +96,10 @@ using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
+#if defined(Q_OS_MACOS) && defined(DISABLE_GUI)
+    constexpr char DAEMONIZED_ENV_NAME[] = "QBT_DAEMONIZED";
+#endif
+
     void displayBadArgMessage(const QString &message)
     {
         const QString help = QCoreApplication::translate("Main", "Run application with -h option to read about command line parameters.");
@@ -178,6 +189,11 @@ namespace
 // Main
 int main(int argc, char *argv[])
 {
+#if defined(Q_OS_MACOS) && defined(DISABLE_GUI)
+    const bool isDaemonized = (qgetenv(DAEMONIZED_ENV_NAME) == "1");
+    qunsetenv(DAEMONIZED_ENV_NAME);
+#endif
+
 #ifdef DISABLE_GUI
     setvbuf(stdout, nullptr, _IONBF, 0);
 #endif
@@ -272,6 +288,61 @@ int main(int argc, char *argv[])
                 legalNoticeShown = true;
         }
 
+#if defined(Q_OS_MACOS) && defined(DISABLE_GUI)
+        if (params.shouldDaemonize && !isDaemonized)
+        {
+            const QByteArray executablePath = QCoreApplication::applicationFilePath().toLocal8Bit();
+            app.reset(); // Release the instance lock before starting the daemon
+
+            posix_spawn_file_actions_t fileActions {};
+            int result = posix_spawn_file_actions_init(&fileActions);
+            const bool fileActionsInitialized = (result == 0);
+            if (result == 0)
+                result = posix_spawn_file_actions_addopen(&fileActions, STDIN_FILENO, "/dev/null", O_RDWR, 0);
+            if (result == 0)
+                result = posix_spawn_file_actions_addopen(&fileActions, STDOUT_FILENO, "/dev/null", O_RDWR, 0);
+            if (result == 0)
+                result = posix_spawn_file_actions_addopen(&fileActions, STDERR_FILENO, "/dev/null", O_RDWR, 0);
+
+            posix_spawnattr_t attributes {};
+            bool attributesInitialized = false;
+            if (result == 0)
+            {
+                result = posix_spawnattr_init(&attributes);
+                attributesInitialized = (result == 0);
+            }
+            if (result == 0)
+            {
+                constexpr short flags = static_cast<short>(POSIX_SPAWN_SETSID | POSIX_SPAWN_CLOEXEC_DEFAULT);
+                result = posix_spawnattr_setflags(&attributes, flags);
+            }
+            if ((result == 0) && !qputenv(DAEMONIZED_ENV_NAME, "1"))
+            {
+                qCritical("Failed to set daemon child marker");
+                result = ENOMEM;
+            }
+
+            pid_t childPID = 0;
+            if (result == 0)
+                result = posix_spawn(&childPID, executablePath.constData(), &fileActions, &attributes, argv, *_NSGetEnviron());
+
+            if (attributesInitialized)
+                posix_spawnattr_destroy(&attributes);
+            if (fileActionsInitialized)
+                posix_spawn_file_actions_destroy(&fileActions);
+
+            if (result != 0)
+            {
+                const QString errorMessage = QCoreApplication::translate("Main", "Error when daemonizing. Reason: \"%1\". Error code: %2.")
+                    .arg(QString::fromLocal8Bit(strerror(result)), QString::number(result));
+                qCritical("%s", qUtf8Printable(errorMessage));
+                return EXIT_FAILURE;
+            }
+
+            return EXIT_SUCCESS;
+        }
+#endif
+
 #ifdef Q_OS_MACOS
         // Since Apple made difficult for users to set PATH, we set here for convenience.
         // Users are supposed to install Homebrew Python for search function.
@@ -286,7 +357,7 @@ int main(int argc, char *argv[])
             app->setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
 
-#if defined(DISABLE_GUI) && !defined(Q_OS_WIN)
+#if defined(DISABLE_GUI) && !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
         if (params.shouldDaemonize)
         {
             app.reset(); // Destroy current application instance


### PR DESCRIPTION

## Problem

The no-GUI macOS build still uses `daemon()`, which Apple has deprecated. The macOS workflow has therefore had to suppress deprecation warnings even though the rest of the build treats warnings as errors.

## Changes

- Replace the macOS no-GUI `daemon()` path with `posix_spawn()`.
- Start the child in a new session and redirect standard input, output, and error to `/dev/null`.
- Release the application instance lock before spawning, then let the marked child perform the normal startup and single-instance checks.
- Keep the existing `daemon()` path unchanged on other Unix platforms.
- Remove the macOS CI deprecation-warning exemption.
- Add an end-to-end daemon test for both `-d` and `QBT_DAEMON=1`.

## Safety and scope

The new code is compiled only for macOS no-GUI builds. The test verifies that the launcher exits successfully, exactly one child remains, the child owns a new session, standard descriptors point to `/dev/null`, the WebUI becomes reachable, a duplicate process is rejected, and `SIGTERM` produces a clean shutdown.

## Tests

```sh
cmake -S . -B build-nox -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTING=ON -DWEBUI=ON -DGUI=OFF
cmake --build build-nox --target check -j6
cmake --build build-nox --target qbt_app -j6
python3 .github/workflows/helper/test_macos_daemon.py build-nox/qbittorrent-nox.app/Contents/MacOS/qbittorrent-nox
```

The focused daemon helper passed both launch modes. On the combined ten-fix integration branch, the full no-GUI macOS validation completed with 20/20 tests passing. The GUI and no-GUI configurations also build without `-Wno-error=deprecated-declarations`.

Closes #15630.

