### PR TITLE
WebUI: Only open http(s) URLs from RSS articles and search results

### DIFF
--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -33,6 +33,7 @@ window.qBittorrent.Misc ??= (() => {
     const exports = () => {
         return {
             getHost: getHost,
+            isHttpUrl: isHttpUrl,
             createDebounceHandler: createDebounceHandler,
             filterInPlace: filterInPlace,
             friendlyUnit: friendlyUnit,
@@ -78,6 +79,22 @@ window.qBittorrent.Misc ??= (() => {
         }
         catch (error) {
             return url;
+        }
+    };
+
+    /**
+     * Whether the URL is safe to navigate to, i.e. it doesn't use a scheme such as `javascript:`
+     *
+     * @param {string} url a URL, possibly relative to the current document
+     * @returns {boolean}
+     */
+    const isHttpUrl = (url) => {
+        try {
+            const scheme = new URL(url, window.location).protocol;
+            return (scheme === "http:") || (scheme === "https:");
+        }
+        catch (error) {
+            return false;
         }
     };
 

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -597,8 +597,21 @@ window.qBittorrent.Search ??= (() => {
     };
 
     const openSearchTorrentDescriptionUrl = () => {
-        for (const rowID of searchResultsTable.selectedRowsIds())
-            window.open(searchResultsTable.getRow(rowID).full_data.descrLink, "_blank");
+        const blockedUrls = [];
+        for (const rowID of searchResultsTable.selectedRowsIds()) {
+            const { descrLink, fileName } = searchResultsTable.getRow(rowID).full_data;
+            if (window.qBittorrent.Misc.isHttpUrl(descrLink)) {
+                window.open(descrLink, "_blank");
+            }
+            else {
+                console.error(`Blocked opening search result description page URL. Only http:// and https:// links can be opened. Name: "${fileName}". URL: "${descrLink}".`);
+                // collapse whitespace and cap the length so that a crafted URL can't pad the dialog with its own text
+                blockedUrls.push(descrLink.replace(/\s+/g, " ").slice(0, 256));
+            }
+        }
+
+        if (blockedUrls.length > 0)
+            alert(`QBT_TR(Blocked opening search result description page URL. Only http:// and https:// links can be opened.)QBT_TR[CONTEXT=SearchJobWidget]\n\n${blockedUrls.join("\n")}`);
     };
 
     const copySearchTorrentName = () => {

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -227,6 +227,7 @@
         };
 
         const serverSyncRssDataInterval = 1500;
+        const blockedArticleUrlMessage = "QBT_TR(Blocked opening RSS article URL. Only http:// and https:// links can be opened.)QBT_TR[CONTEXT=RSSWidget]";
         let feedData = {};
         let pathByFeedId = new Map();
         let feedRefreshTimer = -1;
@@ -331,8 +332,21 @@
                         }
                     },
                     OpenNews: (el) => {
-                        for (const rowID of rssArticleTable.selectedRows)
-                            window.open(rssArticleTable.getRow(rowID).full_data.link);
+                        const blockedUrls = [];
+                        for (const rowID of rssArticleTable.selectedRows) {
+                            const { link, name } = rssArticleTable.getRow(rowID).full_data;
+                            if (window.qBittorrent.Misc.isHttpUrl(link)) {
+                                window.open(link);
+                            }
+                            else {
+                                console.error(`Blocked opening RSS article URL. Only http:// and https:// links can be opened. Article: "${name}". URL: "${link}".`);
+                                // collapse whitespace and cap the length so that a crafted URL can't pad the dialog with its own text
+                                blockedUrls.push(link.replace(/\s+/g, " ").slice(0, 256));
+                            }
+                        }
+
+                        if (blockedUrls.length > 0)
+                            alert(`${blockedArticleUrlMessage}\n\n${blockedUrls.join("\n")}`);
                     }
                 },
                 offsets: {
@@ -522,7 +536,10 @@
                 divElement.id = "rssTorrentDetailsLink";
 
                 const anchorElement = document.createElement("a");
-                anchorElement.href = articleLink;
+                if (window.qBittorrent.Misc.isHttpUrl(articleLink))
+                    anchorElement.href = articleLink;
+                else
+                    anchorElement.title = blockedArticleUrlMessage;
                 anchorElement.textContent = "QBT_TR(Open link)QBT_TR[CONTEXT=RSSWidget]";
                 anchorElement.target = "_blank";
                 anchorElement.style = "font-weight: bold;";

--- a/src/webui/www/test/private/misc.test.js
+++ b/src/webui/www/test/private/misc.test.js
@@ -30,6 +30,32 @@ import { expect, test, vi } from "vitest";
 
 import "../../private/scripts/misc.js";
 
+test("Test isHttpUrl()", () => {
+    const isHttpUrl = window.qBittorrent.Misc.isHttpUrl;
+
+    expect(isHttpUrl("http://example.com")).toBe(true);
+    expect(isHttpUrl("https://example.com/path?a=b#c")).toBe(true);
+    expect(isHttpUrl("HTTPS://EXAMPLE.COM")).toBe(true);
+    expect(isHttpUrl("  https://example.com  ")).toBe(true);
+    // relative URLs are resolved against the document URL
+    expect(isHttpUrl("")).toBe(true);
+    expect(isHttpUrl("/foo")).toBe(true);
+
+    expect(isHttpUrl("javascript:alert(1)")).toBe(false);
+    expect(isHttpUrl("JavaScript:alert(1)")).toBe(false);
+    expect(isHttpUrl("  javascript:alert(1)")).toBe(false);
+    expect(isHttpUrl("java\tscript:alert(1)")).toBe(false);
+    expect(isHttpUrl("java\nscript:alert(1)")).toBe(false);
+    expect(isHttpUrl("java\rscript:alert(1)")).toBe(false);
+    expect(isHttpUrl("vbscript:msgbox(1)")).toBe(false);
+    expect(isHttpUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isHttpUrl("blob:https://example.com/1234")).toBe(false);
+    expect(isHttpUrl("file:///etc/passwd")).toBe(false);
+    expect(isHttpUrl("ftp://example.com")).toBe(false);
+    expect(isHttpUrl("mailto:someone@example.com")).toBe(false);
+    expect(isHttpUrl("magnet:?xt=urn:btih:0000000000000000000000000000000000000000")).toBe(false);
+});
+
 test("Test filterInPlace()", () => {
     const filterInPlace = (array, predicate) => {
         window.qBittorrent.Misc.filterInPlace(array, predicate);


### PR DESCRIPTION
Opening a malicious URI (e.g. `javascript:`) via Search or RSS can result in running arbitrary JS in the same origin as the WebUI session. This would allow modifying settings, including "run external program on torrent completion". This PR ensures that only http and https URLs are opened.
