### PR TITLE
Detect redundant quotes from Python executable path

### DIFF
--- a/src/gui/addtorrentparamswidget.cpp
+++ b/src/gui/addtorrentparamswidget.cpp
@@ -343,7 +343,7 @@ void AddTorrentParamsWidget::populateDefaultPaths()
 
     const Path defaultSavePath = btSession->suggestedSavePath(
             m_ui->categoryComboBox->currentText(), toOptionalBool(m_ui->comboTTM->currentData()));
-    m_ui->savePathEdit->setPlaceholder(defaultSavePath);
+    m_ui->savePathEdit->setPlaceholder(defaultSavePath.toString());
 
     populateDefaultDownloadPath();
 }
@@ -357,11 +357,11 @@ void AddTorrentParamsWidget::populateDefaultDownloadPath()
     {
         const Path defaultDownloadPath = btSession->suggestedDownloadPath(
                 m_ui->categoryComboBox->currentText(), toOptionalBool(m_ui->comboTTM->currentData()));
-        m_ui->downloadPathEdit->setPlaceholder(defaultDownloadPath);
+        m_ui->downloadPathEdit->setPlaceholder(defaultDownloadPath.toString());
     }
     else
     {
-        m_ui->downloadPathEdit->setPlaceholder(Path());
+        m_ui->downloadPathEdit->setPlaceholder(QString());
     }
 }
 

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -359,7 +359,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     // Ignore SSL errors
     pref->setIgnoreSSLErrors(m_checkBoxIgnoreSSLErrors.isChecked());
     // Python executable path
-    pref->setPythonExecutablePath(Path(m_pythonExecutablePath.text().trimmed()));
+    pref->setPythonExecutablePath(m_pythonExecutablePath.selectedPath());
     // Start session paused
     session->setStartPaused(m_checkBoxStartSessionPaused.isChecked());
     // Session shutdown timeout
@@ -923,8 +923,10 @@ void AdvancedSettings::loadAdvancedSettings()
     m_checkBoxIgnoreSSLErrors.setToolTip(tr("Affects certificate validation and non-torrent protocol activities (e.g. RSS feeds, program updates, torrent files, geoip db, etc)"));
     addRow(IGNORE_SSL_ERRORS, tr("Ignore SSL errors"), &m_checkBoxIgnoreSSLErrors);
     // Python executable path
-    m_pythonExecutablePath.setPlaceholderText(tr("(Auto detect if empty)"));
-    m_pythonExecutablePath.setText(pref->getPythonExecutablePath().toString());
+    m_pythonExecutablePath.setMode(FileSystemPathEdit::Mode::FileOpen);
+    m_pythonExecutablePath.setDialogCaption(tr("Select Python Executable"));
+    m_pythonExecutablePath.setPlaceholder(tr("(Auto detect if empty)"));
+    m_pythonExecutablePath.setSelectedPath(pref->getPythonExecutablePath());
     addRow(PYTHON_EXECUTABLE_PATH, tr("Python executable path (may require restart)"), &m_pythonExecutablePath);
     // Start session paused
     m_checkBoxStartSessionPaused.setChecked(session->isStartPaused());
@@ -1039,7 +1041,9 @@ void AdvancedSettings::addRow(const int row, const QString &text, T *widget)
     setCellWidget(row, PROPERTY, label);
     setCellWidget(row, VALUE, widget);
 
-    if constexpr (std::is_same_v<T, QCheckBox>)
+    if constexpr (std::is_same_v<T, FileSystemPathLineEdit>)
+        connect(widget, &FileSystemPathEdit::selectedPathChanged, this, &AdvancedSettings::settingsChanged);
+    else if constexpr (std::is_same_v<T, QCheckBox>)
     {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
         connect(widget, &QCheckBox::checkStateChanged, this, &AdvancedSettings::settingsChanged);
@@ -1047,10 +1051,10 @@ void AdvancedSettings::addRow(const int row, const QString &text, T *widget)
         connect(widget, &QCheckBox::stateChanged, this, &AdvancedSettings::settingsChanged);
 #endif
     }
-    else if constexpr (std::is_same_v<T, QSpinBox>)
-        connect(widget, qOverload<int>(&QSpinBox::valueChanged), this, &AdvancedSettings::settingsChanged);
     else if constexpr (std::is_same_v<T, QComboBox>)
         connect(widget, qOverload<int>(&QComboBox::currentIndexChanged), this, &AdvancedSettings::settingsChanged);
     else if constexpr (std::is_same_v<T, QLineEdit>)
         connect(widget, &QLineEdit::textChanged, this, &AdvancedSettings::settingsChanged);
