### PR TITLE
Only auto-download torrents from http(s), magnet, or info hash sources

### DIFF
--- a/src/base/rss/rss_article.cpp
+++ b/src/base/rss/rss_article.cpp
@@ -32,6 +32,7 @@
 
 #include <QVariant>
 
+#include "base/bittorrent/torrentdescriptor.h"
 #include "base/global.h"
 #include "rss_feed.h"
 
@@ -119,6 +120,14 @@ void Article::markAsRead()
 bool Article::articleDateRecentThan(const Article *article, const QDateTime &date)
 {
     return article->date() > date;
+}
+
+bool Article::isSupportedTorrentURL(const QString &url)
+{
+    return url.startsWith(u"http:"_s, Qt::CaseInsensitive)
+            || url.startsWith(u"https:"_s, Qt::CaseInsensitive)
+            || url.startsWith(u"magnet:"_s, Qt::CaseInsensitive)
+            || BitTorrent::TorrentDescriptor::parse(url).has_value();
 }
 
 Feed *Article::feed() const

--- a/src/base/rss/rss_article.h
+++ b/src/base/rss/rss_article.h
@@ -72,6 +72,7 @@ namespace RSS
         void markAsRead();
 
         static bool articleDateRecentThan(const Article *article, const QDateTime &date);
+        static bool isSupportedTorrentURL(const QString &url);
 
     signals:
         void read(Article *article = nullptr);

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -499,10 +499,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
                 .arg(job->articleData.value(Article::KeyTitle).toString(), rule.name()));
 
         const auto torrentURL = job->articleData.value(Article::KeyTorrentURL).toString();
-        if (!torrentURL.startsWith(u"http:"_s, Qt::CaseInsensitive)
-                && !torrentURL.startsWith(u"https:"_s, Qt::CaseInsensitive)
-                && !torrentURL.startsWith(u"magnet:"_s, Qt::CaseInsensitive)
-                && !BitTorrent::TorrentDescriptor::parse(torrentURL).has_value())
+        if (!Article::isSupportedTorrentURL(torrentURL))
         {
             LogMsg(tr("Failed to add torrent from RSS article. Reason: unsupported torrent URL."
                       " Only HTTP(S) URLs, magnet URIs and info hashes are supported."

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -499,6 +499,18 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
                 .arg(job->articleData.value(Article::KeyTitle).toString(), rule.name()));
 
         const auto torrentURL = job->articleData.value(Article::KeyTorrentURL).toString();
+        if (!torrentURL.startsWith(u"http:"_s, Qt::CaseInsensitive)
+                && !torrentURL.startsWith(u"https:"_s, Qt::CaseInsensitive)
+                && !torrentURL.startsWith(u"magnet:"_s, Qt::CaseInsensitive)
+                && !BitTorrent::TorrentDescriptor::parse(torrentURL).has_value())
+        {
+            LogMsg(tr("Failed to add torrent from RSS article. Reason: unsupported torrent URL."
+                      " Only HTTP(S) URLs, magnet URIs and info hashes are supported."
+                      " Article: \"%1\". URL: \"%2\"")
+                    .arg(job->articleData.value(Article::KeyTitle).toString(), torrentURL), Log::WARNING);
+            return;
+        }
+
         app()->addTorrentManager()->addTorrent(torrentURL, rule.addTorrentParams());
 
         if (BitTorrent::TorrentDescriptor::parse(torrentURL))

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -451,6 +451,8 @@ void RSSWidget::refreshAllFeeds()
 
 void RSSWidget::downloadSelectedTorrents()
 {
+    qsizetype badURLCount = 0;
+    QString articleTitle;
     for (QListWidgetItem *item : asConst(m_ui->articleListWidget->selectedItems()))
     {
         auto *article = item->data(Qt::UserRole).value<RSS::Article *>();
@@ -459,7 +461,29 @@ void RSSWidget::downloadSelectedTorrents()
         // Mark as read
         article->markAsRead();
 
-        app()->addTorrentManager()->addTorrent(article->torrentUrl());
+        const QString torrentURL = article->torrentUrl();
+        if (!RSS::Article::isSupportedTorrentURL(torrentURL))
+        {
+            if (badURLCount == 0)
+                articleTitle = article->title();
+            ++badURLCount;
+
+            LogMsg(tr("Blocked adding torrent from RSS article. Unsupported torrent URL."
+                      " Only HTTP(S) URLs, magnet URIs and info hashes are supported."
+                      " Article: \"%1\". URL: \"%2\".")
+                    .arg(article->title(), torrentURL), Log::WARNING);
+            continue;
+        }
+
+        app()->addTorrentManager()->addTorrent(torrentURL);
+    }
+
+    if (badURLCount > 0)
+    {
+        QString message = tr("Blocked adding torrent from RSS article. The following article has an unsupported torrent URL and it may be malicious behaviour:\n%1").arg(articleTitle);
+        if (badURLCount > 1)
+            message.append(u"\n" + tr("There are %1 more articles with the same issue.").arg(badURLCount - 1));
+        QMessageBox::warning(this, u"qBittorrent"_s, message, QMessageBox::Ok);
     }
 }
 


### PR DESCRIPTION
A torrent URL taken verbatim from remote feed XML was passed unvalidated to `AddTorrentManager::addTorrent`, which treats a string with no supported scheme as a local filesystem path and wraps it in a `TorrentFileGuard`. With `Core/AutoDeleteAddedTorrentFile` set to Always, a feed could therefore delete any file the process can unlink, with no user interaction once a rule matched. The same value also reached `Net::DownloadManager` for any scheme `QNetworkAccessManager` supports, including `file:` and `qrc:`.

We now validate the raw value before it reaches addTorrent, mirroring `hasSupportedScheme`'s own startsWith form so the check cannot diverge from the routing it guards. Bare info hashes remain accepted via `TorrentDescriptor::parse`, which is what `addTorrent` itself uses.

