### PR TITLE
GHA CI: Raise the libtorrent versions

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -19,12 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         libtorrent:
-          - version: "2.1.0"
+          - version: "2.1.1"
             boost_major_version: "1"
             boost_minor_version: "91"
             boost_patch_version: "0"
-            libt_build_flags: "-Dwebtorrent=ON"
-          - version: "2.0.13"
+            libt_build_flags: ""
+          - version: "2.0.14"
             boost_major_version: "1"
             boost_minor_version: "91"
             boost_patch_version: "0"

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -20,12 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         libtorrent:
-          - version: "2.1.0"
+          - version: "2.1.1"
             boost_major_version: "1"
             boost_minor_version: "77"
             boost_patch_version: "0"
-            libt_build_flags: "-Dwebtorrent=ON"
-          - version: "2.0.13"
+            libt_build_flags: ""
+          - version: "2.0.14"
             boost_major_version: "1"
             boost_minor_version: "77"
             boost_patch_version: "0"

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -19,12 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         libtorrent:
-          - version: "2.1.0"
+          - version: "2.1.1"
             boost_major_version: "1"
             boost_minor_version: "91"
             boost_patch_version: "0"
-            libt_build_flags: "-Dwebtorrent=ON"
-          - version: "2.0.13"
+            libt_build_flags: ""
+          - version: "2.0.14"
             boost_major_version: "1"
             boost_minor_version: "91"
             boost_patch_version: "0"


### PR DESCRIPTION
The WebTorrent flag has also been removed: this feature is enabled by default.