### PR TITLE
Fix recheck with externally added files

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1713,6 +1713,41 @@ void TorrentImpl::forceRecheck()
     if (!hasMetadata())
         return;
 
+    if (isStopped() && m_session->isAppendExtensionEnabled())
+    {
+        const Path storagePath = actualStorageLocation();
+        bool normalizationFailed = false;
+
+        for (int i = 0; i < filesCount(); ++i)
+        {
+            const Path regularRelativePath = filePath(i);
+            const Path expectedIncompletePath = regularRelativePath + QB_EXT;
+
+            // Only normalize files for which libtorrent already expects
+            // the corresponding .!qB path.
+            if (actualFilePath(i) != expectedIncompletePath)
+                continue;
+
+            const Path regularPath = storagePath / regularRelativePath;
+            const Path incompletePath = storagePath / expectedIncompletePath;
+
+            // Missing files are valid. If both paths exist, leave them
+            // untouched rather than overwriting either one.
+            if (!regularPath.exists() || incompletePath.exists())
+                continue;
+
+            if (!Utils::Fs::renameFile(regularPath, incompletePath))
+            {
+                normalizationFailed = true;
+                LogMsg(tr("Failed to append .!qB before rechecking torrent \"%1\": %2")
+                    .arg(name(), regularPath.toString()), Log::WARNING);
+            }
+        }
+
+        if (normalizationFailed)
+            return;
+    }
+
     m_nativeHandle.force_recheck();
 
     // We have to force update the cached state, otherwise someone will be able to get


### PR DESCRIPTION
Fixes #21987.

When "Append .!qB extension to incomplete files" is enabled, a stopped
torrent may already have its libtorrent file paths registered with the
.!qB suffix.

If the user later copies existing files using their regular filenames,
the first Force Recheck only renames those files to .!qB, requiring a
second Force Recheck to actually start hashing.

This change normalizes only the files that:

- are expected by libtorrent with the .!qB suffix,
- exist under their regular filename,
- and do not already exist under the .!qB filename.

Missing files are left untouched, which preserves partial-content
rechecks. If both filenames exist, neither file is modified.

The filesystem rename is synchronous and does not alter libtorrent's
internal file mapping, since libtorrent already expects the .!qB path.

Tested successfully with qBittorrent 5.2.3 and verified to compile on
current master.
