### PR TITLE
Improve build script for Lua

### DIFF
--- a/src/base/3rdparty/lua/CMakeLists.txt
+++ b/src/base/3rdparty/lua/CMakeLists.txt
@@ -82,7 +82,17 @@ target_include_directories(qbt_lua
     PRIVATE "include/lua"
 )
 
-set_target_properties(qbt_lua PROPERTIES COMPILE_OPTIONS "-w")
+target_compile_definitions(qbt_lua
+    PUBLIC
+        $<$<PLATFORM_ID:Darwin>:LUA_USE_MACOSX>
+        $<$<PLATFORM_ID:Linux>:LUA_USE_LINUX>
+        # luaconf.h will define `LUA_USE_WINDOWS` automatically on Windows
+)
+
+target_compile_options(qbt_lua
+    PRIVATE
+        -w
+)
 
 target_link_libraries(qbt_lua
     PRIVATE

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -290,7 +290,7 @@ if (PLUGINS)
     set_target_properties(qbt_luabridge PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:qbt_luabridge,INTERFACE_INCLUDE_DIRECTORIES>)
 
     target_compile_definitions(qbt_base PUBLIC ENABLE_PLUGINS)
-    target_link_libraries(qbt_base PUBLIC qbt_lua qbt_luabridge)
+    target_link_libraries(qbt_base PRIVATE qbt_lua qbt_luabridge)
 
     target_sources(qbt_base PRIVATE
             plugins/luaclasses.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -267,7 +267,8 @@ target_link_libraries(qbt_gui
     PRIVATE
         qbt_base
     PUBLIC
-        Qt::Gui Qt::Widgets
+        Qt::Gui
+        Qt::Widgets
 )
 
 if (DBUS)


### PR DESCRIPTION
* Use platform defines for Lua This prevents using outdated system calls on each platform. Addresses the following warning from the CI: https://github.com/qbittorrent/qBittorrent/actions/runs/30277287206/job/90014446818#step:9:597 ``` /home/runner/work/qBittorrent/qBittorrent/src/base/3rdparty/lua/src/loslib.c:175:(.text+0x424): warning: the use of `tmpnam' is dangerous, better use `mkstemp' ```
* Restrict Lua targets to `PRIVATE` Ideally, only `base` target should interact with Lua directly.
