### PR TITLE
Fix macOS crash when opening files

### DIFF
--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -43,6 +43,7 @@ namespace MacUtils
     void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...));
     void askForNotificationPermission();
     void displayNotification(const QString &title, const QString &message);
+    void openFile(const Path &path);
     void openFiles(const PathList &pathList);
 
     bool isMagnetLinkAssocSet();

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -123,6 +123,21 @@ namespace MacUtils
         }
     }
 
+    void openFile(const Path &path)
+    {
+        @autoreleasepool
+        {
+            NSURL *pathURL = [NSURL fileURLWithPath:path.toString().toNSString()];
+
+            // Opening a file through the workspace can affect Qt's main loop.
+            // Dispatch the request in the background, as done for revealing files in Finder.
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
+            {
+                [[NSWorkspace sharedWorkspace] openURL:pathURL];
+            });
+        }
+    }
+
     void openFiles(const PathList &pathList)
     {
         @autoreleasepool

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -66,8 +66,13 @@
 #include "base/utils/fs.h"
 #include "base/utils/version.h"
 
+#ifdef Q_OS_MACOS
+#include "macutilities.h"
+#endif
+
 namespace
 {
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
     QUrl toURL(const Path &path)
     {
         // Hack to access samba shares with QDesktopServices::openUrl
@@ -75,6 +80,7 @@ namespace
             ? QUrl(u"file:" + path.data())
             : QUrl::fromLocalFile(path.data());
     }
+#endif
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     void invokeFileManager(const Path &path)
@@ -200,8 +206,6 @@ QPoint Utils::Gui::screenCenter(const QWidget *w)
 // Open the given path with an appropriate application
 void Utils::Gui::openPath(const Path &path)
 {
-    const QUrl url = toURL(path);
-
 #ifdef Q_OS_WIN
     auto *thread = QThread::create([path]()
     {
@@ -217,7 +221,10 @@ void Utils::Gui::openPath(const Path &path)
     thread->setObjectName("Utils::Gui::openPath thread");
     QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
+#elif defined(Q_OS_MACOS)
+    MacUtils::openFile(path);
 #else
+    const QUrl url = toURL(path);
     QDesktopServices::openUrl(url);
 #endif
 }


### PR DESCRIPTION
Closes #24836.

Opening a file from qBittorrent on macOS can leave the Qt event loop in a state that later crashes the app. This uses the existing asynchronous `NSWorkspace` pattern already used when revealing files in Finder, so opening a file no longer runs on the Qt event-loop thread.

The change applies to Contents double-clicks and the other shared file-preview entry points that use `Utils::Gui::openPath()`.

Validation:

- Reviewed the macOS ownership/threading and cross-platform build paths independently.
- Built the macOS GUI locally with AppleClang, libtorrent 1.2.20, Boost 1.86, and warnings treated as errors.
- `cmake --build build-local --target check` passes (17/17 tests).
- Packaged and launched the local app with an isolated qBittorrent profile; it accepted a self-contained test torrent without touching an existing profile or tracker.
- Reproduced the exact Contents-panel path in the isolated build: macOS opened `video.mp4` in QuickTime, then qBittorrent displayed its Crash info dialog. This patch is not yet validated and needs follow-up.
- Upstream macOS CI remains pending maintainer approval for this fork-originated PR.