### PR TITLE
Add streaming playback for incomplete videos

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased - sledgehammer999 <sledgehammer999@qbittorrent.org> - v5.3.0alpha1
+    - FEATURE: Add experimental token-authenticated streaming playback
     - FEATURE: Add an option to match all share limits (glassez) #24043
     - FEATURE: Put Email examples in placeholder text (Chocobo1) #23949
     - FEATURE: Add support for widely used image types in HTTP server (Chocobo1) #23886

--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -11,6 +11,8 @@
 
 ## 2.16.0
 
+* Add `torrents/streamUrl` endpoint with `hash` and numeric `file` parameters to create a tokenized streaming URL
+* `app/preferences` and `app/setPreferences` include streaming enabled, address, port, read-ahead, timeout, and LAN opt-in options
 * [#24791](https://github.com/qbittorrent/qBittorrent/pull/24791)
   * `search/downloadTorrent` and `rss/setFeedRefreshInterval` endpoints now only accept `POST` requests
 * [#24724](https://github.com/qbittorrent/qBittorrent/pull/24724)

--- a/doc/streaming-playback.md
+++ b/doc/streaming-playback.md
@@ -1,0 +1,54 @@
+# Experimental streaming playback design
+
+## Problem solved
+
+Opening an incomplete qBittorrent payload file directly is not safe for media playback. The file may already have its final filesystem size while some BitTorrent pieces inside that byte range have not been downloaded and verified yet. A media player that reads those holes as if they were valid media bytes can show corrupted frames, decoder artifacts, freezes, or container errors.
+
+The streaming feature therefore follows one central invariant:
+
+> **No payload bytes are read from disk and sent to the player until every BitTorrent piece covering that read has been reported present by libtorrent.**
+
+The player never reads the incomplete file directly. It reads an HTTP resource exposed by qBittorrent, and qBittorrent uses the existing torrent session as the source of truth for piece availability. Missing pieces are requested with ordered deadlines and the HTTP response waits rather than returning unverified bytes.
+
+This verified-piece gate is the mechanism that makes playback of an incomplete video substantially different from simply opening a partially downloaded `.!qB`/payload file in a media player.
+
+## Server design
+
+Streaming playback is disabled by default. When enabled, qBittorrent starts a dedicated asynchronous HTTP listener using `QTcpServer` and the existing BitTorrent session. The default bind address is `127.0.0.1`; non-loopback binding requires a separate LAN opt-in. Wildcard addresses are rejected so generated URLs always contain an explicit usable host. An authenticated Web API action creates a URL containing a persistent cryptographically random token, torrent ID, and stable payload file index. The listener never accepts filesystem paths.
+
+`HEAD` and single-range `GET` requests are supported, with at most one active GET stream. Pure helpers normalize HTTP ranges and map file-relative bytes through the torrent file offset to piece indexes. Before every positional disk read, a read gate verifies all covering pieces through libtorrent. Missing pieces receive ordered `set_piece_deadline()` requests with `alert_when_available` and a bounded read-ahead window. A new range replaces the active GET and resets only the piece deadlines owned by that stream. Streaming never changes file priorities, enables global sequential-download mode, creates a second libtorrent session, or copies torrent data.
+
+The current output block size is 1 MiB. The socket write backlog is limited to 4 MiB. Piece availability is polled on a 100 ms single-shot timer while the current block is waiting, so waiting does not block the Qt event loop.
+
+Stopped, checking, moving, errored, missing, removed, metadata-less, or priority-0 files fail closed. The resolved actual libtorrent path is used, including the `.!qB` name when append-extension mode applies. A timer polls piece verification without blocking the Qt event loop; timeout, cancellation, shutdown, storage changes, or an I/O error stops the response. `QFile` reads occur only after every piece covering that disk block reports `have_piece()`.
+
+The default settings are `enabled=false`, `address=127.0.0.1`, `port=8081`, `read-ahead=128 MiB`, `wait timeout=30 seconds`, and `allow LAN=false`. The access token is created internally, saved in the profile, never returned by the preferences API, and remains mandatory for loopback and LAN requests. Settings changes reconfigure the listener immediately. The authenticated `torrents/streamUrl` Web API action accepts `hash` and a numeric stable file index and returns the tokenized URL used by the WebUI Stream / Play action.
+
+## Playback flow
+
+For an HTTP request, the server performs the following sequence:
+
+1. Validate the token, torrent ID, file index, torrent state, and actual storage path.
+2. Parse the requested byte range.
+3. Map the next output block to its covering torrent pieces.
+4. Extend that piece range by the configured read-ahead window.
+5. Assign ordered libtorrent piece deadlines to missing pieces.
+6. Check `have_piece()` for every piece covering the block that would be read now.
+7. If any current piece is unavailable, wait and poll again; do not call `QFile::read()` for that block.
+8. Once all current pieces are present, seek to the requested file offset, read the block, and write it to the HTTP socket.
+9. Continue with the next block.
+10. On a seek/new Range request, cancel the old active GET and replace its owned deadlines with priorities around the new playback position.
+
+This means buffering may be visible when the required torrent pieces are unavailable, but the server prefers waiting or timing out over sending bytes that libtorrent has not confirmed.
+
+## WebUI
+
+When streaming is enabled, the torrent Files tab shows a dedicated Play column. Recognized video files whose download priority is not ignored receive a per-row play button, and the same action is available from the file context menu. Folders, subtitle/poster files, ignored files, and the Add Torrent file-selection dialog do not expose playback. The main torrent list intentionally has no generic play action because a multi-file torrent has no unambiguous playback target. Disabling streaming hides the Play column and its buttons without changing normal file-list behavior.
+
+The currently recognized extensions are `.3g2`, `.3gp`, `.asf`, `.avi`, `.divx`, `.flv`, `.m2ts`, `.m4v`, `.mkv`, `.mov`, `.mp4`, `.mpeg`, `.mpg`, `.mts`, `.ogm`, `.ogv`, `.ts`, `.vob`, `.webm`, and `.wmv`.
+
+## Initial limits
+
+Initial limits are one HTTP byte range per request, one active GET, plain HTTP, no transcoding, no playlist generation, and cancellation rather than migration when storage paths change. Media format and seeking behavior depend on the client player and the torrent's piece availability.
+
+The feature intentionally does not promise uninterrupted playback at insufficient torrent speed. Its correctness goal is narrower: **never substitute not-yet-verified torrent data for valid media bytes.**

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -85,6 +85,7 @@
 #include "base/rss/rss_session.h"
 #include "base/search/searchpluginmanager.h"
 #include "base/settingsstorage.h"
+#include "base/streaming/server.h"
 #include "base/torrentfileswatcher.h"
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
@@ -904,6 +905,7 @@ int Application::exec()
     Net::DownloadManager::initInstance();
 
     BitTorrent::Session::initInstance();
+    Streaming::Server::initInstance();
 #ifndef DISABLE_GUI
     UIThemeManager::initInstance();
 
@@ -1484,6 +1486,7 @@ void Application::cleanup()
 #ifdef DISABLE_GUI
     delete m_addTorrentManager;
 #endif
+    Streaming::Server::freeInstance();
     BitTorrent::Session::freeInstance();
     Net::ReverseResolution::freeInstance();
     Net::GeoIPManager::freeInstance();

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -103,6 +103,8 @@ add_library(qbt_base STATIC
     search/searchhandler.h
     search/searchpluginmanager.h
     settingsstorage.h
+    streaming/helpers.h
+    streaming/server.h
     tag.h
     tagset.h
     torrentfileguard.h
@@ -204,6 +206,8 @@ add_library(qbt_base STATIC
     search/searchhandler.cpp
     search/searchpluginmanager.cpp
     settingsstorage.cpp
+    streaming/helpers.cpp
+    streaming/server.cpp
     tag.cpp
     tagset.cpp
     torrentfileguard.cpp

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -264,6 +264,9 @@ namespace BitTorrent
         virtual bool isPEXDisabled() const = 0;
         virtual bool isLSDDisabled() const = 0;
         virtual QBitArray pieces() const = 0;
+        virtual bool havePiece(int pieceIndex) const = 0;
+        virtual void setStreamingPieceDeadline(int pieceIndex, int deadline) = 0;
+        virtual void resetStreamingPieceDeadline(int pieceIndex) = 0;
         virtual qreal distributedCopies() const = 0;
         virtual qreal realRatio() const = 0;
         virtual qreal popularity() const = 0;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1554,6 +1554,31 @@ QBitArray TorrentImpl::pieces() const
     return m_pieces;
 }
 
+bool TorrentImpl::havePiece(const int pieceIndex) const
+{
+    if (!isValid() || (pieceIndex < 0) || (pieceIndex >= piecesCount()))
+        return false;
+
+    return m_nativeHandle.have_piece(lt::piece_index_t {pieceIndex});
+}
+
+void TorrentImpl::setStreamingPieceDeadline(const int pieceIndex, const int deadline)
+{
+    if (!isValid() || (pieceIndex < 0) || (pieceIndex >= piecesCount()))
+        return;
+
+    m_nativeHandle.set_piece_deadline(lt::piece_index_t {pieceIndex}, deadline
+            , lt::torrent_handle::alert_when_available);
+}
+
+void TorrentImpl::resetStreamingPieceDeadline(const int pieceIndex)
+{
+    if (!isValid() || (pieceIndex < 0) || (pieceIndex >= piecesCount()))
+        return;
+
+    m_nativeHandle.reset_piece_deadline(lt::piece_index_t {pieceIndex});
+}
+
 qreal TorrentImpl::distributedCopies() const
 {
     return m_nativeStatus.distributed_copies;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -199,6 +199,9 @@ namespace BitTorrent
         bool isPEXDisabled() const override;
         bool isLSDDisabled() const override;
         QBitArray pieces() const override;
+        bool havePiece(int pieceIndex) const override;
+        void setStreamingPieceDeadline(int pieceIndex, int deadline) override;
+        void resetStreamingPieceDeadline(int pieceIndex) override;
         qreal distributedCopies() const override;
         qreal realRatio() const override;
         qreal popularity() const override;

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -890,6 +890,100 @@ void Preferences::setUPnPForWebUIPort(const bool enabled)
     setValue(u"WebUI/UseUPnP"_s, enabled);
 }
 
+bool Preferences::isStreamingEnabled() const
+{
+    return value(u"Streaming/Enabled"_s, false);
+}
+
+void Preferences::setStreamingEnabled(const bool enabled)
+{
+    if (enabled == isStreamingEnabled())
+        return;
+
+    setValue(u"Streaming/Enabled"_s, enabled);
+}
+
+QString Preferences::streamingAddress() const
+{
+    return value<QString>(u"Streaming/Address"_s, u"127.0.0.1"_s).trimmed();
+}
+
+void Preferences::setStreamingAddress(const QString &address)
+{
+    const QString trimmedAddress = address.trimmed();
+    if (trimmedAddress == streamingAddress())
+        return;
+
+    setValue(u"Streaming/Address"_s, trimmedAddress);
+}
+
+quint16 Preferences::streamingPort() const
+{
+    return value<quint16>(u"Streaming/Port"_s, 8081);
+}
+
+void Preferences::setStreamingPort(const quint16 port)
+{
+    if (port == streamingPort())
+        return;
+
+    setValue(u"Streaming/Port"_s, static_cast<int>(port));
+}
+
+int Preferences::streamingReadAheadMiB() const
+{
+    return value<int>(u"Streaming/ReadAheadMiB"_s, 128);
+}
+
+void Preferences::setStreamingReadAheadMiB(const int size)
+{
+    const int clampedSize = std::clamp(size, 0, 4096);
+    if (clampedSize == streamingReadAheadMiB())
+        return;
+
+    setValue(u"Streaming/ReadAheadMiB"_s, clampedSize);
+}
+
+int Preferences::streamingWaitTimeout() const
+{
+    return value<int>(u"Streaming/WaitTimeout"_s, 30);
+}
+
+void Preferences::setStreamingWaitTimeout(const int timeout)
+{
+    const int clampedTimeout = std::clamp(timeout, 1, 3600);
+    if (clampedTimeout == streamingWaitTimeout())
+        return;
+
+    setValue(u"Streaming/WaitTimeout"_s, clampedTimeout);
+}
+
+bool Preferences::isStreamingLANAllowed() const
+{
+    return value(u"Streaming/AllowLAN"_s, false);
+}
+
+void Preferences::setStreamingLANAllowed(const bool allowed)
+{
+    if (allowed == isStreamingLANAllowed())
+        return;
+
+    setValue(u"Streaming/AllowLAN"_s, allowed);
+}
+
+QString Preferences::streamingToken() const
+{
+    return value<QString>(u"Streaming/Token"_s);
+}
+
+void Preferences::setStreamingToken(const QString &token)
+{
+    if (token == streamingToken())
+        return;
+
+    setValue(u"Streaming/Token"_s, token);
+}
+
 QString Preferences::getWebUIUsername() const
 {
     return value<QString>(u"WebUI/Username"_s, u"admin"_s);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -190,6 +190,22 @@ public:
     bool useUPnPForWebUIPort() const;
     void setUPnPForWebUIPort(bool enabled);
 
+    // Streaming HTTP server
+    bool isStreamingEnabled() const;
+    void setStreamingEnabled(bool enabled);
+    QString streamingAddress() const;
+    void setStreamingAddress(const QString &address);
+    quint16 streamingPort() const;
+    void setStreamingPort(quint16 port);
+    int streamingReadAheadMiB() const;
+    void setStreamingReadAheadMiB(int size);
+    int streamingWaitTimeout() const;
+    void setStreamingWaitTimeout(int timeout);
+    bool isStreamingLANAllowed() const;
+    void setStreamingLANAllowed(bool allowed);
+    QString streamingToken() const;
+    void setStreamingToken(const QString &token);
+
     // Authentication
     bool isWebUILocalAuthEnabled() const;
     void setWebUILocalAuthEnabled(bool enabled);

--- a/src/base/streaming/helpers.cpp
+++ b/src/base/streaming/helpers.cpp
@@ -1,0 +1,95 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  qBittorrent contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include "helpers.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace Streaming
+{
+    qint64 ByteRange::length() const
+    {
+        return (last - first + 1);
+    }
+
+    nonstd::expected<ByteRange, RangeError> parseHttpRange(const QByteArray &value, const qint64 resourceSize)
+    {
+        if (resourceSize < 0)
+            return nonstd::make_unexpected(RangeError::Unsatisfiable);
+
+        const QByteArray trimmedValue = value.trimmed();
+        const qsizetype equalsPos = trimmedValue.indexOf('=');
+        if ((equalsPos <= 0) || (trimmedValue.left(equalsPos).trimmed().compare("bytes", Qt::CaseInsensitive) != 0))
+            return nonstd::make_unexpected(RangeError::Malformed);
+
+        const QByteArray rangeSpec = trimmedValue.mid(equalsPos + 1).trimmed();
+        if (rangeSpec.contains(','))
+            return nonstd::make_unexpected(RangeError::MultipleRanges);
+
+        if (rangeSpec.count('-') != 1)
+            return nonstd::make_unexpected(RangeError::Malformed);
+
+        const qsizetype dashPos = rangeSpec.indexOf('-');
+        const QByteArray firstPart = rangeSpec.left(dashPos).trimmed();
+        const QByteArray lastPart = rangeSpec.mid(dashPos + 1).trimmed();
+        if (firstPart.isEmpty() && lastPart.isEmpty())
+            return nonstd::make_unexpected(RangeError::Malformed);
+
+        if (resourceSize == 0)
+            return nonstd::make_unexpected(RangeError::Unsatisfiable);
+
+        bool ok = false;
+        if (firstPart.isEmpty())
+        {
+            const qint64 suffixLength = lastPart.toLongLong(&ok);
+            if (!ok || (suffixLength <= 0))
+                return nonstd::make_unexpected(ok ? RangeError::Unsatisfiable : RangeError::Malformed);
+
+            const qint64 length = std::min(suffixLength, resourceSize);
+            return ByteRange {.first = resourceSize - length, .last = resourceSize - 1};
+        }
+
+        const qint64 first = firstPart.toLongLong(&ok);
+        if (!ok || (first < 0))
+            return nonstd::make_unexpected(RangeError::Malformed);
+        if (first >= resourceSize)
+            return nonstd::make_unexpected(RangeError::Unsatisfiable);
+
+        if (lastPart.isEmpty())
+            return ByteRange {.first = first, .last = resourceSize - 1};
+
+        const qint64 requestedLast = lastPart.toLongLong(&ok);
+        if (!ok || (requestedLast < 0))
+            return nonstd::make_unexpected(RangeError::Malformed);
+        if (requestedLast < first)
+            return nonstd::make_unexpected(RangeError::Unsatisfiable);
+
+        return ByteRange {.first = first, .last = std::min(requestedLast, resourceSize - 1)};
+    }
+
+    std::optional<PieceRange> mapByteRangeToPieces(const qint64 fileRelativeFirst, const qint64 fileRelativeLast
+            , const qint64 torrentFileOffset, const qint64 pieceLength, const int piecesCount)
+    {
+        if ((fileRelativeFirst < 0) || (fileRelativeLast < fileRelativeFirst) || (torrentFileOffset < 0)
+                || (pieceLength <= 0) || (piecesCount <= 0))
+            return std::nullopt;
+
+        if (fileRelativeLast > (std::numeric_limits<qint64>::max() - torrentFileOffset))
+            return std::nullopt;
+
+        const qint64 first = (torrentFileOffset + fileRelativeFirst) / pieceLength;
+        const qint64 last = (torrentFileOffset + fileRelativeLast) / pieceLength;
+        if ((first < 0) || (last >= piecesCount) || (first > std::numeric_limits<int>::max()))
+            return std::nullopt;
+
+        return PieceRange {.first = static_cast<int>(first), .last = static_cast<int>(last)};
+    }
+}

--- a/src/base/streaming/helpers.h
+++ b/src/base/streaming/helpers.h
@@ -1,0 +1,47 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  qBittorrent contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <QByteArray>
+#include <QtTypes>
+
+#include "base/3rdparty/expected.hpp"
+
+namespace Streaming
+{
+    struct ByteRange
+    {
+        qint64 first = 0;
+        qint64 last = 0;
+
+        qint64 length() const;
+    };
+
+    enum class RangeError
+    {
+        Malformed,
+        MultipleRanges,
+        Unsatisfiable
+    };
+
+    struct PieceRange
+    {
+        int first = 0;
+        int last = 0;
+    };
+
+    nonstd::expected<ByteRange, RangeError> parseHttpRange(const QByteArray &value, qint64 resourceSize);
+
+    std::optional<PieceRange> mapByteRangeToPieces(qint64 fileRelativeFirst, qint64 fileRelativeLast
+            , qint64 torrentFileOffset, qint64 pieceLength, int piecesCount);
+}

--- a/src/base/streaming/server.cpp
+++ b/src/base/streaming/server.cpp
@@ -1,0 +1,630 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  qBittorrent contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include "server.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include <QDateTime>
+#include <QFile>
+#include <QFileInfo>
+#include <QHostAddress>
+#include <QIODevice>
+#include <QLocale>
+#include <QMetaObject>
+#include <QMimeDatabase>
+#include <QRegularExpression>
+#include <QStringList>
+#include <QTcpSocket>
+#include <QUrlQuery>
+
+#include "base/bittorrent/downloadpriority.h"
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrent.h"
+#include "base/bittorrent/torrentinfo.h"
+#include "base/logger.h"
+#include "base/path.h"
+#include "base/preferences.h"
+#include "base/utils/password.h"
+
+namespace
+{
+    using namespace Qt::Literals::StringLiterals;
+
+    constexpr qint64 BLOCK_SIZE = 1024 * 1024;
+    constexpr qint64 MAX_REQUEST_SIZE = 32 * 1024;
+    constexpr qint64 WRITE_BUFFER_LIMIT = 4 * BLOCK_SIZE;
+
+    QByteArray httpDate()
+    {
+        return QLocale::c().toString(QDateTime::currentDateTimeUtc()
+                , u"ddd, dd MMM yyyy HH:mm:ss 'GMT'"_s).toLatin1();
+    }
+
+    bool tokenMatches(const QString &provided, const QString &expected)
+    {
+        const QByteArray providedBytes = provided.toUtf8();
+        const QByteArray expectedBytes = expected.toUtf8();
+        return !expected.isEmpty() && Utils::Password::slowEquals(providedBytes, expectedBytes);
+    }
+
+    QByteArray dispositionHeader(const QString &fileName)
+    {
+        QString fallback = fileName;
+        fallback.replace(QRegularExpression(uR"([\x00-\x1f\x7f"\\/])"_s), u"_"_s);
+        const QByteArray encoded = QUrl::toPercentEncoding(fileName);
+        return "Content-Disposition: inline; filename=\"" + fallback.toLatin1()
+                + "\"; filename*=UTF-8''" + encoded;
+    }
+}
+
+namespace Streaming
+{
+    Server *Server::m_instance = nullptr;
+
+    void Server::initInstance()
+    {
+        if (!m_instance)
+            m_instance = new Server;
+    }
+
+    void Server::freeInstance()
+    {
+        delete m_instance;
+        m_instance = nullptr;
+    }
+
+    Server *Server::instance()
+    {
+        return m_instance;
+    }
+
+    Server::Server()
+    {
+        m_pollTimer.setInterval(100);
+        m_pollTimer.setSingleShot(true);
+
+        Preferences *const preferences = Preferences::instance();
+        if (preferences->streamingToken().isEmpty())
+            preferences->setStreamingToken(makeToken());
+
+        connect(preferences, &Preferences::changed, this, &Server::configure);
+        connect(&m_listener, &QTcpServer::newConnection, this, &Server::acceptConnections);
+        connect(&m_pollTimer, &QTimer::timeout, this, &Server::pumpStream);
+
+        BitTorrent::Session *const session = BitTorrent::Session::instance();
+        connect(session, &BitTorrent::Session::torrentAboutToBeRemoved, this, [this](BitTorrent::Torrent *torrent)
+        {
+            if (torrent == m_activeTorrent)
+                cancelActiveStream();
+        });
+        connect(session, &BitTorrent::Session::torrentSavePathChanged, this, [this](BitTorrent::Torrent *torrent)
+        {
+            if (torrent == m_activeTorrent)
+                cancelActiveStream();
+        });
+        connect(session, &BitTorrent::Session::torrentSavingModeChanged, this, [this](BitTorrent::Torrent *torrent)
+        {
+            if (torrent == m_activeTorrent)
+                cancelActiveStream();
+        });
+        connect(session, &BitTorrent::Session::torrentContentFileRenamed, this
+                , [this](BitTorrent::Torrent *torrent, int, const Path &)
+        {
+            if (torrent == m_activeTorrent)
+                cancelActiveStream();
+        });
+        connect(session, &BitTorrent::Session::torrentContentFolderRenamed, this
+                , [this](BitTorrent::Torrent *torrent, const Path &, const Path &, const QHash<int, Path> &)
+        {
+            if (torrent == m_activeTorrent)
+                cancelActiveStream();
+        });
+        connect(session, &BitTorrent::Session::torrentIOError, this, [this](BitTorrent::Torrent *torrent)
+        {
+            if (torrent == m_activeTorrent)
+                cancelActiveStream();
+        });
+
+        configure();
+    }
+
+    Server::~Server()
+    {
+        m_listener.close();
+        cancelActiveStream();
+        const QList<QTcpSocket *> sockets = m_requestBuffers.keys();
+        m_requestBuffers.clear();
+        for (QTcpSocket *socket : sockets)
+            socket->abort();
+    }
+
+    bool Server::isListening() const
+    {
+        return m_listener.isListening();
+    }
+
+    QUrl Server::streamUrl(const BitTorrent::TorrentID &torrentID, const int fileIndex) const
+    {
+        if (!isListening() || (fileIndex < 0) || (Preferences::instance()->streamingToken().size() < 32))
+            return {};
+
+        QHostAddress address = m_listener.serverAddress();
+        if (address.isEqual(QHostAddress::Any, QHostAddress::ConvertUnspecifiedAddress))
+            return {};
+
+        QUrl url;
+        url.setScheme(u"http"_s);
+        url.setHost(address.toString());
+        url.setPort(m_listener.serverPort());
+        url.setPath(u"/stream/%1/%2"_s.arg(torrentID.toString(), QString::number(fileIndex)));
+        QUrlQuery query;
+        query.addQueryItem(u"token"_s, Preferences::instance()->streamingToken());
+        url.setQuery(query);
+        return url;
+    }
+
+    void Server::configure()
+    {
+        m_listener.close();
+        cancelActiveStream();
+        const QList<QTcpSocket *> sockets = m_requestBuffers.keys();
+        m_requestBuffers.clear();
+        for (QTcpSocket *socket : sockets)
+            socket->abort();
+
+        const Preferences *const preferences = Preferences::instance();
+        if (!preferences->isStreamingEnabled())
+            return;
+
+        if (preferences->streamingToken().size() < 32)
+        {
+            LogMsg(tr("Streaming server cannot listen without a valid access token"), Log::WARNING);
+            return;
+        }
+
+        const QString configuredAddress = preferences->streamingAddress();
+        if (configuredAddress.isEmpty())
+        {
+            LogMsg(tr("Streaming server cannot listen: the address is empty"), Log::WARNING);
+            return;
+        }
+
+        QHostAddress address;
+        if (!address.setAddress(configuredAddress))
+        {
+            LogMsg(tr("Streaming server cannot listen: invalid address %1").arg(configuredAddress), Log::WARNING);
+            return;
+        }
+
+        if (address.isEqual(QHostAddress::Any, QHostAddress::ConvertUnspecifiedAddress))
+        {
+            LogMsg(tr("Streaming server cannot use a wildcard address; configure an explicit address"), Log::WARNING);
+            return;
+        }
+
+        if (!address.isLoopback() && !preferences->isStreamingLANAllowed())
+        {
+            LogMsg(tr("Streaming server refused a non-loopback address because LAN access is disabled"), Log::WARNING);
+            return;
+        }
+
+        const quint16 port = preferences->streamingPort();
+        if (port == 0)
+        {
+            LogMsg(tr("Streaming server cannot listen on port 0"), Log::WARNING);
+            return;
+        }
+
+        if (!m_listener.listen(address, port))
+        {
+            LogMsg(tr("Streaming server failed to listen on %1:%2. Reason: %3")
+                    .arg(address.toString(), QString::number(port), m_listener.errorString()), Log::WARNING);
+        }
+    }
+
+    void Server::acceptConnections()
+    {
+        while (QTcpSocket *socket = m_listener.nextPendingConnection())
+        {
+            m_requestBuffers.insert(socket, {});
+            connect(socket, &QTcpSocket::readyRead, this, &Server::processRequestData);
+            connect(socket, &QTcpSocket::disconnected, this, [this, socket]
+            {
+                m_requestBuffers.remove(socket);
+                if (socket == m_activeSocket)
+                    cancelActiveStream();
+                socket->deleteLater();
+            });
+        }
+    }
+
+    void Server::processRequestData()
+    {
+        auto *const socket = qobject_cast<QTcpSocket *>(sender());
+        if (!socket || !m_requestBuffers.contains(socket))
+            return;
+
+        QByteArray &buffer = m_requestBuffers[socket];
+        buffer += socket->readAll();
+        if (buffer.size() > MAX_REQUEST_SIZE)
+        {
+            m_requestBuffers.remove(socket);
+            sendError(socket, 431, "Request Header Fields Too Large");
+            return;
+        }
+
+        const qsizetype headerEnd = buffer.indexOf("\r\n\r\n");
+        if (headerEnd < 0)
+            return;
+
+        const QByteArray requestData = buffer.left(headerEnd + 4);
+        m_requestBuffers.remove(socket);
+        processRequest(socket, requestData);
+    }
+
+    void Server::processRequest(QTcpSocket *socket, const QByteArray &data)
+    {
+        QList<QByteArray> lines = data.split('\n');
+        if (lines.isEmpty())
+        {
+            sendError(socket, 400, "Bad Request");
+            return;
+        }
+
+        const QList<QByteArray> requestLine = lines.takeFirst().trimmed().split(' ');
+        if ((requestLine.size() != 3) || !requestLine[2].startsWith("HTTP/1."))
+        {
+            sendError(socket, 400, "Bad Request");
+            return;
+        }
+
+        Request request {.method = requestLine[0], .target = requestLine[1], .headers = {}};
+        for (const QByteArray &rawLine : lines)
+        {
+            const QByteArray line = rawLine.trimmed();
+            if (line.isEmpty())
+                continue;
+
+            const qsizetype colonPos = line.indexOf(':');
+            if (colonPos <= 0)
+            {
+                sendError(socket, 400, "Bad Request");
+                return;
+            }
+
+            const QByteArray name = line.left(colonPos).trimmed().toLower();
+            if (request.headers.contains(name))
+            {
+                sendError(socket, 400, "Bad Request");
+                return;
+            }
+            request.headers.insert(name, line.mid(colonPos + 1).trimmed());
+        }
+
+        startResponse(socket, request);
+    }
+
+    void Server::startResponse(QTcpSocket *socket, const Request &request)
+    {
+        if (!isListening() || !Preferences::instance()->isStreamingEnabled())
+        {
+            sendError(socket, 503, "Service Unavailable");
+            return;
+        }
+
+        if ((request.method != "GET") && (request.method != "HEAD"))
+        {
+            sendError(socket, 405, "Method Not Allowed", {"Allow: GET, HEAD"});
+            return;
+        }
+
+        const QUrl url = QUrl::fromEncoded(request.target, QUrl::StrictMode);
+        const QStringList segments = url.path().split(u'/', Qt::SkipEmptyParts);
+        if (!url.isValid() || (segments.size() != 3) || (segments[0] != u"stream"))
+        {
+            sendError(socket, 404, "Not Found");
+            return;
+        }
+
+        const QString token = QUrlQuery(url).queryItemValue(u"token"_s, QUrl::FullyDecoded);
+        if (!tokenMatches(token, Preferences::instance()->streamingToken()))
+        {
+            sendError(socket, 403, "Forbidden");
+            return;
+        }
+
+        bool fileIndexOK = false;
+        const int fileIndex = segments[2].toInt(&fileIndexOK);
+        const BitTorrent::TorrentID torrentID = BitTorrent::TorrentID::fromString(segments[1]);
+        BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(torrentID);
+        if (!fileIndexOK || (fileIndex < 0) || !torrent)
+        {
+            sendError(socket, 404, "Not Found");
+            return;
+        }
+
+        if (!torrent->hasMetadata() || (fileIndex >= torrent->filesCount()))
+        {
+            sendError(socket, 409, "Conflict");
+            return;
+        }
+
+        const QList<BitTorrent::DownloadPriority> priorities = torrent->filePriorities();
+        if ((fileIndex >= priorities.size()) || (priorities[fileIndex] == BitTorrent::DownloadPriority::Ignored)
+                || torrent->isChecking() || torrent->isMoving()
+                || torrent->isErrored() || torrent->hasMissingFiles())
+        {
+            sendError(socket, 409, "Conflict");
+            return;
+        }
+
+        const qint64 fileSize = torrent->fileSize(fileIndex);
+        // actualFilePath() is qBittorrent's resolved libtorrent path. It includes
+        // the .!qB suffix when append-extension mode is active for this file.
+        const Path filePath = torrent->actualStorageLocation() / torrent->actualFilePath(fileIndex);
+        const QFileInfo fileInfo(filePath.data());
+        if ((fileSize < 0) || !fileInfo.exists() || !fileInfo.isFile() || !fileInfo.isReadable())
+        {
+            sendError(socket, 404, "Not Found");
+            return;
+        }
+
+        ByteRange range {.first = 0, .last = fileSize - 1};
+        const bool isPartial = request.headers.contains("range");
+        if (isPartial)
+        {
+            const auto parsedRange = parseHttpRange(request.headers.value("range"), fileSize);
+            if (!parsedRange)
+            {
+                sendError(socket, 416, "Range Not Satisfiable"
+                        , {"Accept-Ranges: bytes", "Content-Range: bytes */" + QByteArray::number(fileSize)});
+                return;
+            }
+            range = parsedRange.value();
+        }
+
+        const QString displayFileName = torrent->filePath(fileIndex).filename();
+        const QByteArray mimeType = QMimeDatabase().mimeTypeForFile(displayFileName
+                , QMimeDatabase::MatchExtension).name().toLatin1();
+        QList<QByteArray> headers {
+            "Accept-Ranges: bytes",
+            "Content-Length: " + QByteArray::number((fileSize == 0) ? 0 : range.length()),
+            "Content-Type: " + (mimeType.isEmpty() ? QByteArray("application/octet-stream") : mimeType),
+            dispositionHeader(displayFileName)
+        };
+        if (isPartial)
+        {
+            headers.append("Content-Range: bytes " + QByteArray::number(range.first) + '-'
+                    + QByteArray::number(range.last) + '/' + QByteArray::number(fileSize));
+        }
+
+        auto streamFile = std::make_unique<QFile>(filePath.data());
+        if (!streamFile->open(QIODevice::ReadOnly))
+        {
+            sendError(socket, 404, "Not Found");
+            return;
+        }
+
+        if ((request.method == "HEAD") || (fileSize == 0))
+        {
+            sendHeaders(socket, isPartial ? 206 : 200, isPartial ? "Partial Content" : "OK", headers);
+            socket->disconnectFromHost();
+            return;
+        }
+
+        cancelActiveStream();
+        m_activeSocket = socket;
+        m_activeTorrent = torrent;
+        m_file = std::move(streamFile);
+        m_torrentID = torrentID;
+        m_fileIndex = fileIndex;
+        m_fileOffset = torrent->info().fileOffset(fileIndex);
+        m_fileSize = fileSize;
+        m_responsePosition = range.first;
+        m_responseLast = range.last;
+        m_pieceLength = torrent->pieceLength();
+        m_piecesCount = torrent->piecesCount();
+
+        connect(socket, &QTcpSocket::bytesWritten, this, &Server::pumpStream);
+        sendHeaders(socket, isPartial ? 206 : 200, isPartial ? "Partial Content" : "OK", headers);
+        m_waitTimer.start();
+        pumpStream();
+    }
+
+    void Server::pumpStream()
+    {
+        if (!m_activeSocket || !m_file || !validateTorrentState())
+        {
+            cancelActiveStream();
+            return;
+        }
+
+        if (m_responsePosition > m_responseLast)
+        {
+            QTcpSocket *const socket = m_activeSocket;
+            clearDeadlines();
+            m_pollTimer.stop();
+            disconnect(socket, &QTcpSocket::bytesWritten, this, &Server::pumpStream);
+            m_activeSocket = nullptr;
+            m_activeTorrent = nullptr;
+            m_file.reset();
+            m_torrentID = {};
+            m_fileIndex = -1;
+            m_fileOffset = 0;
+            m_fileSize = 0;
+            m_responsePosition = 0;
+            m_responseLast = -1;
+            m_pieceLength = 0;
+            m_piecesCount = 0;
+            socket->disconnectFromHost();
+            return;
+        }
+
+        if (m_activeSocket->bytesToWrite() >= WRITE_BUFFER_LIMIT)
+            return;
+
+        const qint64 blockLength = std::min(BLOCK_SIZE, (m_responseLast - m_responsePosition + 1));
+        const qint64 blockLast = m_responsePosition + blockLength - 1;
+        if (!preparePieces(m_responsePosition, blockLast))
+        {
+            const qint64 timeout = static_cast<qint64>(Preferences::instance()->streamingWaitTimeout()) * 1000;
+            if (m_waitTimer.elapsed() >= timeout)
+                cancelActiveStream();
+            else
+                m_pollTimer.start();
+            return;
+        }
+
+        if (!m_file->seek(m_responsePosition))
+        {
+            cancelActiveStream();
+            return;
+        }
+
+        const QByteArray block = m_file->read(blockLast - m_responsePosition + 1);
+        if (block.size() != (blockLast - m_responsePosition + 1))
+        {
+            cancelActiveStream();
+            return;
+        }
+
+        if (m_activeSocket->write(block) != block.size())
+        {
+            cancelActiveStream();
+            return;
+        }
+
+        m_responsePosition = blockLast + 1;
+        m_waitTimer.restart();
+        QMetaObject::invokeMethod(this, &Server::pumpStream, Qt::QueuedConnection);
+    }
+
+    void Server::sendError(QTcpSocket *socket, const int status, const QByteArray &reason
+            , const QList<QByteArray> &extraHeaders)
+    {
+        QList<QByteArray> headers = extraHeaders;
+        headers.append("Content-Length: 0");
+        sendHeaders(socket, status, reason, headers);
+        socket->disconnectFromHost();
+    }
+
+    void Server::sendHeaders(QTcpSocket *socket, const int status, const QByteArray &reason
+            , const QList<QByteArray> &headers)
+    {
+        QByteArray response = "HTTP/1.1 " + QByteArray::number(status) + ' ' + reason + "\r\n"
+                + "Date: " + httpDate() + "\r\n"
+                + "Connection: close\r\n"
+                + "Server: qBittorrent streaming\r\n";
+        for (const QByteArray &header : headers)
+            response += header + "\r\n";
+        response += "\r\n";
+        socket->write(response);
+    }
+
+    void Server::cancelActiveStream()
+    {
+        m_pollTimer.stop();
+        clearDeadlines();
+
+        if (m_activeSocket)
+        {
+            QTcpSocket *const socket = m_activeSocket;
+            disconnect(socket, &QTcpSocket::bytesWritten, this, &Server::pumpStream);
+            m_activeSocket = nullptr;
+            socket->abort();
+        }
+
+        m_activeTorrent = nullptr;
+        m_file.reset();
+        m_torrentID = {};
+        m_fileIndex = -1;
+        m_fileOffset = 0;
+        m_fileSize = 0;
+        m_responsePosition = 0;
+        m_responseLast = -1;
+        m_pieceLength = 0;
+        m_piecesCount = 0;
+    }
+
+    void Server::clearDeadlines()
+    {
+        if (m_activeTorrent)
+        {
+            for (const int piece : m_deadlinePieces.keys())
+                m_activeTorrent->resetStreamingPieceDeadline(piece);
+        }
+        m_deadlinePieces.clear();
+    }
+
+    bool Server::validateTorrentState() const
+    {
+        if (!m_activeTorrent || (BitTorrent::Session::instance()->getTorrent(m_torrentID) != m_activeTorrent))
+            return false;
+
+        if (!m_activeTorrent->hasMetadata() || (m_fileIndex < 0) || (m_fileIndex >= m_activeTorrent->filesCount())
+                || m_activeTorrent->isChecking() || m_activeTorrent->isMoving()
+                || m_activeTorrent->isErrored() || m_activeTorrent->hasMissingFiles())
+            return false;
+
+        const QList<BitTorrent::DownloadPriority> priorities = m_activeTorrent->filePriorities();
+        return (m_fileIndex < priorities.size()) && (priorities[m_fileIndex] != BitTorrent::DownloadPriority::Ignored);
+    }
+
+    bool Server::preparePieces(const qint64 first, const qint64 last)
+    {
+        const auto currentPieces = mapByteRangeToPieces(first, last, m_fileOffset, m_pieceLength, m_piecesCount);
+        if (!currentPieces)
+            return false;
+
+        const qint64 readAheadBytes = static_cast<qint64>(Preferences::instance()->streamingReadAheadMiB()) * 1024 * 1024;
+        const qint64 fileLast = m_fileSize - 1;
+        const qint64 bytesRemaining = fileLast - last;
+        const qint64 readAheadLast = (readAheadBytes >= bytesRemaining) ? fileLast : (last + readAheadBytes);
+        const auto requestedPieces = mapByteRangeToPieces(first, readAheadLast, m_fileOffset, m_pieceLength, m_piecesCount);
+        if (!requestedPieces)
+            return false;
+
+        QHash<int, int> nextDeadlines;
+        int order = 0;
+        for (int piece = requestedPieces->first; piece <= requestedPieces->last; ++piece)
+        {
+            if (!m_activeTorrent->havePiece(piece))
+            {
+                const int deadline = std::min(order, (std::numeric_limits<int>::max() / 1000)) * 1000;
+                nextDeadlines.insert(piece, deadline);
+                if (!m_deadlinePieces.contains(piece) || (m_deadlinePieces.value(piece) != deadline))
+                    m_activeTorrent->setStreamingPieceDeadline(piece, deadline);
+                ++order;
+            }
+        }
+
+        for (const int piece : m_deadlinePieces.keys())
+        {
+            if (!nextDeadlines.contains(piece))
+                m_activeTorrent->resetStreamingPieceDeadline(piece);
+        }
+        m_deadlinePieces = std::move(nextDeadlines);
+
+        for (int piece = currentPieces->first; piece <= currentPieces->last; ++piece)
+        {
+            if (!m_activeTorrent->havePiece(piece))
+                return false;
+        }
+        return true;
+    }
+
+    QString Server::makeToken()
+    {
+        return Utils::Password::generate(48);
+    }
+}

--- a/src/base/streaming/server.h
+++ b/src/base/streaming/server.h
@@ -1,0 +1,100 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  qBittorrent contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QList>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QTcpServer>
+#include <QTimer>
+#include <QUrl>
+
+#include "base/bittorrent/infohash.h"
+#include "helpers.h"
+
+class QFile;
+class QTcpSocket;
+
+namespace BitTorrent
+{
+    class Torrent;
+}
+
+namespace Streaming
+{
+    class Server final : public QObject
+    {
+        Q_OBJECT
+        Q_DISABLE_COPY_MOVE(Server)
+
+    public:
+        static void initInstance();
+        static void freeInstance();
+        static Server *instance();
+
+        bool isListening() const;
+        QUrl streamUrl(const BitTorrent::TorrentID &torrentID, int fileIndex) const;
+
+    private slots:
+        void configure();
+        void acceptConnections();
+        void processRequestData();
+        void pumpStream();
+
+    private:
+        Server();
+        ~Server() override;
+
+        struct Request
+        {
+            QByteArray method;
+            QByteArray target;
+            QHash<QByteArray, QByteArray> headers;
+        };
+
+        static Server *m_instance;
+
+        void processRequest(QTcpSocket *socket, const QByteArray &data);
+        void startResponse(QTcpSocket *socket, const Request &request);
+        void sendError(QTcpSocket *socket, int status, const QByteArray &reason
+                , const QList<QByteArray> &extraHeaders = {});
+        void sendHeaders(QTcpSocket *socket, int status, const QByteArray &reason
+                , const QList<QByteArray> &headers);
+        void cancelActiveStream();
+        void clearDeadlines();
+        bool validateTorrentState() const;
+        bool preparePieces(qint64 first, qint64 last);
+        QString makeToken();
+
+        QTcpServer m_listener;
+        QHash<QTcpSocket *, QByteArray> m_requestBuffers;
+        QPointer<QTcpSocket> m_activeSocket;
+        QPointer<BitTorrent::Torrent> m_activeTorrent;
+        std::unique_ptr<QFile> m_file;
+        BitTorrent::TorrentID m_torrentID;
+        int m_fileIndex = -1;
+        qint64 m_fileOffset = 0;
+        qint64 m_fileSize = 0;
+        qint64 m_responsePosition = 0;
+        qint64 m_responseLast = -1;
+        qint64 m_pieceLength = 0;
+        int m_piecesCount = 0;
+        QHash<int, int> m_deadlinePieces;
+        QElapsedTimer m_waitTimer;
+        QTimer m_pollTimer;
+    };
+}

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -38,6 +38,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QDirIterator>
+#include <QHostAddress>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -342,6 +343,12 @@ void AppController::preferencesAction()
     data[u"web_ui_address"_s] = pref->getWebUIAddress();
     data[u"web_ui_port"_s] = pref->getWebUIPort();
     data[u"web_ui_upnp"_s] = pref->useUPnPForWebUIPort();
+    data[u"streaming_enabled"_s] = pref->isStreamingEnabled();
+    data[u"streaming_address"_s] = pref->streamingAddress();
+    data[u"streaming_port"_s] = pref->streamingPort();
+    data[u"streaming_read_ahead_mib"_s] = pref->streamingReadAheadMiB();
+    data[u"streaming_wait_timeout"_s] = pref->streamingWaitTimeout();
+    data[u"streaming_allow_lan"_s] = pref->isStreamingLANAllowed();
     data[u"use_https"_s] = pref->isWebUIHttpsEnabled();
     data[u"web_ui_https_cert_path"_s] = pref->getWebUIHttpsCertificatePath().toString();
     data[u"web_ui_https_key_path"_s] = pref->getWebUIHttpsKeyPath().toString();
@@ -913,6 +920,27 @@ void AppController::setPreferencesAction()
 
     // WebUI
     // HTTP Server
+    if (m.contains(u"streaming_port"_s))
+    {
+        const int port = m.value(u"streaming_port"_s).toInt();
+        if ((port < 1) || (port > 65535))
+            throw APIError(APIErrorType::BadParams, tr("Streaming port must be between 1 and 65535"));
+    }
+
+    const bool streamingEnabled = m.value(u"streaming_enabled"_s, pref->isStreamingEnabled()).toBool();
+    if (streamingEnabled)
+    {
+        QHostAddress streamingAddress;
+        const QString address = m.value(u"streaming_address"_s, pref->streamingAddress()).toString().trimmed();
+        if (address.isEmpty() || !streamingAddress.setAddress(address)
+                || streamingAddress.isEqual(QHostAddress::Any, QHostAddress::ConvertUnspecifiedAddress))
+            throw APIError(APIErrorType::BadParams, tr("Streaming requires an explicit valid IP address"));
+
+        const bool allowLAN = m.value(u"streaming_allow_lan"_s, pref->isStreamingLANAllowed()).toBool();
+        if (!streamingAddress.isLoopback() && !allowLAN)
+            throw APIError(APIErrorType::BadParams, tr("Streaming LAN access must be enabled for non-loopback addresses"));
+    }
+
     if (hasKey(u"web_ui_domain_list"_s))
         pref->setServerDomains(it.value().toString());
     if (hasKey(u"web_ui_address"_s))
@@ -921,6 +949,18 @@ void AppController::setPreferencesAction()
         pref->setWebUIPort(it.value().value<quint16>());
     if (hasKey(u"web_ui_upnp"_s))
         pref->setUPnPForWebUIPort(it.value().toBool());
+    if (hasKey(u"streaming_enabled"_s))
+        pref->setStreamingEnabled(it.value().toBool());
+    if (hasKey(u"streaming_address"_s))
+        pref->setStreamingAddress(it.value().toString());
+    if (hasKey(u"streaming_port"_s))
+        pref->setStreamingPort(static_cast<quint16>(it.value().toInt()));
+    if (hasKey(u"streaming_read_ahead_mib"_s))
+        pref->setStreamingReadAheadMiB(it.value().toInt());
+    if (hasKey(u"streaming_wait_timeout"_s))
+        pref->setStreamingWaitTimeout(it.value().toInt());
+    if (hasKey(u"streaming_allow_lan"_s))
+        pref->setStreamingLANAllowed(it.value().toBool());
     if (hasKey(u"use_https"_s))
         pref->setWebUIHttpsEnabled(it.value().toBool());
     if (hasKey(u"web_ui_https_cert_path"_s))

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -60,6 +60,7 @@
 #include "base/preferences.h"
 #include "base/search/searchdownloadhandler.h"
 #include "base/search/searchpluginmanager.h"
+#include "base/streaming/server.h"
 #include "base/torrentfilter.h"
 #include "base/utils/datetime.h"
 #include "base/utils/dict.h"
@@ -2383,6 +2384,48 @@ void TorrentsController::downloadFileAction()
 
     const Path filePath = torrent->actualStorageLocation() / torrent->actualFilePath(fileIndex);
     setResult(filePath);
+}
+
+void TorrentsController::streamUrlAction()
+{
+    requireParams({u"hash"_s, u"file"_s});
+
+    Streaming::Server *const server = Streaming::Server::instance();
+    if (!server || !server->isListening())
+        throw APIError(APIErrorType::Conflict, tr("Streaming is disabled or unavailable"));
+
+    const BitTorrent::TorrentID id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
+    if (!torrent)
+        throw APIError(APIErrorType::NotFound, tr("Torrent not found"));
+    if (!torrent->hasMetadata())
+        throw APIError(APIErrorType::Conflict, tr("Torrent metadata not available"));
+
+    bool ok = false;
+    const int fileIndex = params()[u"file"_s].toInt(&ok);
+    if (!ok || (fileIndex < 0) || (fileIndex >= torrent->filesCount()))
+        throw APIError(APIErrorType::Conflict, tr("Invalid file index"));
+
+    const QList<BitTorrent::DownloadPriority> priorities = torrent->filePriorities();
+    if ((fileIndex >= priorities.size()) || (priorities[fileIndex] == BitTorrent::DownloadPriority::Ignored)
+            || torrent->isChecking() || torrent->isMoving()
+            || torrent->isErrored() || torrent->hasMissingFiles())
+        throw APIError(APIErrorType::Conflict, tr("Torrent file is not available for streaming"));
+
+    const QList<qreal> filesProgress = torrent->filesProgress();
+    if (torrent->isStopped() && ((fileIndex >= filesProgress.size()) || (filesProgress[fileIndex] < 1)))
+        torrent->start();
+
+    const Path filePath = torrent->actualStorageLocation() / torrent->actualFilePath(fileIndex);
+    const QFileInfo fileInfo(filePath.data());
+    if (!fileInfo.exists() || !fileInfo.isFile() || !fileInfo.isReadable())
+        throw APIError(APIErrorType::Conflict, tr("Torrent file is not accessible"));
+
+    const QUrl url = server->streamUrl(id, fileIndex);
+    if (!url.isValid())
+        throw APIError(APIErrorType::Conflict, tr("Unable to create streaming URL"));
+
+    setResult(QJsonObject {{u"url"_s, url.toString(QUrl::FullyEncoded)}});
 }
 
 void TorrentsController::onDownloadFinished(const Net::DownloadResult &result)

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -119,6 +119,7 @@ private slots:
     void parseMetadataAction();
     void saveMetadataAction();
     void downloadFileAction();
+    void streamUrlAction();
 
 private:
     void onDownloadFinished(const Net::DownloadResult &result);

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -710,6 +710,26 @@ td.noWrap {
     transform: rotate(270deg);
 }
 
+.streamPlayButton {
+    align-items: center;
+    cursor: pointer;
+    display: inline-flex;
+    height: 24px;
+    justify-content: center;
+    margin: 0 auto;
+    padding: 2px;
+    width: 32px;
+}
+
+.streamPlayButton:disabled {
+    cursor: wait;
+}
+
+.streamPlayButton img {
+    height: 16px;
+    width: 16px;
+}
+
 .unselectable {
     -webkit-touch-callout: none;
     user-select: none;

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -289,6 +289,7 @@
         <li><a href="#Download"><img src="images/download.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Download)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li><a href="#CopyPath"><img src="images/edit-copy.svg" alt="QBT_TR(Copy path)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy path)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li><a href="#CopyDownloadURL"><img src="images/edit-copy.svg" alt="QBT_TR(Copy download URL)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy download URL)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li class="invisible"><a href="#Stream"><img src="images/torrent-start.svg" alt="QBT_TR(Stream / Play)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Stream / Play)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li class="separator">
             <a href="#FilePrio" class="arrow-right"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Priority)QBT_TR[CONTEXT=PropertiesWidget]</a>
             <ul>

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -2405,6 +2405,22 @@ window.qBittorrent.DynamicTable ??= (() => {
         fileNameColumn = "name";
         headerCheckboxClickHandler = null;
         headerCheckboxId = "tristateCb";
+        streamingEnabled = false;
+
+        setStreamingEnabled(enabled) {
+            this.streamingEnabled = enabled;
+
+            const playColumn = this.columns["play"];
+            if (playColumn === undefined)
+                return;
+
+            const forceHide = !enabled;
+            if (playColumn.force_hide === forceHide)
+                return;
+
+            playColumn.force_hide = forceHide;
+            this.updateColumn("play", true);
+        }
 
         updateHeaderCheckbox() {
             const checkbox = document.getElementById(this.headerCheckboxId);
@@ -2653,6 +2669,8 @@ window.qBittorrent.DynamicTable ??= (() => {
         initColumns() {
             this.newColumn("checked", "", "", 50, true);
             this.newColumn("name", "", "QBT_TR(Name)QBT_TR[CONTEXT=TrackerListWidget]", 300, true);
+            this.newColumn("play", "text-align: center;", "QBT_TR(Play)QBT_TR[CONTEXT=TorrentContent]", 70, true);
+            this.columns["play"].force_hide = true;
             this.newColumn("size", "", "QBT_TR(Total Size)QBT_TR[CONTEXT=TrackerListWidget]", 75, true);
             this.newColumn("progress", "", "QBT_TR(Progress)QBT_TR[CONTEXT=TrackerListWidget]", 100, true);
             this.newColumn("priority", "", "QBT_TR(Download Priority)QBT_TR[CONTEXT=TrackerListWidget]", 150, true);
@@ -2762,6 +2780,57 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const folderBuffer = node.isFolder ? 35 : 0;
                 return (node.depth * 20) + folderBuffer;
             };
+
+            // play
+            if (this.columns["play"] !== undefined) {
+                this.columns["play"].dataProperties = ["rowId"];
+                this.columns["play"].updateTd = (td, row) => {
+                    const node = that.getNode(row.rowId);
+                    const canStream = that.streamingEnabled
+                        && window.qBittorrent.TorrentContent.isStreamableFile(node);
+                    if (!canStream) {
+                        td.replaceChildren();
+                        td.title = "";
+                        return;
+                    }
+
+                    let button = td.firstElementChild;
+                    if (button === null) {
+                        button = document.createElement("button");
+                        button.type = "button";
+                        button.className = "streamPlayButton";
+                        button.title = "QBT_TR(Play)QBT_TR[CONTEXT=TorrentContent]";
+                        button.setAttribute("aria-label", button.title);
+
+                        const image = document.createElement("img");
+                        image.src = "images/torrent-start.svg";
+                        image.alt = "";
+                        button.append(image);
+
+                        button.addEventListener("mousedown", (event) => event.stopPropagation());
+                        button.addEventListener("click", async (event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            if (button.disabled)
+                                return;
+
+                            button.disabled = true;
+                            try {
+                                await window.qBittorrent.TorrentContent.streamFile(button.dataset.fileId);
+                            }
+                            finally {
+                                button.disabled = false;
+                            }
+                        });
+                        td.append(button);
+                    }
+
+                    button.dataset.fileId = node.fileId;
+                    td.title = button.title;
+                };
+                this.columns["play"].compareRows = () => 0;
+                this.columns["play"].staticWidth = 70;
+            }
 
             // size
             this.columns["size"].updateTd = displaySize;

--- a/src/webui/www/private/scripts/torrent-content.js
+++ b/src/webui/www/private/scripts/torrent-content.js
@@ -39,6 +39,8 @@ window.qBittorrent.TorrentContent ??= (() => {
             updateDownloadCheckbox: updateDownloadCheckbox,
             createPriorityCombo: createPriorityCombo,
             updatePriorityCombo: updatePriorityCombo,
+            isStreamableFile: isStreamableFile,
+            streamFile: streamFile,
             updateData: updateData,
             clearFilterInputTimer: clearFilterInputTimer
         };
@@ -49,6 +51,12 @@ window.qBittorrent.TorrentContent ??= (() => {
     const TriState = window.qBittorrent.FileTree.TriState;
     let torrentFilesFilterInputTimer = -1;
     let onFilePriorityChanged = null;
+
+    const STREAMABLE_EXTENSIONS = new Set([
+        ".3g2", ".3gp", ".asf", ".avi", ".divx", ".flv", ".m2ts", ".m4v",
+        ".mkv", ".mov", ".mp4", ".mpeg", ".mpg", ".mts", ".ogm", ".ogv",
+        ".ts", ".vob", ".webm", ".wmv"
+    ]);
 
     const normalizePriority = (priority) => {
         priority = Number(priority);
@@ -80,6 +88,58 @@ window.qBittorrent.TorrentContent ??= (() => {
 
     const isFolder = (fileId) => {
         return fileId === -1;
+    };
+
+    const isStreamableFile = (node) => {
+        if (!node || node.isFolder || (normalizePriority(node.priority) === FilePriority.Ignored))
+            return false;
+
+        const filePath = String(node.path ?? node.name ?? "").toLowerCase();
+        const dotPosition = filePath.lastIndexOf(".");
+        if (dotPosition < 0)
+            return false;
+
+        return STREAMABLE_EXTENSIONS.has(filePath.slice(dotPosition));
+    };
+
+    const streamFile = async (fileId) => {
+        const torrentID = torrentsTable.getCurrentTorrentID();
+        const numericFileId = Number(fileId);
+        if ((torrentID.length === 0) || !Number.isInteger(numericFileId) || (numericFileId < 0))
+            return false;
+
+        const playbackWindow = window.open("about:blank", "_blank");
+
+        try {
+            const response = await fetch("api/v2/torrents/streamUrl", {
+                method: "POST",
+                body: new URLSearchParams({
+                    hash: torrentID,
+                    file: numericFileId
+                })
+            });
+            if (!response.ok)
+                throw new Error((await response.text()) || "QBT_TR(Unable to start streaming playback.)QBT_TR[CONTEXT=TorrentContent]");
+
+            const data = await response.json();
+            if ((typeof data.url !== "string") || (data.url.length === 0))
+                throw new Error("QBT_TR(Unable to create streaming URL.)QBT_TR[CONTEXT=TorrentContent]");
+
+            if (playbackWindow) {
+                playbackWindow.opener = null;
+                playbackWindow.location.href = data.url;
+            }
+            else {
+                window.location.href = data.url;
+            }
+
+            return true;
+        }
+        catch (error) {
+            playbackWindow?.close();
+            alert(error.message || "QBT_TR(Unable to start streaming playback.)QBT_TR[CONTEXT=TorrentContent]");
+            return false;
+        }
     };
 
     const getAllChildren = (id, fileId) => {
@@ -276,6 +336,8 @@ window.qBittorrent.TorrentContent ??= (() => {
     };
 
     const updateData = (files) => {
+        torrentFilesTable.setStreamingEnabled(window.qBittorrent.Cache.preferences.get()?.streaming_enabled === true);
+
         const rows = files.map((file, index) => {
             const ignore = (file.priority === FilePriority.Ignored);
             const row = {
@@ -498,6 +560,11 @@ window.qBittorrent.TorrentContent ??= (() => {
                     const url = getSelectedFilesURL().join("\n");
                     await clipboardCopy(url);
                 },
+                Stream: async (element, ref) => {
+                    const selectedRow = torrentFilesTable.selectedRowsIds()[0];
+                    const node = torrentFilesTable.getNode(selectedRow);
+                    await streamFile(node.fileId);
+                },
                 FilePrioIgnore: (element, ref) => {
                     filesPriorityMenuClicked(FilePriority.Ignored);
                 },
@@ -526,6 +593,16 @@ window.qBittorrent.TorrentContent ??= (() => {
                         hasFolder = true;
                     if (!isFullyDownloaded)
                         isAllComplete = false;
+                }
+
+                const streamingEnabled = window.qBittorrent.Cache.preferences.get()?.streaming_enabled === true;
+                const selectedRows = torrentFilesTable.selectedRowsIds();
+                const selectedNode = (selectedRows.length === 1) ? torrentFilesTable.getNode(selectedRows[0]) : null;
+                if (this.menu.querySelector('a[href$="Stream"]') !== null) {
+                    if (streamingEnabled && isStreamableFile(selectedNode))
+                        this.showItem("Stream");
+                    else
+                        this.hideItem("Stream");
                 }
 
                 const fileOnlyActions = ["CopyDownloadURL", "Download"];

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1223,6 +1223,36 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
     <fieldset class="settings">
         <legend>
+            <input type="checkbox" id="streamingEnabledCheckbox" onclick="qBittorrent.Preferences.updateStreamingSettings();">
+            <label for="streamingEnabledCheckbox">QBT_TR(Enable streaming playback (experimental))QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
+        <div id="streamingSettings">
+            <table>
+                <tbody>
+                    <tr>
+                        <td><label for="streamingAddressValue">QBT_TR(IP address:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                        <td><input type="text" id="streamingAddressValue"></td>
+                        <td><label for="streamingPortValue">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                        <td><input type="number" id="streamingPortValue" min="1" max="65535" style="width: 6em;"></td>
+                    </tr>
+                    <tr>
+                        <td><label for="streamingReadAheadValue">QBT_TR(Read-ahead:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                        <td><input type="number" id="streamingReadAheadValue" min="0" max="4096" style="width: 6em;"> QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]</td>
+                        <td><label for="streamingTimeoutValue">QBT_TR(Wait timeout:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                        <td><input type="number" id="streamingTimeoutValue" min="1" max="3600" style="width: 6em;"> QBT_TR(sec)QBT_TR[CONTEXT=OptionsDialog]</td>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="formRow">
+                <input type="checkbox" id="streamingAllowLANCheckbox">
+                <label for="streamingAllowLANCheckbox">QBT_TR(Allow binding to non-loopback addresses)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </div>
+            <div class="formRow"><i>QBT_TR(Streaming uses token-authenticated plain HTTP. Keep the token secret.)QBT_TR[CONTEXT=OptionsDialog]</i></div>
+        </div>
+    </fieldset>
+
+    <fieldset class="settings">
+        <legend>
             <input type="checkbox" id="use_dyndns_checkbox" onclick="qBittorrent.Preferences.updateDynDnsSettings();">
             <label id="UseDyndnsLabel" for="use_dyndns_checkbox">QBT_TR(Update my dynamic domain name)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
@@ -1952,6 +1982,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateAddTrackersEnabled: updateAddTrackersEnabled,
                 updateAddTrackersFromURLEnabled: updateAddTrackersFromURLEnabled,
                 updateHttpsSettings: updateHttpsSettings,
+                updateStreamingSettings: updateStreamingSettings,
                 updateBypasssAuthSettings: updateBypasssAuthSettings,
                 updateAlternativeWebUISettings: updateAlternativeWebUISettings,
                 updateHostHeaderValidationSettings: updateHostHeaderValidationSettings,
@@ -2274,6 +2305,12 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const isUseHttpsEnabled = document.getElementById("use_https_checkbox").checked;
             document.getElementById("ssl_cert_text").disabled = !isUseHttpsEnabled;
             document.getElementById("ssl_key_text").disabled = !isUseHttpsEnabled;
+        };
+
+        const updateStreamingSettings = () => {
+            const enabled = document.getElementById("streamingEnabledCheckbox").checked;
+            for (const control of document.querySelectorAll("#streamingSettings input"))
+                control.disabled = !enabled;
         };
 
         const updateBypasssAuthSettings = () => {
@@ -2737,6 +2774,13 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("webuiAddressValue").value = pref.web_ui_address;
                     document.getElementById("webuiPortValue").value = pref.web_ui_port;
                     document.getElementById("webuiUpnpCheckbox").checked = pref.web_ui_upnp;
+                    document.getElementById("streamingEnabledCheckbox").checked = pref.streaming_enabled;
+                    document.getElementById("streamingAddressValue").value = pref.streaming_address;
+                    document.getElementById("streamingPortValue").value = pref.streaming_port;
+                    document.getElementById("streamingReadAheadValue").value = pref.streaming_read_ahead_mib;
+                    document.getElementById("streamingTimeoutValue").value = pref.streaming_wait_timeout;
+                    document.getElementById("streamingAllowLANCheckbox").checked = pref.streaming_allow_lan;
+                    updateStreamingSettings();
                     document.getElementById("use_https_checkbox").checked = pref.use_https;
                     document.getElementById("ssl_cert_text").value = pref.web_ui_https_cert_path;
                     document.getElementById("ssl_key_text").value = pref.web_ui_https_key_path;
@@ -3212,6 +3256,32 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["web_ui_address"] = webUIAddress;
             settings["web_ui_port"] = webUIPort;
             settings["web_ui_upnp"] = document.getElementById("webuiUpnpCheckbox").checked;
+
+            settings["streaming_enabled"] = document.getElementById("streamingEnabledCheckbox").checked;
+            settings["streaming_address"] = document.getElementById("streamingAddressValue").value.trim();
+            if (settings["streaming_enabled"] && (settings["streaming_address"].length === 0)) {
+                alert("QBT_TR(The streaming address must not be empty.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            const streamingPort = Number(document.getElementById("streamingPortValue").value);
+            if (Number.isNaN(streamingPort) || (streamingPort < 1) || (streamingPort > 65535)) {
+                alert("QBT_TR(The streaming port must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings["streaming_port"] = streamingPort;
+            const streamingReadAhead = Number(document.getElementById("streamingReadAheadValue").value);
+            if (Number.isNaN(streamingReadAhead) || (streamingReadAhead < 0) || (streamingReadAhead > 4096)) {
+                alert("QBT_TR(The streaming read-ahead must be between 0 and 4096 MiB.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings["streaming_read_ahead_mib"] = streamingReadAhead;
+            const streamingTimeout = Number(document.getElementById("streamingTimeoutValue").value);
+            if (Number.isNaN(streamingTimeout) || (streamingTimeout < 1) || (streamingTimeout > 3600)) {
+                alert("QBT_TR(The streaming wait timeout must be between 1 and 3600 seconds.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings["streaming_wait_timeout"] = streamingTimeout;
+            settings["streaming_allow_lan"] = document.getElementById("streamingAllowLANCheckbox").checked;
 
             const useHTTPS = document.getElementById("use_https_checkbox").checked;
             settings["use_https"] = useHTTPS;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(testFiles
     testglobal.cpp
     testorderedset.cpp
     testpath.cpp
+    teststreaminghelpers.cpp
     testutilsbytearray.cpp
     testutilscompare.cpp
     testutilsdatetime.cpp

--- a/test/teststreaminghelpers.cpp
+++ b/test/teststreaminghelpers.cpp
@@ -1,0 +1,131 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  qBittorrent contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <limits>
+
+#include <QTest>
+
+#include "base/streaming/helpers.h"
+
+class TestStreamingHelpers final : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void parseRange_data();
+    void parseRange();
+    void rejectRange_data();
+    void rejectRange();
+    void mapPieces_data();
+    void mapPieces();
+    void rejectPieceMapping();
+};
+
+void TestStreamingHelpers::parseRange_data()
+{
+    QTest::addColumn<QByteArray>("header");
+    QTest::addColumn<qint64>("size");
+    QTest::addColumn<qint64>("first");
+    QTest::addColumn<qint64>("last");
+
+    QTest::newRow("closed") << QByteArray("bytes=2-5") << 10LL << 2LL << 5LL;
+    QTest::newRow("open-ended") << QByteArray("bytes=7-") << 10LL << 7LL << 9LL;
+    QTest::newRow("suffix") << QByteArray("bytes=-4") << 10LL << 6LL << 9LL;
+    QTest::newRow("large-suffix") << QByteArray("bytes=-20") << 10LL << 0LL << 9LL;
+    QTest::newRow("clamped-end") << QByteArray("bytes=5-100") << 10LL << 5LL << 9LL;
+    QTest::newRow("case-and-whitespace") << QByteArray(" Bytes = 0 - 0 ") << 10LL << 0LL << 0LL;
+}
+
+void TestStreamingHelpers::parseRange()
+{
+    QFETCH(QByteArray, header);
+    QFETCH(qint64, size);
+    QFETCH(qint64, first);
+    QFETCH(qint64, last);
+
+    const auto result = Streaming::parseHttpRange(header, size);
+    QVERIFY(result.has_value());
+    QCOMPARE(result->first, first);
+    QCOMPARE(result->last, last);
+    QCOMPARE(result->length(), (last - first + 1));
+}
+
+void TestStreamingHelpers::rejectRange_data()
+{
+    QTest::addColumn<QByteArray>("header");
+    QTest::addColumn<qint64>("size");
+    QTest::addColumn<int>("error");
+
+    using Streaming::RangeError;
+    QTest::newRow("wrong-unit") << QByteArray("items=0-1") << 10LL << static_cast<int>(RangeError::Malformed);
+    QTest::newRow("multiple") << QByteArray("bytes=0-1,4-5") << 10LL << static_cast<int>(RangeError::MultipleRanges);
+    QTest::newRow("empty") << QByteArray("bytes=-") << 10LL << static_cast<int>(RangeError::Malformed);
+    QTest::newRow("past-end") << QByteArray("bytes=10-") << 10LL << static_cast<int>(RangeError::Unsatisfiable);
+    QTest::newRow("reversed") << QByteArray("bytes=6-5") << 10LL << static_cast<int>(RangeError::Unsatisfiable);
+    QTest::newRow("zero-suffix") << QByteArray("bytes=-0") << 10LL << static_cast<int>(RangeError::Unsatisfiable);
+    QTest::newRow("empty-resource") << QByteArray("bytes=0-0") << 0LL << static_cast<int>(RangeError::Unsatisfiable);
+    QTest::newRow("not-a-number") << QByteArray("bytes=x-y") << 10LL << static_cast<int>(RangeError::Malformed);
+    QTest::newRow("numeric-overflow") << QByteArray("bytes=999999999999999999999-") << 10LL << static_cast<int>(RangeError::Malformed);
+    QTest::newRow("416-start-at-size") << QByteArray("bytes=10-20") << 10LL << static_cast<int>(RangeError::Unsatisfiable);
+}
+
+void TestStreamingHelpers::rejectRange()
+{
+    QFETCH(QByteArray, header);
+    QFETCH(qint64, size);
+    QFETCH(int, error);
+
+    const auto result = Streaming::parseHttpRange(header, size);
+    QVERIFY(!result.has_value());
+    QCOMPARE(static_cast<int>(result.error()), error);
+}
+
+void TestStreamingHelpers::mapPieces_data()
+{
+    QTest::addColumn<qint64>("firstByte");
+    QTest::addColumn<qint64>("lastByte");
+    QTest::addColumn<qint64>("fileOffset");
+    QTest::addColumn<qint64>("pieceLength");
+    QTest::addColumn<int>("firstPiece");
+    QTest::addColumn<int>("lastPiece");
+
+    QTest::newRow("one-piece") << 0LL << 9LL << 0LL << 16LL << 0 << 0;
+    QTest::newRow("file-offset-crossing") << 0LL << 2LL << 15LL << 16LL << 0 << 1;
+    QTest::newRow("offset-file") << 10LL << 50LL << 100LL << 32LL << 3 << 4;
+    QTest::newRow("inclusive-boundary") << 0LL << 16LL << 32LL << 16LL << 2 << 3;
+}
+
+void TestStreamingHelpers::mapPieces()
+{
+    QFETCH(qint64, firstByte);
+    QFETCH(qint64, lastByte);
+    QFETCH(qint64, fileOffset);
+    QFETCH(qint64, pieceLength);
+    QFETCH(int, firstPiece);
+    QFETCH(int, lastPiece);
+
+    const auto result = Streaming::mapByteRangeToPieces(firstByte, lastByte, fileOffset, pieceLength, 100);
+    QVERIFY(result.has_value());
+    QCOMPARE(result->first, firstPiece);
+    QCOMPARE(result->last, lastPiece);
+}
+
+void TestStreamingHelpers::rejectPieceMapping()
+{
+    QVERIFY(!Streaming::mapByteRangeToPieces(-1, 2, 0, 16, 4));
+    QVERIFY(!Streaming::mapByteRangeToPieces(2, 1, 0, 16, 4));
+    QVERIFY(!Streaming::mapByteRangeToPieces(0, 1, -1, 16, 4));
+    QVERIFY(!Streaming::mapByteRangeToPieces(0, 1, 0, 0, 4));
+    QVERIFY(!Streaming::mapByteRangeToPieces(0, 64, 0, 16, 4));
+    QVERIFY(!Streaming::mapByteRangeToPieces(0, std::numeric_limits<qint64>::max(), 1, 16, 4));
+}
+
+QTEST_APPLESS_MAIN(TestStreamingHelpers)
+#include "teststreaminghelpers.moc"


### PR DESCRIPTION
## Summary

This PR adds streaming playback for video files that are still being downloaded.

Instead of opening a partially downloaded payload file directly, qBittorrent exposes the selected file through a dedicated HTTP streaming endpoint and only serves bytes after all BitTorrent pieces covering the requested range are available. This prevents media players from reading holes or unverified regions of an incomplete file.

## Motivation

A torrent payload file can already have its final filesystem size while some byte ranges are still missing. Opening such a file directly in a media player can produce corrupted frames, decoder artifacts, freezes, or container errors.

The streaming layer uses libtorrent piece availability as the source of truth. Before each disk read it checks every piece covering the requested block. If any piece is missing, qBittorrent waits and prioritizes the required pieces instead of sending incomplete data.

## Implementation

- Add a dedicated asynchronous HTTP streaming server using `QTcpServer` and the existing BitTorrent session.
- Support `HEAD`, regular `GET`, and single HTTP byte-range requests.
- Map requested file byte ranges to torrent piece indexes.
- Check `have_piece()` before every payload read.
- Prioritize missing pieces using ordered `set_piece_deadline()` calls.
- Maintain a configurable read-ahead window around the current playback position.
- Replace streaming deadlines when a new Range request seeks to another position.
- Add a configurable timeout rather than returning unverified data indefinitely.
- Use a token-authenticated streaming URL and never accept arbitrary filesystem paths.

Streaming does not create another libtorrent session, enable global sequential download mode, change normal file priorities, copy the payload to a temporary file, or transcode media.

## WebUI and Web API

When streaming is enabled, supported video files in the torrent content view get a Play action. The WebUI requests a tokenized URL from the new `torrents/streamUrl` Web API endpoint and opens the stream for playback.

Streaming preferences expose enable/disable, bind address, port, read-ahead, wait timeout, and an explicit LAN opt-in. The default listener is disabled and bound to `127.0.0.1`.

## Safety

- Streaming is disabled by default.
- Non-loopback binding requires an explicit LAN opt-in.
- Wildcard bind addresses are rejected for generated URLs.
- Stream URLs require a cryptographically generated token.
- The endpoint identifies content by torrent ID and stable file index, not arbitrary filesystem paths.
- Stopped, checking, moving, errored, missing, removed, metadata-less, or ignored files fail closed.

## Current limitations

- One active GET stream at a time.
- One byte range per request.
- Plain HTTP only.
- No transcoding or playlist generation.
- Playback format support depends on the client media player/browser.
- If requested pieces cannot be downloaded before the configured timeout, the stream is closed rather than serving incomplete data.

## Tests

Added unit coverage for HTTP Range parsing and mapping file-relative byte ranges to torrent pieces, including invalid, suffix, open-ended, and boundary cases.

Local verification after rebasing onto current `master` (`55ded55`):

- full ARM64 `qbittorrent-nox` build completed successfully;
- `teststreaminghelpers`: 23 passed, 0 failed, 0 skipped;
- `git diff --check`: passed;
- WebUI JavaScript syntax check: passed.

The central correctness invariant is that qBittorrent never reads and serves a payload block until every BitTorrent piece covering that block is reported available by libtorrent.