### PR TITLE
GHA CI: Bump action versions

### DIFF
--- a/.github/workflows/ci_file_health.yaml
+++ b/.github/workflows/ci_file_health.yaml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "*"
 

--- a/.github/workflows/ci_python.yaml
+++ b/.github/workflows/ci_python.yaml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup python (auxiliary scripts)
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3'  # use default version
 
@@ -54,7 +54,7 @@ jobs:
           python -m compileall $PY_FILES
 
       - name: Setup python (search engine)
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/ci_webui.yaml
+++ b/.github/workflows/ci_webui.yaml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup nodejs
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/stale_bot.yaml
+++ b/.github/workflows/stale_bot.yaml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Mark and close stale PRs
-        uses: actions/stale@v10
+        uses: actions/stale@v11
         with:
           stale-pr-message: "This PR is stale because it has been 60 days with no activity. This PR will be automatically closed within 7 days if there is no further activity."
           close-pr-message: "This PR was closed because it has been stalled for some time with no activity."


### PR DESCRIPTION
Due to the following upstream issue, we couldn't use the PR from dependabot for now.
https://github.com/dependabot/dependabot-core/issues/15738
https://github.com/qbittorrent/qBittorrent/pull/24767

