### PR TITLE
Fix displayed ratio limit being lower than the value that was set

### DIFF
--- a/src/base/utils/number.cpp
+++ b/src/base/utils/number.cpp
@@ -29,6 +29,7 @@
 #include "number.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 
@@ -41,4 +42,10 @@ int Utils::Number::clampingAdd(const int num1, const int num2)
     const int64_t sumResult = static_cast<int64_t>(num1) + num2;
     const int64_t clampedValue = std::clamp(sumResult, intMin, intMax);
     return static_cast<int>(clampedValue);
+}
+
+double Utils::Number::roundToPrecision(const double value, const int precision)
+{
+    const double factor = std::pow(10.0, precision);
+    return (std::round(value * factor) / factor);
 }

--- a/src/base/utils/number.h
+++ b/src/base/utils/number.h
@@ -32,4 +32,7 @@ namespace Utils::Number
 {
     // math addition that the result will never overflow/underflow
     int clampingAdd(int num1, int num2);
+
+    // rounds the number to `precision` digits after the decimal point
+    double roundToPrecision(double value, int precision);
 }

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -30,6 +30,7 @@
 #include "string.h"
 
 #include <cmath>
+#include <limits>
 
 #include <QList>
 #include <QLocale>
@@ -46,7 +47,22 @@ QString Utils::String::fromDouble(const double n, const int precision)
     ** precision we add an extra 0 behind 1 in the below algorithm. */
 
     const double prec = std::pow(10.0, precision);
-    return QLocale::system().toString(std::floor(n * prec) / prec, 'f', precision);
+    const double scaled = (n * prec);
+
+    /* `scaled` may land just below a whole number solely because of the rounding error of
+    ** the multiplication above and of representing `n` itself, in which case truncating it
+    ** loses a digit the number actually has, e.g. 2.30 would be shown as "2.29". Compensate
+    ** for that error only: a number that really does have more digits is still truncated.
+    ** The multiplication alone accounts for one unit in the last place, a few more leave
+    ** room for callers that pass a value which already accumulated some error of its own,
+    ** e.g. `peer.progress() * 100` or `100. * diskWriteQueue / peersCount`. Truncation
+    ** still holds out to 64 of them, so this sits well inside a safe range. */
+    const int TOLERANCE_ULP = 4;
+    const double nearestWhole = std::round(scaled);
+    const double tolerance = (std::abs(scaled) * std::numeric_limits<double>::epsilon() * TOLERANCE_ULP);
+    const double truncated = (std::abs(scaled - nearestWhole) <= tolerance) ? nearestWhole : std::floor(scaled);
+
+    return QLocale::system().toString((truncated / prec), 'f', precision);
 }
 
 QString Utils::String::fromLatin1(const std::string_view string)

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -68,6 +68,7 @@
 #include "base/utils/io.h"
 #include "base/utils/misc.h"
 #include "base/utils/net.h"
+#include "base/utils/number.h"
 #include "base/utils/password.h"
 #include "base/utils/random.h"
 #include "base/utils/sslkey.h"
@@ -1751,7 +1752,11 @@ bool OptionsDialog::isUPnPEnabled() const
 qreal OptionsDialog::getMaxRatio() const
 {
     if (m_ui->checkMaxRatio->isChecked())
-        return m_ui->spinMaxRatio->value();
+    {
+        // stepping the spin box accumulates a rounding error, so its value drifts away
+        // from the number it displays. Take the value the user actually sees.
+        return Utils::Number::roundToPrecision(m_ui->spinMaxRatio->value(), m_ui->spinMaxRatio->decimals());
+    }
     return -1;
 }
 

--- a/src/gui/torrentsharelimitswidget.cpp
+++ b/src/gui/torrentsharelimitswidget.cpp
@@ -30,6 +30,7 @@
 
 #include <limits>
 
+#include "base/utils/number.h"
 #include "ui_torrentsharelimitswidget.h"
 
 namespace
@@ -324,7 +325,7 @@ std::optional<qreal> TorrentShareLimitsWidget::ratioLimit() const
     case UnlimitedComboModeIndex:
         return BitTorrent::NO_RATIO_LIMIT;
     case AssignedComboModeIndex:
-        return m_ui->spinBoxRatioValue->value();
+        return ratioLimitValue();
     default:
         return std::nullopt;
     }
@@ -399,7 +400,7 @@ void TorrentShareLimitsWidget::onRatioLimitModeChanged(const int currentIndex, c
     m_ui->spinBoxRatioValue->setEnabled(currentIndex == AssignedComboModeIndex);
 
     if (previousIndex == AssignedComboModeIndex)
-        m_ratioLimit = m_ui->spinBoxRatioValue->value();
+        m_ratioLimit = ratioLimitValue();
 
     if (currentIndex == AssignedComboModeIndex)
     {
@@ -497,4 +498,11 @@ void TorrentShareLimitsWidget::resetDefaultItemsText()
                         ? tr("From category")
                         : tr("From category (%1)", "From category (share limits mode)").arg(shareLimitsModeName(m_defaultShareLimitsMode)));
     }
