### PR TITLE
Suppress useless compiler warning

### DIFF
--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -72,6 +72,12 @@ if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "C
     endif()
 endif()
 
+if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16"))
+    target_compile_options(qbt_common_cfg INTERFACE
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-sfinae-incomplete>
+    )
+endif()
+
 if ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
     target_compile_options(qbt_common_cfg INTERFACE
         -Wno-range-loop-analysis


### PR DESCRIPTION
Otherwise gcc 16+ will emit the following during compilation:
```
/home/user/qBittorrent/src/base/bittorrent/torrentdescriptor.h:52:11: warning: defining ‘BitTorrent::TorrentDescriptor’, which previously failed to be complete in a SFINAE context [-Wsfinae-incomplete=]
   52 |     class TorrentDescriptor
```

Upstream issue: https://qt-project.atlassian.net/browse/QTBUG-143470
