### PR TITLE
WebUI: Detect cross-site requests using `Sec-Fetch-Site` header

### DIFF
--- a/src/base/http/constants.h
+++ b/src/base/http/constants.h
@@ -53,6 +53,7 @@ namespace Http
     inline const QString HEADER_RANGE = u"range"_s;
     inline const QString HEADER_REFERER = u"referer"_s;
     inline const QString HEADER_REFERRER_POLICY = u"referrer-policy"_s;
+    inline const QString HEADER_SEC_FETCH_SITE = u"sec-fetch-site"_s;
     inline const QString HEADER_SET_COOKIE = u"set-cookie"_s;
     inline const QString HEADER_X_CONTENT_TYPE_OPTIONS = u"x-content-type-options"_s;
     inline const QString HEADER_X_FORWARDED_FOR = u"x-forwarded-for"_s;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -983,9 +983,26 @@ bool WebApplication::isCrossSiteRequest(const Http::Request &request) const
 
     if (originValue.isEmpty() && refererValue.isEmpty())
     {
-        // owasp.org recommends to block this request, but doing so will inevitably lead Web API users to spoof headers
-        // so lets be permissive here
-        return false;
+        // A page can suppress both 'Origin' and 'Referer', so fall back to 'Sec-Fetch-Site', which is
+        // set by the browser itself and cannot be tampered with by the requesting page.
+        const QString secFetchSiteValue = request.headers.value(Http::HEADER_SEC_FETCH_SITE);
+        if (secFetchSiteValue.isEmpty())
+        {
+            // owasp.org recommends to block this request, but doing so will inevitably lead Web API users to spoof headers
+            // so let's be permissive here (Web API clients don't send 'Sec-Fetch-Site' at all)
+            return false;
+        }
+
+        // "none" means the request wasn't initiated by a page (typed URL, bookmark, etc.)
+        const bool isValid = (secFetchSiteValue.compare(u"same-origin", Qt::CaseInsensitive) == 0)
+                || (secFetchSiteValue.compare(u"none", Qt::CaseInsensitive) == 0);
+        if (!isValid)
+        {
+            LogMsg(tr("WebUI: Cross-site request blocked. Source IP: '%1'. Sec-Fetch-Site header: '%2'. Target origin: '%3'")
+                   .arg(m_env.clientAddress.toString(), secFetchSiteValue, targetOrigin)
+                   , Log::WARNING);
+        }
+        return !isValid;
     }
 
     // sent with CORS requests, as well as with POST requests


### PR DESCRIPTION
When both `Origin` and `Referer` headers were absent the request was always accepted, so an attacker page could opt out of the Referer check by setting `Referrer-Policy: no-referrer`. `Sec-Fetch-Site` is set by the browser and cannot be suppressed or forged by the initiating page.

Browsers only send it to secure origins, so this covers HTTPS and localhost deployments. Clients that don't send it keep the previous permissive path.
