### PR TITLE
WebUI: Add RSS rule import and export

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -2,6 +2,8 @@
 
 ## 2.16.2
 
+* [#24842](https://github.com/qbittorrent/qBittorrent/pull/24842)
+  * Add JSON `rss/exportRules` and `rss/importRules` endpoints for RSS auto-download rules (`rss/importRules` accepts `POST` requests only)
 * [#24269](https://github.com/qbittorrent/qBittorrent/pull/24269)
   * Add `transfer/pauseSession` endpoint for pausing the session
   * Add `transfer/resumeSession` endpoint for resuming the session

--- a/src/webui/api/rsscontroller.cpp
+++ b/src/webui/api/rsscontroller.cpp
@@ -142,7 +142,8 @@ void RSSController::markAsReadAction()
     const QString articleId {params()[u"articleId"_s]};
 
     RSS::Item *item = RSS::Session::instance()->itemByPath(itemPath);
-    if (!item) return;
+    if (!item)
+        return;
 
     if (!articleId.isNull())
     {
@@ -185,6 +186,29 @@ void RSSController::setRuleAction()
     RSS::AutoDownloader::instance()->setRule(RSS::AutoDownloadRule::fromJsonObject(jsonObj, ruleName));
 
     setResult(QString());
+}
+
+void RSSController::exportRulesAction()
+{
+    setResult(RSS::AutoDownloader::instance()->exportRules(
+        RSS::AutoDownloader::RulesFileFormat::JSON), u"application/json"_s
+        , u"rss-downloader-rules.json"_s);
+}
+
+void RSSController::importRulesAction()
+{
+    if (data().size() != 1)
+        throw APIError(APIErrorType::BadParams, tr("Exactly one rules file is required"));
+
+    try
+    {
+        RSS::AutoDownloader::instance()->importRules(data().cbegin().value()
+            , RSS::AutoDownloader::RulesFileFormat::JSON);
+    }
+    catch (const RSS::ParsingError &error)
+    {
+        throw APIError(APIErrorType::BadParams, error.message());
+    }
 }
 
 void RSSController::renameRuleAction()
@@ -242,7 +266,8 @@ void RSSController::matchingArticlesAction()
     for (const QString &feedURL : rule.feedURLs())
     {
         const RSS::Feed *feed = RSS::Session::instance()->feedByURL(feedURL);
-        if (!feed) continue; // feed doesn't exist
+        if (!feed)
+            continue;        // feed doesn't exist
 
         QJsonArray matchingArticles;
         for (const RSS::Article *article : feed->articles())

--- a/src/webui/api/rsscontroller.h
+++ b/src/webui/api/rsscontroller.h
@@ -49,6 +49,8 @@ private slots:
     void markAsReadAction();
     void refreshItemAction();
     void setRuleAction();
+    void exportRulesAction();
+    void importRulesAction();
     void renameRuleAction();
     void removeRuleAction();
     void cloneRuleAction();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -165,6 +165,7 @@ private:
         {{u"rss"_s, u"addFeed"_s}, Http::HEADER_REQUEST_METHOD_POST},
         {{u"rss"_s, u"addFolder"_s}, Http::HEADER_REQUEST_METHOD_POST},
         {{u"rss"_s, u"cloneRule"_s}, Http::HEADER_REQUEST_METHOD_POST},
+        {{u"rss"_s, u"importRules"_s}, Http::HEADER_REQUEST_METHOD_POST},
         {{u"rss"_s, u"markAsRead"_s}, Http::HEADER_REQUEST_METHOD_POST},
         {{u"rss"_s, u"moveItem"_s}, Http::HEADER_REQUEST_METHOD_POST},
         {{u"rss"_s, u"refreshItem"_s}, Http::HEADER_REQUEST_METHOD_POST},

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -126,6 +126,15 @@
         background-image: url('images/edit-clear.svg');
     }
 
+    #rulesFileButtons {
+        display: flex;
+        gap: 4px;
+    }
+
+    #rulesFileButtons button {
+        flex: 1;
+    }
+
 </style>
 
 <div id="RssDownloader" class="RssDownloader">
