### PR TITLE
GHA CI: switch back to `ubuntu-latest` runner for WebUI

### DIFF
--- a/.github/workflows/ci_webui.yaml
+++ b/.github/workflows/ci_webui.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   ci:
     name: Check
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
 


### PR DESCRIPTION
The slim runner was too weak and frequently timed out, so revert to the normal runner.

Partially reverts eb593aa8464a7dcce363789525a4ce31896f5495.
