### PR TITLE
Fix black screen on close MacOS

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1205,7 +1205,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
     if (!m_forceExit)
     {
         hide();
-        e->ignore();
+        e->accept();
         return;
     }
 #else


### PR DESCRIPTION
This is a simple fix for an issue where closing qBittorrent while in fullscreen causes the application to show a black screen.

Tested locally using Qt 6.11.1 installed via Homebrew on macOS.

<img width="463" height="624" alt="system" src="https://github.com/user-attachments/assets/7656d4b8-3ea7-4dcc-829c-83f20083ee39" />