@@ -137,6 +146,11 @@
             <b id="rulesTableDesc">QBT_TR(Download Rules)QBT_TR[CONTEXT=AutomatedRssDownloader]</b>
             <button type="button" id="newRuleButton" aria-label="QBT_TR(Add rule)QBT_TR[CONTEXT=AutomatedRssDownloader]" class="imageButton" onclick="qBittorrent.RssDownloader.addRule()"></button>
             <button type="button" id="deleteRuleButton" aria-label="QBT_TR(Remove rule)QBT_TR[CONTEXT=AutomatedRssDownloader]" class="imageButton" onclick="qBittorrent.RssDownloader.removeSelectedRule()"></button>
+        </div>
+        <div id="rulesFileButtons">
+            <button type="button" onclick="qBittorrent.RssDownloader.exportRules()">QBT_TR(Export)QBT_TR[CONTEXT=AutomatedRssDownloader]</button>
+            <button type="button" onclick="qBittorrent.RssDownloader.importRules()">QBT_TR(Import)QBT_TR[CONTEXT=AutomatedRssDownloader]</button>
+            <input type="file" id="rssRulesFileInput" accept=".json" hidden>
         </div>
         <div id="rulesTable">
             <div id="rulesSelectionCheckBoxList">
@@ -348,7 +362,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 rssDownloaderFeedSelectionTable: rssDownloaderFeedSelectionTable,
                 setElementTitles: setElementTitles,
                 addRule: addRule,
-                removeSelectedRule: removeSelectedRule
+                removeSelectedRule: removeSelectedRule,
+                exportRules: exportRules,
+                importRules: importRules
             };
         };
 
@@ -358,6 +374,36 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
 
         let rulesList = {};
         let feedList = [];
+
+        const exportRules = () => {
+            const url = new URL("api/v2/rss/exportRules", window.location);
+            window.qBittorrent.Misc.downloadFile(url, "rss-downloader-rules.json");
+        };
+
+        const importRules = () => {
+            const input = document.getElementById("rssRulesFileInput");
+            input.value = "";
+            input.click();
+        };
+
+        document.getElementById("rssRulesFileInput").addEventListener("change", (event) => {
+            const file = document.getElementById("rssRulesFileInput").files[0];
+            if (!file)
+                return;
+
+            const formData = new FormData();
+            formData.append("rules", file, "rules");
+            fetch("api/v2/rss/importRules", {
+                    method: "POST",
+                    body: formData
+                })
+                .then(async (response) => {
+                    if (!response.ok)
+                        throw new Error(await response.text());
+                    updateRulesList();
+                })
+                .catch((error) => alert(error.message));
+        });
 
         const setup = () => {
             const pref = window.parent.qBittorrent.Cache.preferences.get();
@@ -372,7 +418,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             document.getElementById("centerRssDownloaderColumn").style.height = `calc(100% - ${warningHeight}px)`;
             document.getElementById("rightRssDownloaderColumn").style.height = `calc(100% - ${warningHeight}px)`;
 
-            document.getElementById("rulesTable").style.height = `calc(100% - ${document.getElementById("rulesTableDesc").getBoundingClientRect().height}px)`;
+            const rulesTableHeaderHeight = document.getElementById("topMenuBar").getBoundingClientRect().height
+                + document.getElementById("rulesFileButtons").getBoundingClientRect().height;
+            document.getElementById("rulesTable").style.height = `calc(100% - ${rulesTableHeaderHeight}px)`;
             document.getElementById("rssDownloaderArticlesTable").style.height = `calc(100% - ${document.getElementById("articleTableDesc").getBoundingClientRect().height}px)`;
 
             const centerRowNotTableHeight = document.getElementById("saveButton").getBoundingClientRect().height


### PR DESCRIPTION
Expose the existing JSON <strike>and legacy</strike> RSS rule serializer through the WebAPI and add import/export controls to the RSS Downloader view.

Closes #13868.

Container build: https://github.com/sedlund/qBittorrent/pkgs/container/qbittorrent

<img width="1005" height="881" alt="qb-import" src="https://github.com/user-attachments/assets/77b5fbb2-f976-40e4-99a5-b15e54bacdaa" />

