### PR TITLE
Select existing torrent when adding duplicate

### DIFF
--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -195,6 +195,10 @@ bool GUIAddTorrentManager::processTorrent(const QString &source
     // Prevent showing the dialog if download is already present
     if (BitTorrent::Torrent *torrent = btSession()->findTorrent(infoHash))
     {
+        // Point the user to the torrent that is already in the transfer list
+        if (MainWindow *mainWindow = app()->mainWindow())
+            mainWindow->selectTorrent(torrent);
+
         if (Preferences::instance()->confirmMergeTrackers())
         {
             if (hasMetadata)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1051,6 +1051,16 @@ TransferListWidget *MainWindow::transferListWidget() const
     return m_transferListWidget;
 }
 
+void MainWindow::selectTorrent(BitTorrent::Torrent *const torrent)
+{
+    if (!torrent)
+        return;
+
+    displayTransferTab();
+    if (m_transferListWidget->selectTorrent(torrent))
+        m_transferListWidget->setFocus();
+}
+
 bool MainWindow::unlockUI()
 {
     if (m_unlockDlgShowing)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -110,6 +110,9 @@ public:
     void activate();
     void cleanup();
 
+    // Brings the transfer list to the front and makes `torrent` the selected one
+    void selectTorrent(BitTorrent::Torrent *torrent);
+
 private slots:
     void showFilterContextMenu();
     void desktopNotificationClicked();

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -673,6 +673,15 @@ BitTorrent::Torrent *TransferListModel::torrentHandle(const QModelIndex &index) 
     return m_torrents.get<ByIndex>().at(index.row());
 }
 
+QModelIndex TransferListModel::torrentIndex(BitTorrent::Torrent *const torrent) const
+{
+    const int row = getTorrentRow(torrent);
+    if (row < 0)
+        return {};
+
+    return index(row);
+}
+
 void TransferListModel::handleTorrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)
 {
     const int row = getTorrentRow(torrent);

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -113,6 +113,7 @@ public:
     Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     BitTorrent::Torrent *torrentHandle(const QModelIndex &index) const;
+    QModelIndex torrentIndex(BitTorrent::Torrent *torrent) const;
 
 private slots:
     void addTorrents(const QList<BitTorrent::Torrent *> &torrents);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -316,6 +316,22 @@ void TransferListWidget::torrentDoubleClicked()
     }
 }
 
+bool TransferListWidget::selectTorrent(BitTorrent::Torrent *const torrent)
+{
+    const QModelIndex sourceIndex = m_listModel->torrentIndex(torrent);
+    if (!sourceIndex.isValid())
+        return false;
+
+    const QModelIndex proxyIndex = m_sortFilterModel->mapFromSource(sourceIndex);
+    if (!proxyIndex.isValid())
+        return false;  // the torrent is hidden by the current filters
+
+    const QModelIndex index = m_sortFilterModel->index(proxyIndex.row(), TransferListModel::TR_NAME);
+    selectionModel()->setCurrentIndex(index, (QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
+    scrollTo(index);
+    return true;
+}
+
 QList<BitTorrent::Torrent *> TransferListWidget::getSelectedTorrents() const
 {
     const QModelIndexList selectedRows = selectionModel()->selectedRows();

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -61,6 +61,7 @@ public:
     TransferListWidget(IGUIApplication *app, QWidget *parent);
     ~TransferListWidget() override;
     TransferListModel *getSourceModel() const;
+    bool selectTorrent(BitTorrent::Torrent *torrent);
 
 public slots:
     void setSelectionCategory(const QString &category);


### PR DESCRIPTION
When a `.torrent` file or magnet link that is already in the transfer list is
opened, qBittorrent shows the "Torrent is already present" dialog but does
nothing else. 
`GUIAddTorrentManager::processTorrent()` now reveals the existing torrent
before the dialog is shown: the transfers tab is brought to the front, the
torrent is selected and scrolled into view. Since this happens before the
modal dialog, the highlighted row and its content in the properties panel are
visible right behind the dialog.
If the existing torrent is currently hidden by the transfer list filters,
`TransferListWidget::selectTorrent()` returns `false` and the current
selection is left untouched.

Closes #21090.





### Screenshots

Before | After
<img width="1215" height="725" alt="image" src="https://github.com/user-attachments/assets/bf66247c-233f-48f3-897b-504f81301767" /> | 
<img width="1220" height="738" alt="image" src="https://github.com/user-attachments/assets/1a1d26bc-834a-42e7-9f52-17205f3becad" />
<img width="1206" height="717" alt="image" src="https://github.com/user-attachments/assets/74050fbc-ad91-4a7a-8278-b145fe6b3024" />


