### PR TITLE
Fix API key session handling to avoid invalid static_cast

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -749,8 +749,12 @@ QString WebApplication::clientId() const
 
 void WebApplication::setSessionCookie(Http::HeaderMap &headers)
 {
+    if (!m_currentSession || 
+        (m_currentSession->type() != WebSessionType::CookieBased))
+        return;
+
     auto *currentSession = static_cast<CookieBasedWebSession *>(m_currentSession);
-    if (currentSession && currentSession->shouldRefreshCookie())
+    if (currentSession->shouldRefreshCookie())
     {
         // 'Permanent Cookie' still require an expiration date so set it to a date in the distant future
         const std::chrono::seconds cookieExpireDuration = (m_sessionTimeout > 0s) ? m_sessionTimeout : std::chrono::years(1);
@@ -887,7 +891,10 @@ void WebApplication::sessionStartImpl(const QString &sessionId, const WebSession
 
     m_currentSession = WebSession::create(sessionType, sessionId);
     m_sessions[m_currentSession->id()] = m_currentSession;
-    m_sessionStateChange = SessionStateChange::Start;
+
+    m_sessionStateChange = (sessionType == WebSessionType::CookieBased)
+        ? SessionStateChange::Start
+        : SessionStateChange::None;
 
     m_currentSession->registerAPIController(u"app"_s, [app = app(), parent = m_currentSession] { return new AppController(app, parent); });
     m_currentSession->registerAPIController(u"log"_s, [app = app(), parent = m_currentSession] { return new LogController(app, parent); });
@@ -918,10 +925,14 @@ void WebApplication::sessionStartImpl(const QString &sessionId, const WebSession
 void WebApplication::sessionEnd()
 {
     Q_ASSERT(m_currentSession);
+    const bool isCookieBased =
+       (m_currentSession->type() == WebSessionType::CookieBased);
 
     delete m_sessions.take(m_currentSession->id());
     m_currentSession = nullptr;
-    m_sessionStateChange = SessionStateChange::End;
+    m_sessionStateChange = isCookieBased
+       ? SessionStateChange::End
+       : SessionStateChange::None;
 }
 
 bool WebApplication::isOriginTrustworthy() const


### PR DESCRIPTION
An invalid static_cast can be triggered by simply issuing a request with the bearer API token.  Avoid the illegal cast and improve session state changes for API key-based requests.

Steps to reproduce:
`curl -v   -H 'Authorization: Bearer qbt_secret'   http://127.0.0.1:8080/api/v2/app/version`

When running under sanitizer, this will trigger:
```
/var/tmp/portage/net-p2p/qbittorrent-9999/work/qbittorrent-9999/src/webui/webapplication.cpp:752:28: runtime error: downcast of address 0x7864e1e6a180 which does not point to an object of type 'CookieBasedWebSession'
0x7864e1e6a180: note: object is of type 'APIKeyBasedWebSession'
 00 00 00 00  b0 d6 b5 9f d1 5f 00 00  40 68 30 e2 b4 78 00 00  38 d7 b5 9f d1 5f 00 00  20 75 f9 e2
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'APIKeyBasedWebSession'
```
