### PR TITLE
Use HTTPS for dynamic DNS

### DIFF
--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -78,7 +78,7 @@ void DNSUpdater::checkPublicIP()
     Q_ASSERT(m_state == OK);
 
     DownloadManager::instance()->download(
-            DownloadRequest(u"http://checkip.dyndns.org"_s).userAgent(QStringLiteral("qBittorrent/" QBT_VERSION_2))
+            DownloadRequest(u"https://checkip.dyndns.org"_s).userAgent(QStringLiteral("qBittorrent/" QBT_VERSION_2))
             , Preferences::instance()->useProxyForGeneralPurposes(), this, &DNSUpdater::ipRequestFinished);
 
     m_lastIPCheckTime = QDateTime::currentDateTime();

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -238,6 +238,14 @@ void Net::DownloadHandlerImpl::handleRedirection(const QUrl &newUrl)
         return;
     }
 
+    if (!m_downloadRequest.allowInsecureRedirect()
+        && (m_reply->url().scheme() == u"https") && (scheme != u"https"))
+    {
+        setError(tr("Redirect from a secure to an insecure protocol: '%1'.").arg(scheme));
+        finish();
+        return;
+    }
+
     m_redirectionHandler = static_cast<DownloadHandlerImpl *>(
             m_manager->download(DownloadRequest(m_downloadRequest).url(newUrlString), useProxy()));
     m_redirectionHandler->m_redirectionCount = m_redirectionCount + 1;

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -403,6 +403,17 @@ Net::DownloadRequest &Net::DownloadRequest::destFileName(const Path &value)
     return *this;
 }
 
+bool Net::DownloadRequest::allowInsecureRedirect() const
+{
+    return m_allowInsecureRedirect;
+}
+
+Net::DownloadRequest &Net::DownloadRequest::allowInsecureRedirect(const bool value)
+{
+    m_allowInsecureRedirect = value;
+    return *this;
+}
+
 Net::ServiceID Net::ServiceID::fromURL(const QUrl &url)
 {
     return {url.host(), url.port(80)};

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -91,12 +91,20 @@ namespace Net
         Path destFileName() const;
         DownloadRequest &destFileName(const Path &value);
 
+        // when disabled, a redirection that downgrades HTTPS to a non-HTTPS scheme
+        // makes the request fail instead of being followed, matching the policy
+        // Qt applies by default (QNetworkRequest::NoLessSafeRedirectPolicy) but
+        // that we opt out of by handling redirections manually
+        bool allowInsecureRedirect() const;
+        DownloadRequest &allowInsecureRedirect(bool value);
+
     private:
         QString m_url;
         QString m_userAgent;
         qint64 m_limit = 0;
         bool m_saveToFile = false;
         Path m_destFileName;
+        bool m_allowInsecureRedirect = false;
     };
 
     struct DownloadResult


### PR DESCRIPTION
The address published to the user's dynamic DNS provider was read from a cleartext `http://` response body and then pushed to the provider with the victim's stored credentials, so an on-path attacker could repoint the victim's hostname at their own infrastructure, or pin a stale address to suppress updates.
