### PR TITLE
Add logging of IP ban alerts

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5988,6 +5988,11 @@ void SessionImpl::handleAlert(lt::alert *alert)
             handleTorrentConflictAlert(static_cast<const lt::torrent_conflict_alert *>(alert));
             break;
 #endif
+#if LIBTORRENT_VERSION_NUM >= 20101
+        case lt::ip_ban_alert::alert_type:
+            handleIPBanAlert(static_cast<const lt::ip_ban_alert *>(alert));
+            break;
+#endif
         }
     }
     catch (const std::exception &exc)
@@ -6582,6 +6587,14 @@ void SessionImpl::handleTorrentFinishedAlert([[maybe_unused]] const lt::torrent_
     if (TorrentImpl *torrent = getTorrent(alert->handle)) [[likely]]
         torrent->handleTorrentFinished();
 }
+
+#if LIBTORRENT_VERSION_NUM >= 20101
+void SessionImpl::handleIPBanAlert(const lt::ip_ban_alert *alert)
+{
+    // an IP was banned by libtorrent internally
+    LogMsg(tr("IP banned by libtorrent. IP: %1.").arg(toString(alert->banned_address)), Log::INFO);
+}
+#endif
 
 void SessionImpl::handleSaveResumeDataAlert(lt::save_resume_data_alert *alert)
 {

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -620,6 +620,9 @@ namespace BitTorrent
         void handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *alert);
         void handleTorrentCheckedAlert(const lt::torrent_checked_alert *alert);
         void handleTorrentFinishedAlert(const lt::torrent_finished_alert *alert);
+#if LIBTORRENT_VERSION_NUM >= 20101
+        void handleIPBanAlert(const lt::ip_ban_alert *alert);
+#endif
 
         TorrentImpl *createTorrent(const lt::torrent_handle &nativeHandle, LoadTorrentParams params);
         TorrentImpl *getTorrent(const lt::torrent_handle &nativeHandle) const;


### PR DESCRIPTION
This alert is available since libtorrent 2.1.1.
Upstream PR: https://github.com/arvidn/libtorrent/pull/8574.