### PR TITLE
WebAPI: Allow to set category share limits

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -2,6 +2,9 @@
 
 ## 2.16.0
 
+* [#24788](https://github.com/qbittorrent/qBittorrent/pull/24788)
+  * `torrents/createCategory` and `torrents/editCategory` endpoints now accept the `ratioLimit`, `seedingTimeLimit`, `inactiveSeedingTimeLimit`, `shareLimitAction`, and `shareLimitsMode` parameters to set a category's share limits
+  * `torrents/editCategory` endpoint no longer erases a category's share limits and download path when they are not part of the request
 * [#24724](https://github.com/qbittorrent/qBittorrent/pull/24724)
   * `torrents/add` endpoint accepts `seedMode` (bool) parameter
   * `torrents/add` endpoint no longer accepts `skip_checking` parameter

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1588,6 +1588,24 @@ void TorrentsController::setShareLimitsAction()
     setResult(QString());
 }
 
+void TorrentsController::applyShareLimitsParams(BitTorrent::ShareLimits &shareLimits)
+{
+    if (!params()[u"ratioLimit"_s].isEmpty())
+        shareLimits.ratioLimit = parseDouble(params()[u"ratioLimit"_s]).value_or(BitTorrent::DEFAULT_RATIO_LIMIT);
+
+    if (!params()[u"seedingTimeLimit"_s].isEmpty())
+        shareLimits.seedingTimeLimit = parseInt(params()[u"seedingTimeLimit"_s]).value_or(BitTorrent::DEFAULT_SEEDING_TIME_LIMIT);
+
+    if (!params()[u"inactiveSeedingTimeLimit"_s].isEmpty())
+        shareLimits.inactiveSeedingTimeLimit = parseInt(params()[u"inactiveSeedingTimeLimit"_s]).value_or(BitTorrent::DEFAULT_SEEDING_TIME_LIMIT);
+
+    if (!params()[u"shareLimitAction"_s].isEmpty())
+        shareLimits.action = Utils::String::toEnum(params()[u"shareLimitAction"_s], BitTorrent::ShareLimitAction::Default);
+
+    if (!params()[u"shareLimitsMode"_s].isEmpty())
+        shareLimits.mode = Utils::String::toEnum(params()[u"shareLimitsMode"_s], BitTorrent::ShareLimitsMode::Default);
+}
+
 void TorrentsController::toggleSequentialDownloadAction()
 {
     requireParams({u"hashes"_s});
@@ -1908,6 +1926,8 @@ void TorrentsController::createCategoryAction()
         categoryOptions.downloadPath = {useDownloadPath.value(), downloadPath};
     }
 
+    applyShareLimitsParams(categoryOptions.shareLimits);
+
     if (!BitTorrent::Session::instance()->addCategory(category, categoryOptions))
         throw APIError(APIErrorType::Conflict, tr("Unable to create category"));
 
@@ -1922,17 +1942,20 @@ void TorrentsController::editCategoryAction()
     if (category.isEmpty())
         throw APIError(APIErrorType::BadParams, tr("Category cannot be empty"));
 
-    const Path savePath {params()[u"savePath"_s]};
+    auto *session = BitTorrent::Session::instance();
+    BitTorrent::CategoryOptions categoryOptions = session->categoryOptions(category);
+
+    categoryOptions.savePath = Path {params()[u"savePath"_s]};
     const auto useDownloadPath = parseBool(params()[u"downloadPathEnabled"_s]);
-    BitTorrent::CategoryOptions categoryOptions;
-    categoryOptions.savePath = savePath;
     if (useDownloadPath.has_value())
     {
         const Path downloadPath {params()[u"downloadPath"_s]};
         categoryOptions.downloadPath = {useDownloadPath.value(), downloadPath};
     }
 
-    if (!BitTorrent::Session::instance()->setCategoryOptions(category, categoryOptions))
+    applyShareLimitsParams(categoryOptions.shareLimits);
+
+    if (!session->setCategoryOptions(category, categoryOptions))
         throw APIError(APIErrorType::NotFound, tr("Category does not exist"));
 
     setResult(QString());

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -31,6 +31,7 @@
 #include <QHash>
 #include <QSet>
 
+#include "base/bittorrent/sharelimits.h"
 #include "base/bittorrent/torrentdescriptor.h"
 #include "apicontroller.h"
 
@@ -126,6 +127,8 @@ private:
     void onSearchPluginTorrentDownloaded(const QString &source, const QString &data);
     void cacheTorrentFile(const QString &source, const QByteArray &data);
     void cacheMagnetURI(const QString &source, const BitTorrent::TorrentDescriptor &torrentDescr);
+
+    void applyShareLimitsParams(BitTorrent::ShareLimits &shareLimits);
 
     QHash<QString, BitTorrent::InfoHash> m_torrentSourceCache;
     QHash<BitTorrent::TorrentID, BitTorrent::TorrentDescriptor> m_torrentMetadataCache;


### PR DESCRIPTION
## Summary

qBittorrent 5.2.0 added per-category share limits, and the desktop dialog can
set them, but the WebAPI could not: `torrents/createCategory` and
`torrents/editCategory` only read `category`, `savePath`, `downloadPath` and
`downloadPathEnabled`. `torrents/categories` already returns the share limits,
so clients could display them but never change them.

This change adds the share-limit parameters to both endpoints and fixes a
related data-loss bug in `editCategory`.

## Changes

- `torrents/createCategory` and `torrents/editCategory` now accept
  `ratioLimit`, `seedingTimeLimit`, `inactiveSeedingTimeLimit`,
  `shareLimitAction` and `shareLimitsMode` — the same names and sentinels that
  `torrents/setShareLimits` uses.
- A shared `applyShareLimitsParams()` helper parses the parameters and only
  overrides the fields that are actually present in the request, leaving the
  rest at their current/default values.
- `torrents/editCategory` no longer erases a category's share limits and
  download path when they are not part of the request. It now reads the
  category's current options first and overrides only the fields the request
  carries, instead of building a fresh `CategoryOptions` that overwrote the
  stored one.

## Motivation

Requested in https://github.com/autobrr/qui/discussions/2266. A WebAPI client
(qui) needs to set a category's share limits. The `editCategory` data loss also
affected the bundled WebUI, which re-sent the download path but could not send
share limits, so editing a category in the WebUI wiped limits set in the
desktop dialog.

## Test plan

- [ ] `createCategory` with `ratioLimit`/`seedingTimeLimit`/`inactiveSeedingTimeLimit`/`shareLimitAction`/`shareLimitsMode` stores them (verifiable via `torrents/categories`).
- [ ] `editCategory` with only `category` + `savePath` preserves existing share limits and download path.
- [ ] `editCategory` with a subset of share-limit params overrides only those and preserves the rest.
- [ ] `qbt_webui` target builds; pre-commit hooks (editorconfig, markdownlint, codespell, typos) pass.

## Related

- Closes #24788
- Fixes #24787
