### PR TITLE
Make status bar icon adapt to system appearance on macOS

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -84,6 +84,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         "${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns"
         "${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentIncompleteData.icns"
         "${qBittorrent_SOURCE_DIR}/dist/mac/qbittorrent_mac.icns"
+        "${qBittorrent_SOURCE_DIR}/src/icons/qbittorrent-tray-light.svg"
             PROPERTIES
                 MACOSX_PACKAGE_LOCATION Resources
     )
@@ -115,6 +116,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         ${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns
         ${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentIncompleteData.icns
         ${qBittorrent_SOURCE_DIR}/dist/mac/qbittorrent_mac.icns
+        ${qBittorrent_SOURCE_DIR}/src/icons/qbittorrent-tray-light.svg
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(qbt_app PROPERTIES WIN32_EXECUTABLE ON)

--- a/src/gui/macosstatusitem/itemview.mm
+++ b/src/gui/macosstatusitem/itemview.mm
@@ -56,8 +56,10 @@ namespace
         self.fDownloadRate = 0.0;
         self.fUploadRate = 0.0;
 
-        NSImage *icon = [NSImage imageNamed:@"qbittorrent_mac"];
+        NSString *iconPath = [NSBundle.mainBundle pathForResource:@"qbittorrent-tray-light" ofType:@"svg"];
+        NSImage *icon = [[NSImage alloc] initWithContentsOfFile:iconPath];
         [icon setSize:NSMakeSize(16, 16)];
+        [icon setTemplate:YES];
 
         self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
         self.statusItem.button.image = icon;


### PR DESCRIPTION
## Description

On macOS, the qBittorrent status bar icon is currently displayed as a regular colored image. This makes it inconsistent with native macOS menu bar items, which use template images and automatically adapt to light/dark appearance.

This change marks the status bar icon as a template image so macOS can render it using the system monochrome appearance.

## Motivation

The current icon does not match other menu bar icons on macOS and remains colored in both light and dark modes.

Using a template image follows Apple's recommended approach for menu bar icons and improves visual consistency with the operating system.

## Testing

Tested on macOS Sequoia:
- status bar icon follows system appearance
- light mode displays correctly
- dark mode displays correctly
- no changes to Windows/Linux behavior