+    else if constexpr (std::is_same_v<T, QSpinBox>)
+        connect(widget, qOverload<int>(&QSpinBox::valueChanged), this, &AdvancedSettings::settingsChanged);
 }

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -37,6 +37,7 @@
 #include <QSpinBox>
 #include <QTableWidget>
 
+#include "fspathedit.h"
 #include "guiapplicationcomponent.h"
 
 class AdvancedSettings final : public GUIApplicationComponent<QTableWidget>
@@ -83,7 +84,8 @@ private:
               m_checkBoxConfirmRemoveTrackerFromAllTorrents, m_checkBoxStartSessionPaused;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxDiskIOReadMode, m_comboBoxDiskIOWriteMode, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage, m_comboBoxTorrentContentRemoveOption;
-    QLineEdit m_lineEditAppInstanceName, m_pythonExecutablePath, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes;
+    QLineEdit m_lineEditAppInstanceName, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes;
+    FileSystemPathLineEdit m_pythonExecutablePath;
 
 #ifndef QBT_USES_LIBTORRENT2
     QSpinBox m_spinBoxCache, m_spinBoxCacheTTL;

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -264,13 +264,13 @@ void FileSystemPathEdit::setFileNameFilter(const QString &val)
 #endif
 }
 
-Path FileSystemPathEdit::placeholder() const
+QString FileSystemPathEdit::placeholder() const
 {
     Q_D(const FileSystemPathEdit);
     return d->m_editor->placeholder();
 }
 
-void FileSystemPathEdit::setPlaceholder(const Path &val)
+void FileSystemPathEdit::setPlaceholder(const QString &val)
 {
     Q_D(FileSystemPathEdit);
     d->m_editor->setPlaceholder(val);

--- a/src/gui/fspathedit.h
+++ b/src/gui/fspathedit.h
@@ -81,8 +81,8 @@ public:
     QString fileNameFilter() const;
     void setFileNameFilter(const QString &val);
 
-    Path placeholder() const;
-    void setPlaceholder(const Path &val);
+    QString placeholder() const;
+    void setPlaceholder(const QString &val);
 
     /// The browse button caption is "..." if true, and "Browse" otherwise
     bool briefBrowseButtonCaption() const;

--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -201,14 +201,14 @@ void Private::FileLineEdit::setValidator(QValidator *validator)
     QLineEdit::setValidator(validator);
 }
 
-Path Private::FileLineEdit::placeholder() const
+QString Private::FileLineEdit::placeholder() const
 {
-    return Path(placeholderText());
+    return placeholderText();
 }
 
-void Private::FileLineEdit::setPlaceholder(const Path &val)
+void Private::FileLineEdit::setPlaceholder(const QString &val)
 {
-    setPlaceholderText(val.toString());
+    setPlaceholderText(val);
 }
 
 QWidget *Private::FileLineEdit::widget()
@@ -339,14 +339,14 @@ void Private::FileComboEdit::setValidator(QValidator *validator)
     lineEdit()->setValidator(validator);
 }
 
-Path Private::FileComboEdit::placeholder() const
+QString Private::FileComboEdit::placeholder() const
 {
-    return Path(lineEdit()->placeholderText());
+    return lineEdit()->placeholderText();
 }
 
-void Private::FileComboEdit::setPlaceholder(const Path &val)
+void Private::FileComboEdit::setPlaceholder(const QString &val)
 {
-    lineEdit()->setPlaceholderText(val.toString());
+    lineEdit()->setPlaceholderText(val);
 }
 
 void Private::FileComboEdit::setFilenameFilters(const QStringList &filters)

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -107,8 +107,8 @@ namespace Private
         virtual void setFilenameFilters(const QStringList &filters) = 0;
         virtual void setBrowseAction(QAction *action) = 0;
         virtual void setValidator(QValidator *validator) = 0;
-        virtual Path placeholder() const = 0;
-        virtual void setPlaceholder(const Path &val) = 0;
+        virtual QString placeholder() const = 0;
+        virtual void setPlaceholder(const QString &val) = 0;
         virtual QWidget *widget() = 0;
     };
 
