### PR TITLE
WebAPI: Do not set cookies for API key based web session

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -386,18 +386,6 @@ void WebApplication::processAPIRequest(const QString &endpoint, const Http::Head
 
         Http::Response response {.headers = commonHeaders};
 
-        if (m_sessionStateChange == SessionStateChange::Start)
-        {
-            setSessionCookie(response.headers);
-        }
-        else if (m_sessionStateChange == SessionStateChange::End)
-        {
-            QNetworkCookie cookie {m_sessionCookieName.toLatin1()};
-            cookie.setPath(u"/"_s);
-            cookie.setExpirationDate(QDateTime::currentDateTime().addDays(-1));
-            response.headers.insert(Http::HEADER_SET_COOKIE, QString::fromLatin1(cookie.toRawForm()));
-        }
-
         const auto result = std::get<RegularAPIResult>(apiResult);
         if (result.data.isNull())
         {

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -316,7 +316,7 @@ void WebApplication::setPasswordHash(const QByteArray &passwordHash)
     m_passwordHash = passwordHash;
 }
 
-void WebApplication::processAPIRequest(const QString &endpoint, const Http::HeaderMap &commonHeaders, Http::ResponseWriter &responseWriter)
+void WebApplication::processAPIRequest(const QString &endpoint, const Http::HeaderMap &commonHeaders, Http::ResponseWriter &responseWriter, const bool isUsingApiKey)
 {
     const auto [scope, action] = parseAPIEndpoint(endpoint);
     if (scope.isEmpty())
@@ -385,6 +385,21 @@ void WebApplication::processAPIRequest(const QString &endpoint, const Http::Head
         }
 
         Http::Response response {.headers = commonHeaders};
+
+        if (!isUsingApiKey)
+        {
+            if (m_sessionStateChange == SessionStateChange::Start)
+            {
+                setSessionCookie(response.headers);
+            }
+            else if (m_sessionStateChange == SessionStateChange::End)
+            {
+                QNetworkCookie cookie {m_sessionCookieName.toLatin1()};
+                cookie.setPath(u"/"_s);
+                cookie.setExpirationDate(QDateTime::currentDateTime().addDays(-1));
+                response.headers.insert(Http::HEADER_SET_COOKIE, QString::fromLatin1(cookie.toRawForm()));
+            }
+        }
 
         const auto result = std::get<RegularAPIResult>(apiResult);
         if (result.data.isNull())
@@ -710,7 +725,7 @@ void WebApplication::processRequest(const Http::Request &request, const Http::En
             if (isUsingApiKey && (endpoint.startsWith(u"auth/")))
                 throw ForbiddenHTTPError();
 
-            processAPIRequest(endpoint, commonHeaders, responseWriter);
+            processAPIRequest(endpoint, commonHeaders, responseWriter, isUsingApiKey);
         }
         else
         {

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -99,7 +99,7 @@ private:
     void sessionStartImpl(const QString &sessionId, WebSessionType sessionType);
     void sessionEnd() override;
 
-    void processAPIRequest(const QString &endpoint, const Http::HeaderMap &commonHeaders, Http::ResponseWriter &responseWriter);
+    void processAPIRequest(const QString &endpoint, const Http::HeaderMap &commonHeaders, Http::ResponseWriter &responseWriter, bool isUsingApiKey);
     void configure();
 
     void declarePublicAPI(const QString &apiPath);


### PR DESCRIPTION
Related issue: https://github.com/qbittorrent/qBittorrent/pull/24744

Based on this comment: https://github.com/qbittorrent/qBittorrent/pull/24744#issuecomment-5086268966

Also the API key based web session is leaking keys in the cookies
<img width="1346" height="501" alt="Screenshot 2026-07-26 at 9 29 51 PM" src="https://github.com/user-attachments/assets/bdb88cb5-0f5a-4e49-b0ac-51daeb88c9fb" />

Note: I think the changes in #24744 might be good enough to fix this leaking key issue. 

