### PR TITLE
Clamp 'Max articles per feed' to a non-negative value

### DIFF
--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -207,6 +207,8 @@ Article *Feed::articleByGUID(const QString &guid) const
 
 void Feed::handleMaxArticlesPerFeedChanged(const int n)
 {
+    Q_ASSERT(n >= 0);
+
     while (m_articlesByDate.size() > n)
         removeOldestArticle();
     // We don't need store articles here
@@ -356,6 +358,8 @@ bool Feed::addArticle(const QVariantHash &articleData)
 
 void Feed::removeOldestArticle()
 {
+    Q_ASSERT(!m_articlesByDate.isEmpty());
+
     auto *oldestArticle = m_articlesByDate.last();
     emit articleAboutToBeRemoved(oldestArticle);
 

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -31,6 +31,7 @@
 
 #include "rss_session.h"
 
+#include <algorithm>
 #include <chrono>
 
 #include <QDebug>
@@ -65,7 +66,7 @@ Session::Session()
     : m_storeProcessingEnabled(u"RSS/Session/EnableProcessing"_s)
     , m_storeRefreshInterval(u"RSS/Session/RefreshInterval"_s, 30)
     , m_storeFetchDelay(u"RSS/Session/FetchDelay"_s, 2)
-    , m_storeMaxArticlesPerFeed(u"RSS/Session/MaxArticlesPerFeed"_s, 50)
+    , m_storeMaxArticlesPerFeed(u"RSS/Session/MaxArticlesPerFeed"_s, 50, [](const int n) { return std::max(n, 0); })
     , m_workingThread(new QThread)
 {
     Q_ASSERT(!m_instance); // only one instance is allowed
@@ -614,10 +615,11 @@ int Session::maxArticlesPerFeed() const
 
 void Session::setMaxArticlesPerFeed(const int n)
 {
-    if (m_storeMaxArticlesPerFeed != n)
+    const int maxArticles = std::max(n, 0);
+    if (m_storeMaxArticlesPerFeed != maxArticles)
     {
-        m_storeMaxArticlesPerFeed = n;
-        emit maxArticlesPerFeedChanged(n);
+        m_storeMaxArticlesPerFeed = maxArticles;
+        emit maxArticlesPerFeedChanged(maxArticles);
     }
 }
 


### PR DESCRIPTION
`app/setPreferences` passed the value straight to `Session::setMaxArticlesPerFeed`, which emitted it to every `Feed`. A negative value made `handleMaxArticlesPerFeedChanged` loop past an empty list, so `removeOldestArticle()` called `QList::last()` on it, read garbage as an `Article *`, emitted it to every `articleAboutToBeRemoved` listener, dereferenced it and deleted it. The value is persisted, so the crash recurred on every start.