+}
+
+qreal TorrentShareLimitsWidget::ratioLimitValue() const
+{
+    // stepping the spin box accumulates a rounding error, so its value drifts away from
+    // the number it displays. Take the value the user actually sees.
+    return Utils::Number::roundToPrecision(m_ui->spinBoxRatioValue->value(), m_ui->spinBoxRatioValue->decimals());
 }

--- a/src/gui/torrentsharelimitswidget.h
+++ b/src/gui/torrentsharelimitswidget.h
@@ -73,6 +73,7 @@ private:
     void onSeedingTimeLimitModeChanged(int currentIndex, int previousIndex);
     void onInactiveSeedingTimeLimitModeChanged(int currentIndex, int previousIndex);
     void resetDefaultItemsText();
+    qreal ratioLimitValue() const;
 
     Ui::TorrentShareLimitsWidget *m_ui = nullptr;
 

--- a/test/testutilsnumber.cpp
+++ b/test/testutilsnumber.cpp
@@ -57,6 +57,23 @@ private slots:
         QCOMPARE(Utils::Number::clampingAdd(intMin, -1), intMin);
         QCOMPARE(Utils::Number::clampingAdd(intMin, intMin), intMin);
     }
+
+    void testRoundToPrecision() const
+    {
+        QCOMPARE(Utils::Number::roundToPrecision(1.234, 2), 1.23);
+        QCOMPARE(Utils::Number::roundToPrecision(1.235, 2), 1.24);
+        QCOMPARE(Utils::Number::roundToPrecision(-1.235, 2), -1.24);
+        QCOMPARE(Utils::Number::roundToPrecision(1.5, 0), 2.0);
+        QCOMPARE(Utils::Number::roundToPrecision(0.0, 2), 0.0);
+
+        // values already having the requested precision are left alone
+        QCOMPARE(Utils::Number::roundToPrecision(4.0, 2), 4.0);
+        QCOMPARE(Utils::Number::roundToPrecision(2.3, 2), 2.3);
+
+        // the error accumulated by repeatedly stepping a spin box is undone
+        QCOMPARE(Utils::Number::roundToPrecision(3.9999999999999938, 2), 4.0);
+        QCOMPARE(Utils::Number::roundToPrecision(2.9999999999999973, 2), 3.0);
+    }
 };
 
 QTEST_APPLESS_MAIN(TestUtilsNumber)

--- a/test/testutilsstring.cpp
+++ b/test/testutilsstring.cpp
@@ -27,6 +27,7 @@
  */
 
 #include <QList>
+#include <QLocale>
 #include <QObject>
 #include <QTest>
 
@@ -62,6 +63,35 @@ public:
     TestUtilsString() = default;
 
 private slots:
+    void testFromDouble() const
+    {
+        // `fromDouble()` truncates instead of rounding, so it has to be compared against
+        // the locale the function itself uses rather than against hardcoded strings
+        const auto localized = [](const double value, const int precision) -> QString
+        {
+            return QLocale::system().toString(value, 'f', precision);
+        };
+
+        // a number that cannot be represented exactly must not lose its last digit
+        QCOMPARE(Utils::String::fromDouble(2.3, 2), localized(2.3, 2));
+        QCOMPARE(Utils::String::fromDouble(0.29, 2), localized(0.29, 2));
+        QCOMPARE(Utils::String::fromDouble(1.001, 3), localized(1.001, 3));
+
+        // every value that already has the requested precision is printed as is
+        for (int i = 0; i <= 10000; ++i)
+        {
+            const double value = (i / 100.0);
+            QCOMPARE(Utils::String::fromDouble(value, 2), localized(value, 2));
+        }
+
+        // numbers that really do have more digits are still truncated, not rounded up
+        QCOMPARE(Utils::String::fromDouble((0.999 * 100.0), 1), localized(99.9, 1));
+        QCOMPARE(Utils::String::fromDouble((0.9999 * 100.0), 1), localized(99.9, 1));
+        QCOMPARE(Utils::String::fromDouble(99.999, 1), localized(99.9, 1));
+        QCOMPARE(Utils::String::fromDouble(1.009999999999, 2), localized(1.0, 2));
+        QCOMPARE(Utils::String::fromDouble(3.999999999999, 2), localized(3.99, 2));
+    }
+
     void testJoinIntoString() const
     {
         const QList<QString> list1;


### PR DESCRIPTION
Closes #11740.

A ratio limit set to 4.00 can end up shown as 3.99 in the transfer list, from two independent causes.

QDoubleSpinBox rounds to the decimals it displays when a value is set, but not when it's stepped, so typing 4.00 works while clicking up to it leaves value() at 3.9999999999999938, and that's what gets stored. Both ratio spin boxes now return what they show.

The second is in fromDouble(). It truncates n * prec, and that product can land just below a whole number from representation error alone, so 2.30 came out as "2.29" with no stepping involved. At 2 decimals that's 573 of the 10001 values between 0.00 and 100.00.

Same code as #16580. The truncation policy is unchanged, std::floor() stays and only the scaling error is compensated, and thalieht's cases from that thread are in the tests. Per Chocobo1's point there, the fix is in the shared function so every caller gets it.

Built and tested against Qt 6.10.1 and libtorrent 2.0.11, GUI and nox.
