### PR TITLE
Skip processing of already being added torrent source

### DIFF
--- a/src/base/addtorrentmanager.cpp
+++ b/src/base/addtorrentmanager.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015-2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -60,6 +60,9 @@ bool AddTorrentManager::addTorrent(const QString &source, const BitTorrent::AddT
 
     if (Net::DownloadManager::hasSupportedScheme(source))
     {
+        if (m_downloadedTorrents.contains(source))
+            return true;
+
         LogMsg(tr("Downloading torrent... Source: \"%1\"").arg(source));
         const auto *pref = Preferences::instance();
         // Launch downloader

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2022-2025  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2012  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -758,6 +758,9 @@ void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &metadata
         return;
 
     BitTorrent::TorrentDescriptor &torrentDescr = m_currentContext->torrentDescr;
+    if (torrentDescr.info())
+        return;
+
     Q_ASSERT(metadata.matchesInfoHash(torrentDescr.infoHash()));
     if (!metadata.matchesInfoHash(torrentDescr.infoHash())) [[unlikely]]
         return;

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -110,6 +110,9 @@ bool GUIAddTorrentManager::addTorrent(const QString &source, const BitTorrent::A
 
     if (Net::DownloadManager::hasSupportedScheme(source))
     {
+        if (m_downloadedTorrents.contains(source))
+            return true;
+
         LogMsg(tr("Downloading torrent... Source: \"%1\"").arg(source));
         // Launch downloader
         Net::DownloadManager::instance()->download(Net::DownloadRequest(source).limit(pref->getTorrentFileSizeLimit())
@@ -191,6 +194,18 @@ bool GUIAddTorrentManager::processTorrent(const QString &source
 {
     const bool hasMetadata = torrentDescr.info().has_value();
     const BitTorrent::InfoHash infoHash = torrentDescr.infoHash();
+
+    if (AddNewTorrentDialog *dialog = m_dialogs.value(infoHash))
+    {
+        if (hasMetadata)
+            dialog->updateMetadata(*torrentDescr.info());
+
+        dialog->setWindowState(dialog->windowState() & ~Qt::WindowMinimized);
+        dialog->show();
+        dialog->activateWindow();
+        dialog->raise();
+        return true;
+    }
 
     // Prevent showing the dialog if download is already present
     if (BitTorrent::Torrent *torrent = btSession()->findTorrent(infoHash))

--- a/src/gui/guiaddtorrentmanager.h
+++ b/src/gui/guiaddtorrentmanager.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015-2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2026  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -54,7 +54,7 @@ enum class AddTorrentOption
     SkipDialog,
 };
 
-class GUIAddTorrentManager : public GUIApplicationComponent<AddTorrentManager>
+class GUIAddTorrentManager final : public GUIApplicationComponent<AddTorrentManager>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(GUIAddTorrentManager)

--- a/src/gui/trackerlist/trackerlistmodel.cpp
+++ b/src/gui/trackerlist/trackerlistmodel.cpp
@@ -53,6 +53,7 @@
 #include "base/bittorrent/trackerentry.h"
 #include "base/bittorrent/trackerentrystatus.h"
 #include "base/global.h"
+#include "base/utils/hashvalue.h"
 #include "base/utils/misc.h"
 
 using namespace std::chrono_literals;
@@ -104,11 +105,6 @@ namespace
 
         return TrackerListModel::tr(STR_WORKING);
     }
-}
-
-std::size_t hash_value(const QString &string)
-{
-    return qHash(string);
 }
 
 struct TrackerListModel::Item final


### PR DESCRIPTION
* Don't start duplicate downloading from already downloading source URL.
* Don't show yet another Add new torrent dialog for the torrent source the dialog is already shown for. Activate existing dialog instead.

Closes #24683.