@@ -125,8 +125,8 @@ namespace Private
         void setFilenameFilters(const QStringList &filters) override;
         void setBrowseAction(QAction *action) override;
         void setValidator(QValidator *validator) override;
-        Path placeholder() const override;
-        void setPlaceholder(const Path &val) override;
+        QString placeholder() const override;
+        void setPlaceholder(const QString &val) override;
         QWidget *widget() override;
 
     protected:
@@ -159,8 +159,8 @@ namespace Private
         void setFilenameFilters(const QStringList &filters) override;
         void setBrowseAction(QAction *action) override;
         void setValidator(QValidator *validator) override;
-        Path placeholder() const override;
-        void setPlaceholder(const Path &val) override;
+        QString placeholder() const override;
+        void setPlaceholder(const QString &val) override;
         QWidget *widget() override;
 
     protected:

--- a/src/gui/torrentcategorydialog.cpp
+++ b/src/gui/torrentcategorydialog.cpp
@@ -191,12 +191,12 @@ void TorrentCategoryDialog::setCategoryOptions(const BitTorrent::CategoryOptions
 void TorrentCategoryDialog::categoryNameChanged(const QString &categoryName)
 {
     const auto *btSession = BitTorrent::Session::instance();
-    m_ui->comboSavePath->setPlaceholder(btSession->categorySavePath(categoryName, categoryOptions()));
+    m_ui->comboSavePath->setPlaceholder(btSession->categorySavePath(categoryName, categoryOptions()).toString());
 
     const int index = m_ui->comboUseDownloadPath->currentIndex();
     const bool useDownloadPath = (index == 1) || ((index == 0) && btSession->isDownloadPathEnabled());
     if (useDownloadPath)
-        m_ui->comboDownloadPath->setPlaceholder(btSession->categoryDownloadPath(categoryName, categoryOptions()));
+        m_ui->comboDownloadPath->setPlaceholder(btSession->categoryDownloadPath(categoryName, categoryOptions()).toString());
 
     const QString parentCategoryName = BitTorrent::Session::parentCategoryName(categoryName);
     if (m_parentCategoryName != parentCategoryName)
@@ -221,7 +221,7 @@ void TorrentCategoryDialog::useDownloadPathChanged(const int index)
     const QString categoryName = m_ui->textCategoryName->text();
     const bool useDownloadPath = (index == 1) || ((index == 0) && btSession->isDownloadPathEnabled());
     const Path categoryPath = btSession->categoryDownloadPath(categoryName, categoryOptions());
-    m_ui->comboDownloadPath->setPlaceholder(useDownloadPath ? categoryPath : Path());
+    m_ui->comboDownloadPath->setPlaceholder(useDownloadPath ? categoryPath.toString() : QString());
 }
 
 void TorrentCategoryDialog::resetShareLimitsWidgetDefaults()

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -3259,7 +3259,15 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["embedded_tracker_port_forwarding"] = document.getElementById("embeddedTrackerPortForwarding").checked;
             settings["mark_of_the_web"] = document.getElementById("markOfTheWeb").checked;
             settings["ignore_ssl_errors"] = document.getElementById("ignoreSSLErrors").checked;
-            settings["python_executable_path"] = document.getElementById("pythonExecutablePath").value;
+
+            const pyPath = document.getElementById("pythonExecutablePath").value;
+            if ((pyPath.length > 0)
+                && (pyPath.startsWith("\"") || pyPath.startsWith("'")
+                    || pyPath.endsWith("\"") || pyPath.endsWith("'"))) {
+                alert("QBT_TR(Invalid path to Python executable. Path contains unnecessary leading and trailing quotes.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings["python_executable_path"] = pyPath;
 
             // libtorrent section
             settings["bdecode_depth_limit"] = Number(document.getElementById("bdecodeDepthLimit").value);


### PR DESCRIPTION
`placeholder()` and `setPlaceholder()` should take a `QString` rather than a `Path` since the UI placeholder should not be restricted to only paths.

Screenshots:
* Invalid path:
  <img width="653" height="63" alt="invalid path" src="https://github.com/user-attachments/assets/e318bf81-3e9a-49d1-add1-96ab7297d0d9" />
* Valid path:
  <img width="561" height="32" alt="ok" src="https://github.com/user-attachments/assets/282dedde-320a-4dc7-a9d5-fda1bc552b7d" />

Closes #24169.
