### PR TITLE
Add torrent deletion dialog alternative

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1562,6 +1562,19 @@ void Preferences::setConfirmTorrentDeletion(const bool enabled)
     setValue(u"Preferences/Advanced/confirmTorrentDeletion"_s, enabled);
 }
 
+bool Preferences::alternativeDeletionDialog() const
+{
+    return value(u"Preferences/Advanced/alternativeDeletionDialog"_s, false);
+}
+
+void Preferences::setAlternativeDeletionDialog(const bool enabled)
+{
+    if (enabled == alternativeDeletionDialog())
+        return;
+
+    setValue(u"Preferences/Advanced/alternativeDeletionDialog"_s, enabled);
+}
+
 bool Preferences::confirmTorrentRecheck() const
 {
     return value(u"Preferences/Advanced/confirmTorrentRecheck"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -321,6 +321,8 @@ public:
 #endif
     bool confirmTorrentDeletion() const;
     void setConfirmTorrentDeletion(bool enabled);
+    bool alternativeDeletionDialog() const;
+    void setAlternativeDeletionDialog(bool enabled);
     bool confirmTorrentRecheck() const;
     void setConfirmTorrentRecheck(bool enabled);
     bool confirmRemoveAllTags() const;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -9,6 +9,7 @@ qt_wrap_ui(UI_HEADERS
     banlistoptionsdialog.ui
     cookiesdialog.ui
     deletionconfirmationdialog.ui
+    deletionconfirmationdialogalternative.ui
     downloadfromurldialog.ui
     executionlogwidget.ui
     ipsubnetwhitelistoptionsdialog.ui
@@ -52,6 +53,7 @@ add_library(qbt_gui STATIC
     cookiesdialog.h
     cookiesmodel.h
     deletionconfirmationdialog.h
+    deletionconfirmationdialogalternative.h
     desktopintegration.h
     downloadfromurldialog.h
     executionlogwidget.h
@@ -161,6 +163,7 @@ add_library(qbt_gui STATIC
     cookiesdialog.cpp
     cookiesmodel.cpp
     deletionconfirmationdialog.cpp
+    deletionconfirmationdialogalternative.cpp
     desktopintegration.cpp
     downloadfromurldialog.cpp
     executionlogwidget.cpp

--- a/src/gui/deletionconfirmationdialogalternative.cpp
+++ b/src/gui/deletionconfirmationdialogalternative.cpp
@@ -1,0 +1,80 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024-2026  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "deletionconfirmationdialogalternative.h"
+
+#include <QPushButton>
+
+#include "base/bittorrent/session.h"
+#include "base/preferences.h"
+#include "uithememanager.h"
+#include "utils.h"
+
+using namespace Qt::Literals::StringLiterals;
+
+DeletionConfirmationDialogAlternative::DeletionConfirmationDialogAlternative(QWidget *parent, const int torrentsCount, const QString &name, const bool defaultDeleteFiles)
+    : QDialog(parent)
+    , m_ui {new Ui::DeletionConfirmationDialogAlternative}
+{
+    m_ui->setupUi(this);
+
+    if (torrentsCount == 1)
+        m_ui->label->setText(tr("Are you sure you want to remove '%1' from the transfer list?", "Are you sure you want to remove 'ubuntu-linux-iso' from the transfer list?").arg(name.toHtmlEscaped()));
+    else
+        m_ui->label->setText(tr("Are you sure you want to remove these %1 torrents from the transfer list?", "Are you sure you want to remove these 5 torrents from the transfer list?").arg(QString::number(torrentsCount)));
+
+    // Warning Icon Setup
+    const QSize iconSize = Utils::Gui::largeIconSize();
+    m_ui->labelWarning->setPixmap(UIThemeManager::instance()->getIcon(u"dialog-warning"_s).pixmap(iconSize));
+    m_ui->labelWarning->setFixedWidth(iconSize.width());
+
+    // Connect custom removal buttons directly to accept/reject flow
+    // (Assumes m_ui contains btnRemoveTorrent, btnRemoveTorrentAndFiles, and btnCancel)
+    connect(m_ui->btnRemoveTorrentAndFiles, &QPushButton::clicked, this, [this] {
+        m_removeContent = true;
+        accept();
+    });
+
+    connect(m_ui->btnRemoveTorrent, &QPushButton::clicked, this, [this] {
+        m_removeContent = false;
+        accept();
+    });
+
+    connect(m_ui->btnCancel, &QPushButton::clicked, this, &QDialog::reject);
+}
+
+DeletionConfirmationDialogAlternative::~DeletionConfirmationDialogAlternative()
+{
+    delete m_ui;
+}
+
+bool DeletionConfirmationDialogAlternative::isRemoveContentSelected() const
+{
+    return m_removeContent;
+}

--- a/src/gui/deletionconfirmationdialogalternative.cpp
+++ b/src/gui/deletionconfirmationdialogalternative.cpp
@@ -38,7 +38,7 @@
 
 using namespace Qt::Literals::StringLiterals;
 
-DeletionConfirmationDialogAlternative::DeletionConfirmationDialogAlternative(QWidget *parent, const int torrentsCount, const QString &name, const bool defaultDeleteFiles)
+DeletionConfirmationDialogAlternative::DeletionConfirmationDialogAlternative(QWidget *parent, const int torrentsCount, const QString &name)
     : QDialog(parent)
     , m_ui {new Ui::DeletionConfirmationDialogAlternative}
 {

--- a/src/gui/deletionconfirmationdialogalternative.h
+++ b/src/gui/deletionconfirmationdialogalternative.h
@@ -1,0 +1,55 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024-2026  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QDialog>
+
+#include "ui_deletionconfirmationdialogalternative.h"
+
+namespace Ui
+{
+    class DeletionConfirmationDialogAlternative;
+}
+
+class DeletionConfirmationDialogAlternative final : public QDialog
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(DeletionConfirmationDialogAlternative)
+
+public:
+    DeletionConfirmationDialogAlternative(QWidget *parent, int torrentsCount, const QString &name, bool defaultDeleteFiles);
+    ~DeletionConfirmationDialogAlternative() override;
+
+    bool isRemoveContentSelected() const;
+
+private:
+    Ui::DeletionConfirmationDialogAlternative *m_ui = nullptr;
+    bool m_removeContent = false;
+};

--- a/src/gui/deletionconfirmationdialogalternative.h
+++ b/src/gui/deletionconfirmationdialogalternative.h
@@ -44,7 +44,7 @@ class DeletionConfirmationDialogAlternative final : public QDialog
     Q_DISABLE_COPY_MOVE(DeletionConfirmationDialogAlternative)
 
 public:
-    DeletionConfirmationDialogAlternative(QWidget *parent, int torrentsCount, const QString &name, bool defaultDeleteFiles);
+    DeletionConfirmationDialogAlternative(QWidget *parent, int torrentsCount, const QString &name);
     ~DeletionConfirmationDialogAlternative() override;
 
     bool isRemoveContentSelected() const;

--- a/src/gui/deletionconfirmationdialogalternative.ui
+++ b/src/gui/deletionconfirmationdialogalternative.ui
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DeletionConfirmationDialogAlternative</class>
+ <widget class="QDialog" name="DeletionConfirmationDialogAlternative">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>463</width>
+    <height>128</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Remove torrent(s)</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="labelWarning">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true">message goes here</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRemoveTorrentAndFiles">
+       <property name="text">
+        <string>Remove torrent and content</string>
+       </property>
+       <property name="styleSheet">
+        <string>background-color: #d9534f; color: white;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRemoveTorrent">
+       <property name="text">
+        <string>Remove torrent</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -278,6 +278,7 @@ void OptionsDialog::loadBehaviorTabOptions()
 #endif
 
     m_ui->confirmDeletion->setChecked(pref->confirmTorrentDeletion());
+    m_ui->alternativeDeletionUI->setChecked(pref->alternativeDeletionDialog());
     m_ui->checkAltRowColors->setChecked(pref->useAlternatingRowColors());
     m_ui->checkUseTorrentStatesColors->setChecked(pref->useTorrentStatesColors());
     m_ui->checkProgressBarFollowsTextColor->setChecked(pref->getProgressBarFollowsTextColor());
@@ -416,6 +417,7 @@ void OptionsDialog::loadBehaviorTabOptions()
     });
 
     connect(m_ui->confirmDeletion, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->alternativeDeletionUI, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkAltRowColors, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseTorrentStatesColors, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseTorrentStatesColors, &QAbstractButton::toggled, m_ui->checkProgressBarFollowsTextColor, &QWidget::setEnabled);
@@ -504,6 +506,7 @@ void OptionsDialog::saveBehaviorTabOptions() const
     pref->setCustomUIThemePath(m_ui->customThemeFilePath->selectedPath());
 
     pref->setConfirmTorrentDeletion(m_ui->confirmDeletion->isChecked());
+    pref->setAlternativeDeletionDialog(m_ui->alternativeDeletionUI->isChecked());
     pref->setAlternatingRowColors(m_ui->checkAltRowColors->isChecked());
     pref->setUseTorrentStatesColors(m_ui->checkUseTorrentStatesColors->isChecked());
     pref->setProgressBarFollowsTextColor(m_ui->checkProgressBarFollowsTextColor->isChecked());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -288,6 +288,16 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="alternativeDeletionUI">
+                 <property name="toolTip">
+                  <string>Replaces the checkbox with dedicated buttons to keep or remove torrent content</string>
+                 </property>
+                 <property name="text">
+                  <string>Alternative torrent deletion UI</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="checkAltRowColors">
                  <property name="text">
                   <string extracomment="In table elements, every other row will have a grey background.">Use alternating row colors</string>

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -58,6 +58,7 @@
 #include "base/utils/string.h"
 #include "autoexpandabledialog.h"
 #include "deletionconfirmationdialog.h"
+#include "deletionconfirmationdialogalternative.h"
 #include "interfaces/iguiapplication.h"
 #include "mainwindow.h"
 #include "optionsdialog.h"
@@ -436,15 +437,27 @@ void TransferListWidget::deleteSelectedTorrents(const bool deleteLocalFiles)
 
     if (Preferences::instance()->confirmTorrentDeletion())
     {
-        auto *dialog = new DeletionConfirmationDialog(this, torrents.size(), torrents[0]->name(), deleteLocalFiles);
-        dialog->setAttribute(Qt::WA_DeleteOnClose);
-        connect(dialog, &DeletionConfirmationDialog::accepted, this, [this, dialog]()
+        if (Preferences::instance()->alternativeDeletionDialog())
         {
-            // Some torrents might be removed when waiting for user input, so refetch the torrent list
-            // NOTE: this will only work when dialog is modal
-            removeTorrents(getSelectedTorrents(), dialog->isRemoveContentSelected());
-        });
-        dialog->open();
+            auto *dialog = new DeletionConfirmationDialogAlternative(this, torrents.size(), torrents[0]->name(), deleteLocalFiles);
+            dialog->setAttribute(Qt::WA_DeleteOnClose);
+            connect(dialog, &DeletionConfirmationDialogAlternative::accepted, this, [this, dialog]()
+            {
+                // Refetch torrents to prevent operating on deleted/invalid pointers
+                removeTorrents(getSelectedTorrents(), dialog->isRemoveContentSelected());
+            });
+            dialog->open();
+        }
+        else
+        {
+            auto *dialog = new DeletionConfirmationDialog(this, torrents.size(), torrents[0]->name(), deleteLocalFiles);
+            dialog->setAttribute(Qt::WA_DeleteOnClose);
+            connect(dialog, &DeletionConfirmationDialog::accepted, this, [this, dialog]()
+            {
+                removeTorrents(getSelectedTorrents(), dialog->isRemoveContentSelected());
+            });
+            dialog->open();
+        }
     }
     else
     {

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -156,6 +156,7 @@ void AppController::preferencesAction()
     data[u"status_bar_external_ip"_s] = pref->isStatusbarExternalIPDisplayed();
     // Transfer List
     data[u"confirm_torrent_deletion"_s] = pref->confirmTorrentDeletion();
+    data[u"alternative_deletion_dialog"_s] = pref->alternativeDeletionDialog();
     // Search
     data[u"store_search_jobs"_s] = pref->storeSearchJobs();
     data[u"store_search_job_results"_s] = pref->storeSearchJobResults();
@@ -558,6 +559,8 @@ void AppController::setPreferencesAction()
     // Transfer List
     if (hasKey(u"confirm_torrent_deletion"_s))
         pref->setConfirmTorrentDeletion(it.value().toBool());
+    if (hasKey(u"alternative_deletion_dialog"_s))
+        pref->setAlternativeDeletionDialog(it.value().toBool());
     // Search
     if (hasKey(u"store_search_jobs"_s))
         pref->setStoreSearchJobs(it.value().toBool());

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -527,7 +527,8 @@ const initializeWindows = () => {
                     title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
                     data: {
                         hashes: hashes,
-                        forceDeleteFiles: forceDeleteFiles
+                        forceDeleteFiles: forceDeleteFiles,
+                        alternativeDeletionDialog: window.qBittorrent.Cache.preferences.get().alternative_deletion_dialog
                     },
                     contentURL: "views/confirmdeletion.html?v=${CACHEID}",
                     onContentLoaded: (w) => {

--- a/src/webui/www/private/views/confirmdeletion.html
+++ b/src/webui/www/private/views/confirmdeletion.html
@@ -86,8 +86,12 @@
         // Conditionally set up the dialog based on the preference flag
         if (alternativeDeletionDialog) {
             // Hide standard elements, show alternative buttons
-            for (const el of document.querySelectorAll(".standard-deletion-item")) el.style.display = "none";
-            for (const el of document.querySelectorAll(".alternative-deletion-item")) el.style.display = "inline-block";
+            for (const el of document.querySelectorAll(".standard-deletion-item")) {
+                el.style.display = "none";
+            }
+            for (const el of document.querySelectorAll(".alternative-deletion-item")) {
+                el.style.display = "inline-block";
+            }
 
             confirmAndFilesButton.addEventListener("click", () => executeDeletion(true));
             confirmAlternativeButton.addEventListener("click", () => executeDeletion(false));

--- a/src/webui/www/private/views/confirmdeletion.html
+++ b/src/webui/www/private/views/confirmdeletion.html
@@ -86,8 +86,8 @@
         // Conditionally set up the dialog based on the preference flag
         if (alternativeDeletionDialog) {
             // Hide standard elements, show alternative buttons
-            document.querySelectorAll(".standard-deletion-item").forEach(el => el.style.display = "none");
-            document.querySelectorAll(".alternative-deletion-item").forEach(el => el.style.display = "inline-block");
+            for (const el of document.querySelectorAll(".standard-deletion-item")) {el.style.display = "none";}
+            for (const el of document.querySelectorAll(".alternative-deletion-item")) {el.style.display = "inline-block";}
 
             confirmAndFilesButton.addEventListener("click", () => executeDeletion(true));
             confirmAlternativeButton.addEventListener("click", () => executeDeletion(false));

--- a/src/webui/www/private/views/confirmdeletion.html
+++ b/src/webui/www/private/views/confirmdeletion.html
@@ -86,8 +86,8 @@
         // Conditionally set up the dialog based on the preference flag
         if (alternativeDeletionDialog) {
             // Hide standard elements, show alternative buttons
-            for (const el of document.querySelectorAll(".standard-deletion-item")) {el.style.display = "none";}
-            for (const el of document.querySelectorAll(".alternative-deletion-item")) {el.style.display = "inline-block";}
+            for (const el of document.querySelectorAll(".standard-deletion-item")) el.style.display = "none";
+            for (const el of document.querySelectorAll(".alternative-deletion-item")) el.style.display = "inline-block";
 
             confirmAndFilesButton.addEventListener("click", () => executeDeletion(true));
             confirmAlternativeButton.addEventListener("click", () => executeDeletion(false));

--- a/src/webui/www/private/views/confirmdeletion.html
+++ b/src/webui/www/private/views/confirmdeletion.html
@@ -2,10 +2,11 @@
     <div class="confirmDeletionGrid">
         <span class="deletionGridItem confirmDialogWarning"></span>
         <span class="deletionGridItem dialogMessage" id="deleteTorrentMessage"></span>
-        <span class="deletionGridItem">
+        <!-- Standard layout elements -->
+        <span class="deletionGridItem standard-deletion-item">
             <button class="disabled" type="button" id="rememberBtn" title="QBT_TR(Remember choice)QBT_TR[CONTEXT=HttpServer]" aria-label="QBT_TR(Remember choice)QBT_TR[CONTEXT=HttpServer]" disabled></button>
         </span>
-        <span class="deletionGridItem">
+        <span class="deletionGridItem standard-deletion-item">
             <input type="checkbox" id="deleteFromDiskCB">
             <label for="deleteFromDiskCB">
                 <em>QBT_TR(Also remove the content files)QBT_TR[CONTEXT=confirmDeletionDlg]</em>
@@ -14,7 +15,14 @@
     </div>
 </div>
 <div>
-    <input type="button" value="QBT_TR(Remove torrent)QBT_TR[CONTEXT=MainWindow]" id="confirmDeletionButton">
+    <!-- Standard layout action button -->
+    <input type="button" value="QBT_TR(Remove torrent)QBT_TR[CONTEXT=MainWindow]" id="confirmDeletionButton" class="standard-deletion-item">
+
+    <!-- Alternative layout action buttons -->
+    <input type="button" value="QBT_TR(Remove torrent and content)QBT_TR[CONTEXT=MainWindow]" id="confirmDeletionAndFilesButton" class="alternative-deletion-item" style="display: none;">
+    <input type="button" value="QBT_TR(Remove torrent)QBT_TR[CONTEXT=MainWindow]" id="confirmDeletionAlternativeButton" class="alternative-deletion-item" style="display: none;">
+
+    <!-- Cancel button (shared) -->
     <input type="button" value="QBT_TR(Cancel)QBT_TR[CONTEXT=MainWindow]" id="cancelDeletionButton">
 </div>
 
@@ -23,6 +31,8 @@
 
     (() => {
         const confirmButton = document.getElementById("confirmDeletionButton");
+        const confirmAndFilesButton = document.getElementById("confirmDeletionAndFilesButton");
+        const confirmAlternativeButton = document.getElementById("confirmDeletionAlternativeButton");
         const cancelButton = document.getElementById("cancelDeletionButton");
         const rememberButton = document.getElementById("rememberBtn");
         const deleteCB = document.getElementById("deleteFromDiskCB");
@@ -32,9 +42,8 @@
             hashes,
             isDeletingVisibleTorrents = false,
             forceDeleteFiles = false,
+            alternativeDeletionDialog = false, // Provided via appcontroller.cpp preference
         } = window.MUI.Windows.instances["confirmDeletionPage"].options.data;
-        let prefDeleteContentFiles = window.qBittorrent.Cache.preferences.get().delete_torrent_content_files;
-        deleteCB.checked = forceDeleteFiles || prefDeleteContentFiles;
 
         let deleteMessage;
         if (hashes.length === 1) {
@@ -46,46 +55,19 @@
         }
 
         deletionText.textContent = deleteMessage;
-
-        confirmButton.value = (deleteCB.checked ? "QBT_TR(Remove torrent and content)QBT_TR[CONTEXT=MainWindow]" : "QBT_TR(Remove torrent)QBT_TR[CONTEXT=MainWindow]");
-
-        // Enable "Remember" button if the current choice is different from the saved preference
-        deleteCB.addEventListener("click", (e) => {
-            const removeTorrentContent = deleteCB.checked;
-            const rememberButtonDisabled = (removeTorrentContent === prefDeleteContentFiles);
-            rememberButton.disabled = rememberButtonDisabled;
-            rememberButton.classList.toggle("disabled", rememberButtonDisabled);
-
-            const confirmButtonText = (removeTorrentContent ? "QBT_TR(Remove torrent and content)QBT_TR[CONTEXT=MainWindow]" : "QBT_TR(Remove torrent)QBT_TR[CONTEXT=MainWindow]");
-            confirmButton.value = confirmButtonText;
-            confirmButton.classList.toggle("value", confirmButtonText);
-        });
-
-        // Set current "Delete files" choice as the default
-        rememberButton.addEventListener("click", (e) => {
-            window.qBittorrent.Cache.preferences.set({
-                delete_torrent_content_files: deleteCB.checked
-            }).then(() => {
-                prefDeleteContentFiles = deleteCB.checked;
-                rememberButton.disabled = true;
-                rememberButton.classList.toggle("disabled", true);
-            });
-        });
-
         cancelButton.focus();
         cancelButton.addEventListener("click", (e) => { window.qBittorrent.Client.closeWindow(document.getElementById("confirmDeletionPage")); });
 
-        confirmButton.addEventListener("click", (e) => {
-            // Some torrents might be removed when waiting for user input, so refetch the torrent list
-            const hashes = isDeletingVisibleTorrents
+        const executeDeletion = (deleteFiles) => {
+            const targetHashes = isDeletingVisibleTorrents
                 ? torrentsTable.getFilteredTorrentsHashes(selectedStatus, selectedCategory, selectedTag, selectedTracker)
                 : torrentsTable.selectedRowsIds();
 
             fetch("api/v2/torrents/delete", {
                     method: "POST",
                     body: new URLSearchParams({
-                        hashes: hashes.join("|"),
-                        deleteFiles: deleteCB.checked
+                        hashes: targetHashes.join("|"),
+                        deleteFiles: deleteFiles
                     })
                 })
                 .then((response) => {
@@ -99,6 +81,45 @@
                     updatePropertiesPanel();
                     window.qBittorrent.Client.closeWindow(document.getElementById("confirmDeletionPage"));
                 });
-        });
+        };
+
+        // Conditionally set up the dialog based on the preference flag
+        if (alternativeDeletionDialog) {
+            // Hide standard elements, show alternative buttons
+            document.querySelectorAll(".standard-deletion-item").forEach(el => el.style.display = "none");
+            document.querySelectorAll(".alternative-deletion-item").forEach(el => el.style.display = "inline-block");
+
+            confirmAndFilesButton.addEventListener("click", () => executeDeletion(true));
+            confirmAlternativeButton.addEventListener("click", () => executeDeletion(false));
+        }
+        else {
+            // Standard layout logic
+            let prefDeleteContentFiles = window.qBittorrent.Cache.preferences.get().delete_torrent_content_files;
+            deleteCB.checked = forceDeleteFiles || prefDeleteContentFiles;
+
+            confirmButton.value = (deleteCB.checked ? "QBT_TR(Remove torrent and content)QBT_TR[CONTEXT=MainWindow]" : "QBT_TR(Remove torrent)QBT_TR[CONTEXT=MainWindow]");
+
+            deleteCB.addEventListener("click", () => {
+                const removeTorrentContent = deleteCB.checked;
+                const rememberButtonDisabled = (removeTorrentContent === prefDeleteContentFiles);
+                rememberButton.disabled = rememberButtonDisabled;
+                rememberButton.classList.toggle("disabled", rememberButtonDisabled);
+
+                const confirmButtonText = (removeTorrentContent ? "QBT_TR(Remove torrent and content)QBT_TR[CONTEXT=MainWindow]" : "QBT_TR(Remove torrent)QBT_TR[CONTEXT=MainWindow]");
+                confirmButton.value = confirmButtonText;
+            });
+
+            rememberButton.addEventListener("click", () => {
+                window.qBittorrent.Cache.preferences.set({
+                    delete_torrent_content_files: deleteCB.checked
+                }).then(() => {
+                    prefDeleteContentFiles = deleteCB.checked;
+                    rememberButton.disabled = true;
+                    rememberButton.classList.toggle("disabled", true);
+                });
+            });
+
+            confirmButton.addEventListener("click", () => executeDeletion(deleteCB.checked));
+        }
     })();
 </script>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -48,6 +48,10 @@
             <input type="checkbox" id="confirmTorrentDeletion">
             <label for="confirmTorrentDeletion">QBT_TR(Confirm when deleting torrents)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
+        <div class="formRow" style="margin-bottom: 3px;" title="QBT_TR(Replaces the checkbox with dedicated buttons to keep or remove torrent content)QBT_TR[CONTEXT=OptionsDialog]">
+            <input type="checkbox" id="alternativeDeletionDialog">
+            <label for="alternativeDeletionDialog">QBT_TR(Alternative torrent deletion UI)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
         <div class="formRow" style="margin-bottom: 3px;">
             <input type="checkbox" id="useAltRowColorsInput">
             <label for="useAltRowColorsInput">QBT_TR(Use alternating row colors)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -2449,6 +2453,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("dblclickCompleteSelect").value = dblclickComplete;
                     document.getElementById("dblclickFiltersSelect").value = dblclickFilter;
                     document.getElementById("confirmTorrentDeletion").checked = pref.confirm_torrent_deletion;
+                    document.getElementById("alternativeDeletionDialog").checked = pref.alternative_deletion_dialog;
                     document.getElementById("storeSearchJobs").checked = pref.store_search_jobs;
                     document.getElementById("storeSearchJobResults").checked = pref.store_search_job_results;
                     qBittorrent.Preferences.updateStoreSearchJobsEnabled();
@@ -2896,6 +2901,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             clientData.dblclick_complete = document.getElementById("dblclickCompleteSelect").value;
             clientData.dblclick_filter = document.getElementById("dblclickFiltersSelect").value;
             settings["confirm_torrent_deletion"] = document.getElementById("confirmTorrentDeletion").checked;
+            settings["alternative_deletion_dialog"] = document.getElementById("alternativeDeletionDialog").checked;
             settings["store_search_jobs"] = document.getElementById("storeSearchJobs").checked;
             settings["store_search_job_results"] = document.getElementById("storeSearchJobResults").checked;
             clientData.use_alt_row_colors = document.getElementById("useAltRowColorsInput").checked;


### PR DESCRIPTION
Shows a different dialog UI with standalone buttons for keeping/removing content, based on user settings.

<img width="1292" height="632" alt="deletiondialog" src="https://github.com/user-attachments/assets/e5307d8f-6442-455f-9414-4e1a676af606" />

Closes #22258 
Closes #24747 
