### PR TITLE
Add unit tests for 'find root folder' method

### DIFF
--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -331,10 +331,14 @@ Path Path::commonPath(const PathList &filePaths)
 
 Path Path::findRootFolder(const PathList &filePaths)
 {
+    // find the common first level path of all `filePaths`
+
     Path rootFolder;
     for (const Path &filePath : filePaths)
     {
-        const auto filePathElements = QStringView(filePath.m_pathStr).split(u'/');
+        Q_ASSERT(!filePath.m_pathStr.startsWith(u'/'));  // currently this function doesn't know how to handle absolute paths
+
+        const auto filePathElements = QStringView(filePath.m_pathStr).split(u'/', Qt::SkipEmptyParts);
         // if at least one file has no root folder, no common root folder exists
         if (filePathElements.count() <= 1)
             return {};

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -492,6 +492,16 @@ private slots:
         }
     }
 
+    void testFindRootFolder() const
+    {
+        QCOMPARE(Path::findRootFolder({}), {});
+        QCOMPARE(Path::findRootFolder({Path(u"a"_s)}), {});
+        QCOMPARE(Path::findRootFolder({Path(u"a"_s), Path(u"b"_s)}), {});
+        QCOMPARE(Path::findRootFolder({Path(u"a/b"_s)}), Path(u"a"_s));
+        QCOMPARE(Path::findRootFolder({Path(u"a/b"_s), Path(u"b/c"_s)}), {});
+        QCOMPARE(Path::findRootFolder({Path(u"a/b"_s), Path(u"a/b/c"_s), Path(u"a/b/d"_s)}), Path(u"a"_s));
+    }
+
     // TODO: add tests for remaining methods
 };
 


### PR DESCRIPTION
Assert that only relative paths are accepted, as absolute paths are not supported currently.