### PR TITLE
Remove middle-click tab closing functionality

### DIFF
--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -457,7 +457,6 @@ bool SearchWidget::eventFilter(QObject *object, QEvent *event)
 {
     if (object == m_ui->tabWidget->tabBar())
     {
-        // Close tabs when middle-clicked
         if (event->type() != QEvent::MouseButtonRelease)
             return false;
 
@@ -465,12 +464,6 @@ bool SearchWidget::eventFilter(QObject *object, QEvent *event)
         const int tabIndex = m_ui->tabWidget->tabBar()->tabAt(mouseEvent->pos());
         if (tabIndex >= 0)
         {
-            if (mouseEvent->button() == Qt::MiddleButton)
-            {
-                closeTab(tabIndex);
-                return true;
-            }
-
             if (mouseEvent->button() == Qt::RightButton)
             {
                 showTabMenu(tabIndex);


### PR DESCRIPTION
Removed the functionality to close tabs with middle-click.

See #24265. 

The rationale for this is that it is easy to click the middle button (esp. on a trackpad) rather than the right button, and the tab is closed immediately without any way of recalling what was being searched or to undo the closure.

If you want to close the tab you can still right click and select close.