### PR TITLE
WebUI: fix startup when embedded in an iframe

### DIFF
--- a/src/webui/www/private/scripts/color-scheme.js
+++ b/src/webui/www/private/scripts/color-scheme.js
@@ -37,7 +37,7 @@ window.qBittorrent.ColorScheme ??= (() => {
     };
 
     const colorSchemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const clientData = window.parent.qBittorrent.ClientData;
+    const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData;
 
     const update = () => {
         const root = document.documentElement;

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -419,7 +419,7 @@ window.qBittorrent.Misc ??= (() => {
      * @param {string} format
      * @returns {string}
      */
-    const formatDate = (date, format = window.parent.qBittorrent.ClientData.get("date_format")) => {
+    const formatDate = (date, format = (window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData).get("date_format")) => {
         if ((format === "default") || !Object.hasOwn(DateFormatOptions, format))
             return date.toLocaleString();
 

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -419,7 +419,8 @@ window.qBittorrent.Misc ??= (() => {
      * @param {string} format
      * @returns {string}
      */
-    const formatDate = (date, format = (window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData).get("date_format")) => {
+    const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData;
+    const formatDate = (date, format = clientData.get("date_format")) => {
         if ((format === "default") || !Object.hasOwn(DateFormatOptions, format))
             return date.toLocaleString();
 


### PR DESCRIPTION
### What

Two call sites read `window.parent.qBittorrent.ClientData` without a fallback:

- `src/webui/www/private/scripts/color-scheme.js:40` — at module scope
- `src/webui/www/private/scripts/misc.js:422` — in a default parameter of `formatDate()`

The other two call sites that read the same value already guard it:

- `src/webui/www/private/scripts/client.js:300`
- `src/webui/www/private/scripts/dynamicTable.js:73`

both with `window.qBittorrent.ClientData ?? window.parent.qBittorrent.ClientData`.
This PR applies that same guard to the two remaining ones.

### Why it breaks when embedded

Inside qBittorrent the unguarded read always resolves: a dialog's parent is the
main WebUI window, and the main window is its own parent. It breaks as soon as
the WebUI is embedded in a page that is not qBittorrent.

`color-scheme.js` reads it at module scope, so the module throws before
`ColorScheme` is exported. `client.js` then calls
`window.qBittorrent.ColorScheme.update()` from its `DOMContentLoaded` handler and
throws in turn, so everything after that line never runs — the filter column, the
transfer list and the status bar values are all built later in that same handler.
What is left on screen is exactly the static markup of `index.html`: menu bar,
toolbar, tabs, and the status bar icons with empty labels.

`misc.js` does the same in a default parameter, so `formatDate()` throws on every
formatted date.

### Effect of the change

- **Main window**: `client-data.js` is loaded before both files in `index.html`, so
  `window.qBittorrent.ClientData` is defined, the left operand is used, and
  `window.parent` is never touched. This also removes the `SecurityError` when the
  embedder is cross-origin.
- **Dialogs**: `download.html` loads `color-scheme.js` but not `client-data.js`, so
  the left operand is `undefined` and they keep falling back to the parent exactly
  as before.

### Testing

The symptom was observed on a 5.x instance embedded in a same-origin `<iframe>`
(reverse-proxied under the embedder's own origin, so `X-Frame-Options: SAMEORIGIN`
and `frame-ancestors 'self'` are satisfied rather than stripped): the frame renders
the static markup described above and nothing else.

To be upfront: I worked around it on the embedder side rather than by patching
qBittorrent, so I have not built and run a binary with this change. The analysis
above comes from reading master. A maintainer check that dialogs still receive
their colour scheme would be welcome.

### Related

Refs #24273, which is the cross-origin variant of the same problem. This PR
removes its `window.qBittorrent.ColorScheme is undefined` error.

It does **not** address the other error quoted there, `Permission denied to access
property 'getCoordinates' on cross-origin object`. That one comes from the bundled
MochaUI copy, `src/webui/www/private/scripts/lib/mocha.min.js`, which calls
`parent.getCoordinates()` in `MUI.underlayInitialize()` (bound to `domready`) and in
`MUI.setUnderlaySize()` (bound to `resize`). `getCoordinates` is a MooTools method
that only exists on a window whose document loaded MooTools, so an embedder that
does not will make both calls throw; `#windowUnderlay` is then never created, and
MochaUI calls `$("windowUnderlay").show()` on every window drag and resize. Since
`parent === window` in a top-level document, those two calls look like they mean
the current window. I left them alone because it is vendored minified code — happy
to change them here if you would rather have it in one PR.