### PR TITLE
Fix accessible names of GUI controls

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -70,6 +70,7 @@
 #include "filterpatternformatmenu.h"
 #include "lineedit.h"
 #include "torrenttagsdialog.h"
+#include "utils.h"
 
 #include "ui_addnewtorrentdialog.h"
 
@@ -197,6 +198,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
     , m_storeFilterPatternFormat {u"GUI/" SETTINGS_KEY(u"FilterPatternFormat"_s)}
 {
     m_ui->setupUi(this);
+    Utils::Gui::nameNestedGroupBoxes(this);
 
     m_ui->scrollArea->viewport()->setAutoFillBackground(false);
     m_ui->scrollAreaWidgetContents->setAutoFillBackground(false);

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -73,6 +73,9 @@
                <property name="text">
                 <string>Torrent Management Mode:</string>
                </property>
+               <property name="buddy">
+                <cstring>comboTMM</cstring>
+               </property>
               </widget>
              </item>
              <item>
@@ -174,6 +177,9 @@
                   <property name="text">
                    <string>Category:</string>
                   </property>
+                  <property name="buddy">
+                   <cstring>categoryComboBox</cstring>
+                  </property>
                  </widget>
                 </item>
                 <item>
@@ -207,6 +213,9 @@
                  <widget class="QLabel" name="tagsLabel">
                   <property name="text">
                    <string>Tags:</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>tagsLineEdit</cstring>
                   </property>
                  </widget>
                 </item>
@@ -256,6 +265,9 @@
                    <widget class="QLabel" name="stopConditionLabel">
                     <property name="text">
                      <string>Stop condition:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>stopConditionComboBox</cstring>
                     </property>
                    </widget>
                   </item>
@@ -326,6 +338,9 @@
                  <widget class="QLabel" name="contentLayoutLabel">
                   <property name="text">
                    <string>Content layout:</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>contentLayoutComboBox</cstring>
                   </property>
                  </widget>
                 </item>

--- a/src/gui/addtorrentparamswidget.ui
+++ b/src/gui/addtorrentparamswidget.ui
@@ -21,6 +21,9 @@
        <property name="text">
         <string>Torrent Management Mode:</string>
        </property>
+       <property name="buddy">
+        <cstring>comboTTM</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -73,6 +76,9 @@
           <property name="text">
            <string>Use another path for incomplete torrents:</string>
           </property>
+          <property name="buddy">
+           <cstring>useDownloadPathComboBox</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -94,7 +100,11 @@
        </layout>
       </item>
       <item>
-       <widget class="FileSystemPathLineEdit" name="downloadPathEdit" native="true"/>
+       <widget class="FileSystemPathLineEdit" name="downloadPathEdit" native="true">
+        <property name="accessibleName">
+         <string>Use another path for incomplete torrents:</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -105,6 +115,9 @@
       <widget class="QLabel" name="labelCategory">
        <property name="text">
         <string>Category:</string>
+       </property>
+       <property name="buddy">
+        <cstring>categoryComboBox</cstring>
        </property>
       </widget>
      </item>
@@ -145,6 +158,9 @@
       <widget class="QLabel" name="tagsLabel">
        <property name="text">
         <string>Tags:</string>
+       </property>
+       <property name="buddy">
+        <cstring>tagsLineEdit</cstring>
        </property>
       </widget>
      </item>
@@ -208,6 +224,9 @@
          <property name="text">
           <string>Start torrent:</string>
          </property>
+         <property name="buddy">
+          <cstring>startTorrentComboBox</cstring>
+         </property>
         </widget>
        </item>
        <item>
@@ -245,6 +264,9 @@
         <widget class="QLabel" name="contentLayoutLabel">
          <property name="text">
           <string>Content layout:</string>
+         </property>
+         <property name="buddy">
+          <cstring>contentLayoutComboBox</cstring>
          </property>
         </widget>
        </item>
@@ -284,6 +306,9 @@
          <property name="text">
           <string>Stop condition:</string>
          </property>
+         <property name="buddy">
+          <cstring>stopConditionComboBox</cstring>
+         </property>
         </widget>
        </item>
        <item>
@@ -321,6 +346,9 @@
         <widget class="QLabel" name="addToQueueTopLabel">
          <property name="text">
           <string>Add to top of queue:</string>
+         </property>
+         <property name="buddy">
+          <cstring>addToQueueTopComboBox</cstring>
          </property>
         </widget>
        </item>

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -35,6 +35,8 @@
 #include <QHostAddress>
 #include <QLabel>
 #include <QNetworkInterface>
+#include <QRegularExpression>
+#include <QTextDocumentFragment>
 
 #include <libtorrent/version.hpp>
 
@@ -51,6 +53,25 @@ namespace
     QString makeLink(const QStringView url, const QStringView linkLabel)
     {
          return u"<a href=\"%1\">%2</a>"_s.arg(url, linkLabel);
+    }
+
+    // the "(?)" documentation links are visual decoration, not something to spell out
+    QString toSpokenText(const QString &richText)
+    {
+        static const QRegularExpression linkPattern {uR"(<a\s[^>]*>[^<]*</a>)"_s};
+
+        QString text = richText;
+        text.remove(linkPattern);
+        return QTextDocumentFragment::fromHtml(text).toPlainText().simplified();
+    }
+
+    // the cells only hold widgets, so the model itself has to supply the text to announce
+    QTableWidgetItem *createAccessibleItem(const QString &name, const QString &description)
+    {
+        auto *item = new QTableWidgetItem;
+        item->setData(Qt::AccessibleTextRole, name);
+        item->setData(Qt::AccessibleDescriptionRole, description);
+        return item;
     }
 
     enum AdvSettingsCols
@@ -1047,8 +1068,16 @@ void AdvancedSettings::addRow(const int row, const QString &text, T *widget)
     label->setOpenExternalLinks(true);
     label->setToolTip(widget->toolTip());
 
+    const QString spokenName = toSpokenText(text);
+    // section headers are labels that already name themselves
+    if constexpr (!std::is_same_v<T, QLabel>)
+        widget->setAccessibleName(spokenName);
+
     setCellWidget(row, PROPERTY, label);
     setCellWidget(row, VALUE, widget);
+
+    setItem(row, PROPERTY, createAccessibleItem(spokenName, widget->toolTip()));
+    setItem(row, VALUE, createAccessibleItem(spokenName, widget->toolTip()));
 
     if constexpr (std::is_same_v<T, FileSystemPathLineEdit>)
         connect(widget, &FileSystemPathEdit::selectedPathChanged, this, &AdvancedSettings::settingsChanged);

--- a/src/gui/autoexpandabledialog.ui
+++ b/src/gui/autoexpandabledialog.ui
@@ -12,7 +12,11 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="textLabel"/>
+    <widget class="QLabel" name="textLabel">
+     <property name="buddy">
+      <cstring>textEdit</cstring>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QLineEdit" name="textEdit"/>

--- a/src/gui/banlistoptionsdialog.ui
+++ b/src/gui/banlistoptionsdialog.ui
@@ -72,7 +72,11 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_18">
         <item>
-         <widget class="QLineEdit" name="txtIP"/>
+         <widget class="QLineEdit" name="txtIP">
+          <property name="accessibleName">
+           <string>IP address</string>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="buttonBanIP">

--- a/src/gui/cookiesdialog.ui
+++ b/src/gui/cookiesdialog.ui
@@ -45,7 +45,11 @@
         </spacer>
        </item>
        <item>
-        <widget class="QToolButton" name="buttonAdd"/>
+        <widget class="QToolButton" name="buttonAdd">
+         <property name="accessibleName">
+          <string>Add cookie</string>
+         </property>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer">
@@ -64,7 +68,11 @@
         </spacer>
        </item>
        <item>
-        <widget class="QToolButton" name="buttonDelete"/>
+        <widget class="QToolButton" name="buttonDelete">
+         <property name="accessibleName">
+          <string>Delete cookie</string>
+         </property>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer_3">

--- a/src/gui/deletionconfirmationdialog.ui
+++ b/src/gui/deletionconfirmationdialog.ui
@@ -72,6 +72,9 @@
          <height>24</height>
         </size>
        </property>
+       <property name="accessibleName">
+        <string>Remember choice</string>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/gui/downloadfromurldialog.ui
+++ b/src/gui/downloadfromurldialog.ui
@@ -24,6 +24,9 @@
      <property name="text">
       <string>Add torrent links</string>
      </property>
+     <property name="buddy">
+      <cstring>textUrls</cstring>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -35,8 +35,11 @@
 #include <QAction>
 #include <QApplication>
 #include <QCoreApplication>
+#include <QEvent>
 #include <QFileDialog>
+#include <QGroupBox>
 #include <QHBoxLayout>
+#include <QLabel>
 #include <QStyle>
 #include <QToolButton>
 
@@ -63,6 +66,26 @@ namespace
         QT_TRANSLATE_NOOP3("FileSystemPathEdit", "Choose a file", "Caption for file open/save dialog");
     constexpr TrStringWithComment defaultDialogCaptionForDirectory =
         QT_TRANSLATE_NOOP3("FileSystemPathEdit", "Choose a folder", "Caption for directory open dialog");
+
+    // names a widget the way QAccessibleWidget does: after its buddy label or its group box
+    QString inferredAccessibleName(const QWidget *widget)
+    {
+        const QWidget *parentWidget = widget->parentWidget();
+        if (!parentWidget)
+            return {};
+
+        const QList<QLabel *> labels = parentWidget->findChildren<QLabel *>();
+        for (const QLabel *label : labels)
+        {
+            if (label->buddy() == widget)
+                return label->text().remove(u'&');
+        }
+
+        if (const auto *groupBox = qobject_cast<const QGroupBox *>(parentWidget))
+            return groupBox->title().remove(u'&');
+
+        return {};
+    }
 }
 
 class FileSystemPathEdit::FileSystemPathEditPrivate
@@ -76,6 +99,7 @@ private:
     void modeChanged();
     void browseActionTriggered();
     QString dialogCaptionOrDefault() const;
+    void updateAccessibleNames();
 
     FileSystemPathEdit *q_ptr = nullptr;
     std::unique_ptr<Private::IFileEditorWithCompletion> m_editor;
@@ -101,6 +125,7 @@ FileSystemPathEdit::FileSystemPathEditPrivate::FileSystemPathEditPrivate(
     m_browseAction->setToolTip(browseButtonFullText.tr().remove(u'&'));
 
     m_browseBtn->setDefaultAction(m_browseAction);
+    m_browseBtn->setAccessibleName(browseButtonFullText.tr().remove(u'&'));
 
     m_validator->setStrictMode(false);
 
@@ -108,6 +133,19 @@ FileSystemPathEdit::FileSystemPathEditPrivate::FileSystemPathEditPrivate(
     m_editor->setValidator(m_validator);
 
     modeChanged();
+}
+
+void FileSystemPathEdit::FileSystemPathEditPrivate::updateAccessibleNames()
+{
+    Q_Q(FileSystemPathEdit);
+
+    // accessibility clients reach the inner edit widget, not this composite widget
+    QString name = q->accessibleName();
+    if (name.isEmpty())
+        name = inferredAccessibleName(q);
+
+    m_editor->widget()->setAccessibleName(name);
+    m_editor->widget()->setAccessibleDescription(q->accessibleDescription());
 }
 
 void FileSystemPathEdit::FileSystemPathEditPrivate::browseActionTriggered()
@@ -193,6 +231,15 @@ FileSystemPathEdit::FileSystemPathEdit(Private::IFileEditorWithCompletion *edito
     layout->addWidget(d->m_browseBtn);
 
     connect(d->m_browseAction, &QAction::triggered, this, [this]() { this->d_func()->browseActionTriggered(); });
+}
+
+bool FileSystemPathEdit::event(QEvent *event)
+{
+    // buddies from setupUi() are in place at polish time; repeat on show for later names
+    if ((event->type() == QEvent::Polish) || (event->type() == QEvent::Show))
+        d_func()->updateAccessibleNames();
+
+    return QWidget::event(event);
 }
 
 FileSystemPathEdit::~FileSystemPathEdit()

--- a/src/gui/fspathedit.h
+++ b/src/gui/fspathedit.h
@@ -99,6 +99,8 @@ signals:
 protected:
     explicit FileSystemPathEdit(Private::IFileEditorWithCompletion *editor, QWidget *parent);
 
+    bool event(QEvent *event) override;
+
     template <class Widget>
     Widget *editWidget() const
     {

--- a/src/gui/ipsubnetwhitelistoptionsdialog.ui
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.ui
@@ -52,6 +52,9 @@
           <property name="placeholderText">
            <string>Example: 172.17.32.0/24, fdff:ffff:c8::/40</string>
           </property>
+          <property name="accessibleName">
+           <string>IP subnet</string>
+          </property>
          </widget>
         </item>
        </layout>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -249,11 +249,14 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 
     m_columnFilterComboBox = new QComboBox;
 
+    auto *columnFilterLabel = new QLabel(tr("Filter by:"));
+    columnFilterLabel->setBuddy(m_columnFilterComboBox);
+
     QHBoxLayout *columnFilterLayout = new QHBoxLayout;
     columnFilterLayout->setContentsMargins(0, 0, 0, 0);
     columnFilterLayout->addWidget(columnFilterSpacer);
     columnFilterLayout->addWidget(m_columnFilterEdit);
-    columnFilterLayout->addWidget(new QLabel(tr("Filter by:")), 0);
+    columnFilterLayout->addWidget(columnFilterLabel, 0);
     columnFilterLayout->addWidget(m_columnFilterComboBox, 0);
 
     m_columnFilterWidget = new QWidget(this);
@@ -266,6 +269,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 
     // Transfer List tab
     m_transferListWidget = new TransferListWidget(app, this);
+    m_transferListWidget->setAccessibleName(tr("Transfers"));
     m_propertiesWidget = new PropertiesWidget(hSplitter);
     connect(m_transferListWidget, &TransferListWidget::currentTorrentChanged, m_propertiesWidget, &PropertiesWidget::loadTorrentInfos);
     hSplitter->addWidget(m_transferListWidget);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -166,6 +166,7 @@ OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
     , m_storeLastViewedPage {SETTINGS_KEY(u"LastViewedPage"_s)}
 {
     m_ui->setupUi(this);
+    Utils::Gui::nameNestedGroupBoxes(this);
     m_applyButton = m_ui->buttonBox->button(QDialogButtonBox::Apply);
 
 #ifdef Q_OS_UNIX

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -157,6 +157,9 @@
                    <property name="text">
                     <string>Language:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>comboLanguage</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -184,6 +187,9 @@
                    <property name="text">
                     <string>Style:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>comboStyle</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="0" column="1">
@@ -202,6 +208,9 @@
                   <widget class="QLabel" name="labelColorScheme">
                    <property name="text">
                     <string>Color scheme:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>comboColorScheme</cstring>
                    </property>
                   </widget>
                  </item>
@@ -236,6 +245,9 @@
                    <widget class="QLabel" name="label_16">
                     <property name="text">
                      <string>UI Theme file:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>customThemeFilePath</cstring>
                     </property>
                    </widget>
                   </item>
@@ -325,6 +337,9 @@
                  </item>
                  <item>
                   <widget class="QComboBox" name="comboHideZero">
+                   <property name="accessibleName">
+                    <string>Hide zero and infinity values</string>
+                   </property>
                    <item>
                     <property name="text">
                      <string>Always</string>
@@ -362,6 +377,9 @@
                    <widget class="QLabel" name="lblDlList_2">
                     <property name="text">
                      <string>Downloading torrents:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>actionTorrentDlOnDblClBox</cstring>
                     </property>
                    </widget>
                   </item>
@@ -414,6 +432,9 @@
                    <widget class="QLabel" name="lblUploadList">
                     <property name="text">
                      <string>Completed torrents:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>actionTorrentFnOnDblClBox</cstring>
                     </property>
                    </widget>
                   </item>
@@ -541,6 +562,9 @@
                    <property name="text">
                     <string>Window state on start up:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>windowStateComboBox</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -626,6 +650,9 @@
                      <widget class="QLabel" name="labelTrayIconStyle">
                       <property name="text">
                        <string>Tray icon style:</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>comboTrayIcon</cstring>
                       </property>
                      </widget>
                     </item>
@@ -815,6 +842,9 @@
                    <property name="text">
                     <string>Save path:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>textFileLogPath</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -847,6 +877,9 @@
                    </property>
                    <property name="value">
                     <number>65</number>
+                   </property>
+                   <property name="accessibleName">
+                    <string>Backup the log file after:</string>
                    </property>
                   </widget>
                  </item>
@@ -885,12 +918,18 @@
                    <property name="value">
                     <number>6</number>
                    </property>
+                   <property name="accessibleName">
+                    <string>Delete backup logs older than:</string>
+                   </property>
                   </widget>
                  </item>
                  <item>
                   <widget class="QComboBox" name="comboFileLogAgeType">
                    <property name="currentIndex">
                     <number>1</number>
+                   </property>
+                   <property name="accessibleName">
+                    <string>Delete backup logs older than:</string>
                    </property>
                    <item>
                     <property name="text">
@@ -1017,6 +1056,9 @@
                    <property name="text">
                     <string>Torrent content layout:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>contentLayoutComboBox</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -1082,6 +1124,9 @@
                   <widget class="QLabel" name="stopConditionLabel">
                    <property name="text">
                     <string>Torrent stop condition:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>stopConditionComboBox</cstring>
                    </property>
                   </widget>
                  </item>
@@ -1165,7 +1210,11 @@
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="FileSystemPathLineEdit" name="backupDirPathEdit" native="true"/>
+                   <widget class="FileSystemPathLineEdit" name="backupDirPathEdit" native="true">
+                    <property name="accessibleName">
+                     <string>Store backup in:</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="1" column="0">
                    <widget class="QCheckBox" name="finishedBackupDirCheckBox">
@@ -1175,7 +1224,11 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="FileSystemPathLineEdit" name="finishedBackupDirPathEdit" native="true"/>
+                   <widget class="FileSystemPathLineEdit" name="finishedBackupDirPathEdit" native="true">
+                    <property name="accessibleName">
+                     <string>When torrent finished move backup to:</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="2" column="0" colspan="2">
                    <widget class="QCheckBox" name="removeBackupTorrentFileCheckBox">
@@ -1289,6 +1342,9 @@
                    <property name="text">
                     <string>Default Torrent Management Mode:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>comboSavingMode</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="0" column="1">
@@ -1334,6 +1390,9 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                    <property name="text">
                     <string>When Torrent Category changed:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>comboTorrentCategoryChanged</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="1" column="1">
@@ -1371,6 +1430,9 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                   <widget class="QLabel" name="labelCategoryDefaultPathChanged">
                    <property name="text">
                     <string>When Default Save/Incomplete Path changed:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>comboCategoryDefaultPathChanged</cstring>
                    </property>
                   </widget>
                  </item>
@@ -1412,6 +1474,9 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                   <widget class="QLabel" name="labelCategoryChanged">
                    <property name="text">
                     <string>When Category Save Path changed:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>comboCategoryChanged</cstring>
                    </property>
                   </widget>
                  </item>
@@ -1468,6 +1533,9 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                    <property name="text">
                     <string>Default Save Path:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>textSavePath</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="0" column="1">
@@ -1481,7 +1549,11 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                   </widget>
                  </item>
                  <item row="1" column="1">
-                  <widget class="FileSystemPathLineEdit" name="textDownloadPath" native="true"/>
+                  <widget class="FileSystemPathLineEdit" name="textDownloadPath" native="true">
+                   <property name="accessibleName">
+                    <string>Use another path for incomplete torrents:</string>
+                   </property>
+                  </widget>
                  </item>
                 </layout>
                </item>
@@ -1644,6 +1716,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <property name="text">
                     <string comment="From sender">From:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>senderEmailTxt</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="0" column="1">
@@ -1661,6 +1736,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <property name="text">
                     <string comment="To receiver">To:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>lineEditDestEmail</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="1" column="1">
@@ -1670,6 +1748,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   <widget class="QLabel" name="label_3">
                    <property name="text">
                     <string>SMTP server:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>lineEditSMTPServer</cstring>
                    </property>
                   </widget>
                  </item>
@@ -1684,6 +1765,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   <widget class="QLabel" name="labelSMTPEncryption">
                    <property name="text">
                     <string>SMTP encryption:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>comboSMTPEncryption</cstring>
                    </property>
                   </widget>
                  </item>
@@ -1733,6 +1817,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                     <property name="text">
                      <string>Username:</string>
                     </property>
+                    <property name="buddy">
+                     <cstring>mailNotifUsername</cstring>
+                    </property>
                    </widget>
                   </item>
                   <item row="0" column="1">
@@ -1742,6 +1829,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <widget class="QLabel" name="label_8">
                     <property name="text">
                      <string>Password:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mailNotifPassword</cstring>
                     </property>
                    </widget>
                   </item>
@@ -1872,6 +1962,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                 <property name="text">
                  <string>Peer connection protocol:</string>
                 </property>
+                <property name="buddy">
+                 <cstring>comboProtocol</cstring>
+                </property>
                </widget>
               </item>
               <item>
@@ -1920,6 +2013,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   <widget class="QLabel" name="lbl_ports">
                    <property name="text">
                     <string>Port used for incoming connections:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>spinPort</cstring>
                    </property>
                   </widget>
                  </item>
@@ -2001,6 +2097,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  <property name="value">
                   <number>500</number>
                  </property>
+                 <property name="accessibleName">
+                  <string>Global maximum number of connections:</string>
+                 </property>
                 </widget>
                </item>
                <item row="0" column="2">
@@ -2037,6 +2136,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  <property name="value">
                   <number>100</number>
                  </property>
+                 <property name="accessibleName">
+                  <string>Maximum number of connections per torrent:</string>
+                 </property>
                 </widget>
                </item>
                <item row="2" column="0">
@@ -2054,6 +2156,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  <property name="value">
                   <number>8</number>
                  </property>
+                 <property name="accessibleName">
+                  <string>Global maximum number of upload slots:</string>
+                 </property>
                 </widget>
                </item>
                <item row="3" column="0">
@@ -2070,6 +2175,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                  <property name="value">
                   <number>4</number>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Maximum number of upload slots per torrent:</string>
                  </property>
                 </widget>
                </item>
@@ -2095,6 +2203,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <property name="text">
                     <string>Host:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>textI2PHost</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -2104,6 +2215,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   <widget class="QLabel" name="labelI2PPort">
                    <property name="text">
                     <string>Port:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>spinI2PPort</cstring>
                    </property>
                   </widget>
                  </item>
@@ -2164,6 +2278,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <property name="text">
                     <string>Type:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>comboProxyType</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -2174,6 +2291,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <property name="text">
                     <string>Host:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>textProxyIP</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -2183,6 +2303,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   <widget class="QLabel" name="lblProxyPort">
                    <property name="text">
                     <string>Port:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>spinProxyPort</cstring>
                    </property>
                   </widget>
                  </item>
@@ -2258,6 +2381,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                       <property name="text">
                        <string>Username:</string>
                       </property>
+                      <property name="buddy">
+                       <cstring>textProxyUsername</cstring>
+                      </property>
                      </widget>
                     </item>
                     <item row="0" column="1">
@@ -2267,6 +2393,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                      <widget class="QLabel" name="lblProxyPassword">
                       <property name="text">
                        <string>Password:</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>textProxyPassword</cstring>
                       </property>
                      </widget>
                     </item>
@@ -2359,11 +2488,18 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   </widget>
                  </item>
                  <item>
-                  <widget class="FileSystemPathLineEdit" name="textFilterPath" native="true"/>
+                  <widget class="FileSystemPathLineEdit" name="textFilterPath" native="true">
+                   <property name="accessibleName">
+                    <string>Filter path (.dat, .p2p, .p2b):</string>
+                   </property>
+                  </widget>
                  </item>
                  <item>
                   <widget class="QToolButton" name="IpFilterRefreshBtn">
                    <property name="toolTip">
+                    <string>Reload the filter</string>
+                   </property>
+                   <property name="accessibleName">
                     <string>Reload the filter</string>
                    </property>
                   </widget>
@@ -2455,6 +2591,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  <property name="text">
                   <string>Upload:</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>spinUploadLimit</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="0" column="2">
@@ -2494,6 +2633,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  <property name="text">
                   <string>Download:</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>spinDownloadLimit</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="1" column="2">
@@ -2531,6 +2673,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                 <widget class="QLabel" name="label_13">
                  <property name="text">
                   <string>Upload:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>spinUploadLimitAlt</cstring>
                  </property>
                 </widget>
                </item>
@@ -2570,6 +2715,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                 <widget class="QLabel" name="label_14">
                  <property name="text">
                   <string>Download:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>spinDownloadLimitAlt</cstring>
                  </property>
                 </widget>
                </item>
@@ -2612,6 +2760,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                     <property name="text">
                      <string comment="From start time">From:</string>
                     </property>
+                    <property name="buddy">
+                     <cstring>timeEditScheduleFrom</cstring>
+                    </property>
                    </widget>
                   </item>
                   <item row="0" column="1">
@@ -2641,6 +2792,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                     </property>
                     <property name="text">
                      <string comment="To end time">To:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>timeEditScheduleTo</cstring>
                     </property>
                    </widget>
                   </item>
@@ -2678,6 +2832,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <widget class="QLabel" name="label_18">
                     <property name="text">
                      <string>When:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>comboBoxScheduleDays</cstring>
                     </property>
                    </widget>
                   </item>
@@ -2842,6 +2999,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    <property name="text">
                     <string>Encryption mode:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>comboEncryption</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -2933,6 +3093,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                 <property name="text">
                  <string>Maximum active checking torrents:</string>
                 </property>
+                <property name="buddy">
+                 <cstring>spinBoxMaxActiveCheckingTorrents</cstring>
+                </property>
                </widget>
               </item>
               <item>
@@ -2980,6 +3143,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  <property name="text">
                   <string>Maximum active downloads:</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>spinMaxActiveDownloads</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="0" column="1">
@@ -3013,6 +3179,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  <property name="text">
                   <string>Maximum active uploads:</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>spinMaxActiveUploads</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="1" column="1">
@@ -3032,6 +3201,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                 <widget class="QLabel" name="maxActiveTorrents_lbl">
                  <property name="text">
                   <string>Maximum active torrents:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>spinMaxActiveTorrents</cstring>
                  </property>
                 </widget>
                </item>
@@ -3064,6 +3236,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    <widget class="QLabel" name="labelDownloadRateForSlowTorrents">
                     <property name="text">
                      <string>Download rate threshold:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>spinDownloadRateForSlowTorrents</cstring>
                     </property>
                    </widget>
                   </item>
@@ -3101,6 +3276,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                     <property name="text">
                      <string>Upload rate threshold:</string>
                     </property>
+                    <property name="buddy">
+                     <cstring>spinUploadRateForSlowTorrents</cstring>
+                    </property>
                    </widget>
                   </item>
                   <item row="1" column="1">
@@ -3123,6 +3301,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    <widget class="QLabel" name="labelSlowTorrentInactivityTimer">
                     <property name="text">
                      <string>Torrent inactivity timer:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>spinSlowTorrentsInactivityTimer</cstring>
                     </property>
                    </widget>
                   </item>
@@ -3172,6 +3353,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  <property name="value">
                   <double>1.000000000000000</double>
                  </property>
+                 <property name="accessibleName">
+                  <string>When ratio reaches</string>
+                 </property>
                 </widget>
                </item>
                <item row="0" column="2">
@@ -3208,6 +3392,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  <property name="value">
                   <number>1440</number>
                  </property>
+                 <property name="accessibleName">
+                  <string>When total seeding time reaches</string>
+                 </property>
                 </widget>
                </item>
                <item row="2" column="0">
@@ -3230,6 +3417,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  </property>
                  <property name="value">
                   <number>1440</number>
+                 </property>
+                 <property name="accessibleName">
+                  <string>When inactive seeding time reaches</string>
                  </property>
                 </widget>
                </item>
@@ -3274,6 +3464,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>comboRatioLimitAct</cstring>
                  </property>
                 </widget>
                </item>
@@ -3348,6 +3541,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    <property name="text">
                     <string>URL:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>textTrackersURL</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -3359,6 +3555,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                 <widget class="QLabel" name="labeltrackersFromURL">
                  <property name="text">
                   <string>Fetched trackers</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>textTrackersFromURL</cstring>
                  </property>
                 </widget>
                </item>
@@ -3454,6 +3653,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                   <widget class="QLabel" name="searchHistoryLengthLabel">
                    <property name="text">
                     <string>History length</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>searchHistoryLengthSpinBox</cstring>
                    </property>
                   </widget>
                  </item>
@@ -3557,6 +3759,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    <property name="text">
                     <string>Feeds refresh interval:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>spinRSSRefreshInterval</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="0" column="1">
@@ -3593,6 +3798,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    <property name="text">
                     <string>Same host request delay:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>spinRSSFetchDelay</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item row="1" column="1">
@@ -3612,6 +3820,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                   <widget class="QLabel" name="label_12">
                    <property name="text">
                     <string>Maximum number of articles per feed:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>spinRSSMaxArticlesPerFeed</cstring>
                    </property>
                   </widget>
                  </item>
@@ -3670,6 +3881,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                 <widget class="QLabel" name="label_5">
                  <property name="text">
                   <string>Filters:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>textSmartEpisodeFilters</cstring>
                  </property>
                 </widget>
                </item>
@@ -3762,6 +3976,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    <property name="text">
                     <string>IP address:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>textWebUIAddress</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -3777,6 +3994,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                   <widget class="QLabel" name="lblWebUIPort">
                    <property name="text">
                     <string>Port:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>spinWebUIPort</cstring>
                    </property>
                   </widget>
                  </item>
@@ -3825,6 +4045,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                     <property name="text">
                      <string>Certificate:</string>
                     </property>
+                    <property name="buddy">
+                     <cstring>textWebUIHttpsCert</cstring>
+                    </property>
                    </widget>
                   </item>
                   <item row="0" column="2">
@@ -3837,6 +4060,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                    <widget class="QLabel" name="lblWebUIKey">
                     <property name="text">
                      <string>Key:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>textWebUIHttpsKey</cstring>
                     </property>
                    </widget>
                   </item>
@@ -3876,6 +4102,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                        <property name="text">
                         <string>Username:</string>
                        </property>
+                       <property name="buddy">
+                        <cstring>textWebUIUsername</cstring>
+                       </property>
                       </widget>
                      </item>
                      <item row="0" column="1">
@@ -3885,6 +4114,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                       <widget class="QLabel" name="lblWebUIPassword">
                        <property name="text">
                         <string>Password:</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>textWebUIPassword</cstring>
                        </property>
                       </widget>
                      </item>
@@ -3912,6 +4144,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                        <property name="text">
                         <string>Key:</string>
                        </property>
+                       <property name="buddy">
+                        <cstring>textWebUIAPIKey</cstring>
+                       </property>
                       </widget>
                      </item>
                      <item row="0" column="1">
@@ -3938,6 +4173,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                           <iconset>
                            <normaloff>:/icons/edit-copy.svg</normaloff>:/icons/edit-copy.svg</iconset>
                          </property>
+                         <property name="accessibleName">
+                          <string>Copy API key</string>
+                         </property>
                         </widget>
                        </item>
                        <item>
@@ -3949,6 +4187,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                           <iconset>
                            <normaloff>:/icons/view-refresh.svg</normaloff>:/icons/view-refresh.svg</iconset>
                          </property>
+                         <property name="accessibleName">
+                          <string>Generate API key</string>
+                         </property>
                         </widget>
                        </item>
                        <item>
@@ -3959,6 +4200,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                          <property name="icon">
                           <iconset>
                            <normaloff>:/icons/list-remove.svg</normaloff>:/icons/list-remove.svg</iconset>
+                         </property>
+                         <property name="accessibleName">
+                          <string>Delete API key</string>
                          </property>
                         </widget>
                        </item>
@@ -4001,6 +4245,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                       <property name="text">
                        <string>Ban client after consecutive failures:</string>
                       </property>
+                      <property name="buddy">
+                       <cstring>spinBanCounter</cstring>
+                      </property>
                      </widget>
                     </item>
                     <item row="0" column="1">
@@ -4034,6 +4281,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                       <property name="alignment">
                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                       </property>
+                      <property name="buddy">
+                       <cstring>spinBanDuration</cstring>
+                      </property>
                      </widget>
                     </item>
                     <item row="1" column="1">
@@ -4057,6 +4307,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                      <widget class="QLabel" name="lblSessionTimeout">
                       <property name="text">
                        <string>Session timeout:</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>spinSessionTimeout</cstring>
                       </property>
                      </widget>
                     </item>
@@ -4094,6 +4347,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                      <widget class="QLabel" name="labelWebUISessionsCountLimit">
                       <property name="text">
                        <string>Sessions count limit:</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>spinBoxWebUISessionsCountLimit</cstring>
                       </property>
                      </widget>
                     </item>
@@ -4143,6 +4399,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                      <widget class="QLabel" name="labelWebUIRootFolder">
                       <property name="text">
                        <string>Files location:</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>textWebUIRootFolder</cstring>
                       </property>
                      </widget>
                     </item>
@@ -4210,6 +4469,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                          <property name="text">
                           <string>Server domains:</string>
                          </property>
+                         <property name="buddy">
+                          <cstring>textServerDomains</cstring>
+                         </property>
                         </widget>
                        </item>
                        <item>
@@ -4272,6 +4534,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                       <property name="text">
                        <string>Trusted proxies list:</string>
                       </property>
+                      <property name="buddy">
+                       <cstring>textTrustedReverseProxiesList</cstring>
+                      </property>
                      </widget>
                     </item>
                     <item>
@@ -4316,6 +4581,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                     <property name="text">
                      <string>Service:</string>
                     </property>
+                    <property name="buddy">
+                     <cstring>comboDNSService</cstring>
+                    </property>
                    </widget>
                   </item>
                   <item row="0" column="1">
@@ -4348,6 +4616,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                     <property name="text">
                      <string>Domain name:</string>
                     </property>
+                    <property name="buddy">
+                     <cstring>domainNameTxt</cstring>
+                    </property>
                    </widget>
                   </item>
                   <item row="1" column="1">
@@ -4362,6 +4633,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                     <property name="text">
                      <string>Username:</string>
                     </property>
+                    <property name="buddy">
+                     <cstring>DNSUsernameTxt</cstring>
+                    </property>
                    </widget>
                   </item>
                   <item row="2" column="1">
@@ -4371,6 +4645,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                    <widget class="QLabel" name="label_22">
                     <property name="text">
                      <string>Password:</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>DNSPasswordTxt</cstring>
                     </property>
                    </widget>
                   </item>

--- a/src/gui/plugins/pluginsdialog.ui
+++ b/src/gui/plugins/pluginsdialog.ui
@@ -28,6 +28,9 @@
      <property name="text">
       <string>Installed plugins:</string>
      </property>
+     <property name="buddy">
+      <cstring>pluginsTree</cstring>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/gui/previewselectdialog.ui
+++ b/src/gui/previewselectdialog.ui
@@ -19,6 +19,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="buddy">
+      <cstring>previewList</cstring>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/gui/properties/peersadditiondialog.ui
+++ b/src/gui/properties/peersadditiondialog.ui
@@ -19,6 +19,9 @@
      <property name="text">
       <string>List of peers to add (one IP per line):</string>
      </property>
+     <property name="buddy">
+      <cstring>textEditPeers</cstring>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -1036,10 +1036,18 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="trackerUpButton"/>
+          <widget class="QPushButton" name="trackerUpButton">
+           <property name="accessibleName">
+            <string>Move tracker up</string>
+           </property>
+          </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="trackerDownButton"/>
+          <widget class="QPushButton" name="trackerDownButton">
+           <property name="accessibleName">
+            <string>Move tracker down</string>
+           </property>
+          </widget>
          </item>
          <item>
           <spacer name="verticalSpacer_3">

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -57,6 +57,9 @@
            <property name="text">
             <string>Download Rules</string>
            </property>
+           <property name="buddy">
+            <cstring>ruleList</cstring>
+           </property>
           </widget>
          </item>
          <item>
@@ -66,6 +69,9 @@
              <width>24</width>
              <height>20</height>
             </size>
+           </property>
+           <property name="accessibleName">
+            <string>Clone rule...</string>
            </property>
           </widget>
          </item>
@@ -83,6 +89,9 @@
              <height>20</height>
             </size>
            </property>
+           <property name="accessibleName">
+            <string>Rename rule...</string>
+           </property>
           </widget>
          </item>
          <item>
@@ -93,6 +102,9 @@
              <height>20</height>
             </size>
            </property>
+           <property name="accessibleName">
+            <string>Delete rule</string>
+           </property>
           </widget>
          </item>
          <item>
@@ -102,6 +114,9 @@
              <width>24</width>
              <height>20</height>
             </size>
+           </property>
+           <property name="accessibleName">
+            <string>Add new rule...</string>
            </property>
           </widget>
          </item>
@@ -156,6 +171,9 @@
              <property name="text">
               <string>Priority:</string>
              </property>
+             <property name="buddy">
+              <cstring>prioritySpinBox</cstring>
+             </property>
             </widget>
            </item>
            <item>
@@ -190,6 +208,9 @@
              <property name="text">
               <string>Must Contain:</string>
              </property>
+             <property name="buddy">
+              <cstring>lineContains</cstring>
+             </property>
             </widget>
            </item>
            <item row="0" column="1">
@@ -210,6 +231,9 @@
              <property name="text">
               <string>Must Not Contain:</string>
              </property>
+             <property name="buddy">
+              <cstring>lineNotContains</cstring>
+             </property>
             </widget>
            </item>
            <item row="1" column="1">
@@ -229,6 +253,9 @@
             <widget class="QLabel" name="lblEFilter">
              <property name="text">
               <string>Episode Filter:</string>
+             </property>
+             <property name="buddy">
+              <cstring>lineEFilter</cstring>
              </property>
             </widget>
            </item>
@@ -274,6 +301,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             <widget class="QLabel" name="lblIgnoreDays">
              <property name="text">
               <string extracomment="... X days">Ignore Subsequent Matches for (0 to Disable)</string>
+             </property>
+             <property name="buddy">
+              <cstring>spinIgnorePeriod</cstring>
              </property>
             </widget>
            </item>
@@ -363,6 +393,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
           <property name="text">
            <string>Apply Rule to Feeds:</string>
           </property>
+          <property name="buddy">
+           <cstring>listFeeds</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -382,6 +415,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
          </property>
          <property name="text">
           <string>Matching RSS Articles</string>
+         </property>
+         <property name="buddy">
+          <cstring>matchingArticlesTree</cstring>
          </property>
         </widget>
        </item>

--- a/src/gui/rss/rssfeeddialog.ui
+++ b/src/gui/rss/rssfeeddialog.ui
@@ -21,6 +21,9 @@
        <property name="text">
         <string>URL:</string>
        </property>
+       <property name="buddy">
+        <cstring>textFeedURL</cstring>
+       </property>
       </widget>
      </item>
      <item row="0" column="1">
@@ -30,6 +33,9 @@
       <widget class="QLabel" name="labelRefreshInterval">
        <property name="text">
         <string>Refresh interval:</string>
+       </property>
+       <property name="buddy">
+        <cstring>spinRefreshInterval</cstring>
        </property>
       </widget>
      </item>

--- a/src/gui/search/searchjobwidget.ui
+++ b/src/gui/search/searchjobwidget.ui
@@ -38,6 +38,9 @@
        <property name="text">
         <string>Search in:</string>
        </property>
+       <property name="buddy">
+        <cstring>filterMode</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -71,6 +74,9 @@
        <property name="text">
         <string>Seeds:</string>
        </property>
+       <property name="buddy">
+        <cstring>minSeeds</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -87,6 +93,9 @@
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>to</string>
+       </property>
+       <property name="buddy">
+        <cstring>maxSeeds</cstring>
        </property>
       </widget>
      </item>
@@ -127,6 +136,9 @@
        <property name="text">
         <string>Size:</string>
        </property>
+       <property name="buddy">
+        <cstring>minSize</cstring>
+       </property>
       </widget>
      </item>
      <item>
@@ -142,7 +154,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="minSizeUnit"/>
+        <widget class="QComboBox" name="minSizeUnit">
+         <property name="accessibleName">
+          <string>Size:</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>
@@ -150,6 +166,9 @@
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>to</string>
+       </property>
+       <property name="buddy">
+        <cstring>maxSize</cstring>
        </property>
       </widget>
      </item>
@@ -169,7 +188,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="maxSizeUnit"/>
+        <widget class="QComboBox" name="maxSizeUnit">
+         <property name="accessibleName">
+          <string>to</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>

--- a/src/gui/search/searchpluginselectdialog.ui
+++ b/src/gui/search/searchpluginselectdialog.ui
@@ -28,6 +28,9 @@
      <property name="text">
       <string>Installed search plugins:</string>
      </property>
+     <property name="buddy">
+      <cstring>pluginsTree</cstring>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/gui/search/searchwidget.ui
+++ b/src/gui/search/searchwidget.ui
@@ -17,7 +17,11 @@
    <item>
     <layout class="QHBoxLayout" name="searchBarLayout">
      <item>
-      <widget class="LineEdit" name="lineEditSearchPattern"/>
+      <widget class="LineEdit" name="lineEditSearchPattern">
+       <property name="accessibleName">
+        <string>Search pattern</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QComboBox" name="comboCategory">
@@ -26,6 +30,9 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="accessibleName">
+        <string>Category</string>
        </property>
       </widget>
      </item>
@@ -36,6 +43,9 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="accessibleName">
+        <string>Plugins</string>
        </property>
       </widget>
      </item>

--- a/src/gui/speedlimitdialog.ui
+++ b/src/gui/speedlimitdialog.ui
@@ -32,12 +32,18 @@
         <property name="text">
          <string>Upload:</string>
         </property>
+        <property name="buddy">
+         <cstring>spinUploadLimit</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="2">
        <widget class="QSlider" name="sliderUploadLimit">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="accessibleName">
+         <string>Upload:</string>
         </property>
        </widget>
       </item>
@@ -62,12 +68,18 @@
         <property name="text">
          <string>Download:</string>
         </property>
+        <property name="buddy">
+         <cstring>spinDownloadLimit</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="2">
        <widget class="QSlider" name="sliderDownloadLimit">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="accessibleName">
+         <string>Download:</string>
         </property>
        </widget>
       </item>
@@ -108,12 +120,18 @@
         <property name="text">
          <string>Upload:</string>
         </property>
+        <property name="buddy">
+         <cstring>spinAltUploadLimit</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="2">
        <widget class="QSlider" name="sliderAltUploadLimit">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="accessibleName">
+         <string>Upload:</string>
         </property>
        </widget>
       </item>
@@ -138,12 +156,18 @@
         <property name="text">
          <string>Download:</string>
         </property>
+        <property name="buddy">
+         <cstring>spinAltDownloadLimit</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="2">
        <widget class="QSlider" name="sliderAltDownloadLimit">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="accessibleName">
+         <string>Download:</string>
         </property>
        </widget>
       </item>

--- a/src/gui/torrentcategorydialog.ui
+++ b/src/gui/torrentcategorydialog.ui
@@ -34,6 +34,9 @@
        <property name="text">
         <string>Name:</string>
        </property>
+       <property name="buddy">
+        <cstring>textCategoryName</cstring>
+       </property>
       </widget>
      </item>
      <item row="0" column="1">
@@ -43,6 +46,9 @@
       <widget class="QLabel" name="labelSavePath">
        <property name="text">
         <string>Save path:</string>
+       </property>
+       <property name="buddy">
+        <cstring>comboSavePath</cstring>
        </property>
       </widget>
      </item>
@@ -70,6 +76,9 @@
          <widget class="QLabel" name="labelUseDownloadPath">
           <property name="text">
            <string>Use another path for incomplete torrents:</string>
+          </property>
+          <property name="buddy">
+           <cstring>comboUseDownloadPath</cstring>
           </property>
          </widget>
         </item>
@@ -122,6 +131,9 @@
           </property>
           <property name="text">
            <string>Path:</string>
+          </property>
+          <property name="buddy">
+           <cstring>comboDownloadPath</cstring>
           </property>
          </widget>
         </item>

--- a/src/gui/torrentcontentlayoutdialog.ui
+++ b/src/gui/torrentcontentlayoutdialog.ui
@@ -34,6 +34,9 @@
        <property name="text">
         <string>Common path:</string>
        </property>
+       <property name="buddy">
+        <cstring>commonPathEdit</cstring>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -121,6 +121,7 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
     , m_storeSource(SETTINGS_KEY(u"Source"_s))
 {
     m_ui->setupUi(this);
+    Utils::Gui::nameNestedGroupBoxes(this);
 
     m_ui->comboPieceSize->addItem(tr("Auto"), 0);
     for (int i = 4; i <= 17; ++i)

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -63,6 +63,9 @@
               <property name="text">
                <string>Path:</string>
               </property>
+              <property name="buddy">
+               <cstring>textInputPath</cstring>
+              </property>
              </widget>
             </item>
             <item>
@@ -140,6 +143,9 @@
                <property name="text">
                 <string>Torrent format:</string>
                </property>
+               <property name="buddy">
+                <cstring>comboTorrentFormat</cstring>
+               </property>
               </widget>
              </item>
              <item>
@@ -183,6 +189,9 @@
              <widget class="QLabel" name="txtPieceSize">
               <property name="text">
                <string>Piece size:</string>
+              </property>
+              <property name="buddy">
+               <cstring>comboPieceSize</cstring>
               </property>
              </widget>
             </item>
@@ -278,6 +287,9 @@
                  <property name="text">
                   <string>Align to piece boundary for files larger than:</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>spinPaddedFileSizeLimit</cstring>
+                 </property>
                 </widget>
                </item>
                <item>
@@ -331,6 +343,9 @@
             <property name="text">
              <string>Tracker URLs:</string>
             </property>
+            <property name="buddy">
+             <cstring>trackersList</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -351,6 +366,9 @@
             <property name="text">
              <string>Web seed URLs:</string>
             </property>
+            <property name="buddy">
+             <cstring>URLSeedsList</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
@@ -368,6 +386,9 @@
             <property name="text">
              <string>Comments:</string>
             </property>
+            <property name="buddy">
+             <cstring>txtComment</cstring>
+            </property>
            </widget>
           </item>
           <item row="2" column="1">
@@ -384,6 +405,9 @@
            <widget class="QLabel" name="labelSource">
             <property name="text">
              <string>Source:</string>
+            </property>
+            <property name="buddy">
+             <cstring>lineEditSource</cstring>
             </property>
            </widget>
           </item>

--- a/src/gui/torrentoptionsdialog.ui
+++ b/src/gui/torrentoptionsdialog.ui
@@ -60,6 +60,9 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="accessibleName">
+             <string>Use another path for incomplete torrent</string>
+            </property>
            </widget>
           </item>
          </layout>
@@ -71,6 +74,9 @@
           <widget class="QLabel" name="labelCategory">
            <property name="text">
             <string>Category:</string>
+           </property>
+           <property name="buddy">
+            <cstring>comboCategory</cstring>
            </property>
           </widget>
          </item>
@@ -106,12 +112,18 @@
             <property name="text">
              <string>Upload:</string>
             </property>
+            <property name="buddy">
+             <cstring>spinUploadLimit</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
            <widget class="QSlider" name="sliderUploadLimit">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="accessibleName">
+             <string>Upload:</string>
             </property>
            </widget>
           </item>
@@ -136,12 +148,18 @@
             <property name="text">
              <string>Download:</string>
             </property>
+            <property name="buddy">
+             <cstring>spinDownloadLimit</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
            <widget class="QSlider" name="sliderDownloadLimit">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="accessibleName">
+             <string>Download:</string>
             </property>
            </widget>
           </item>

--- a/src/gui/torrentsharelimitswidget.ui
+++ b/src/gui/torrentsharelimitswidget.ui
@@ -18,6 +18,9 @@
        <property name="text">
         <string>Ratio:</string>
        </property>
+       <property name="buddy">
+        <cstring>comboBoxRatioMode</cstring>
+       </property>
       </widget>
      </item>
      <item row="0" column="1">
@@ -34,12 +37,18 @@
        <property name="value">
         <double>1.000000000000000</double>
        </property>
+       <property name="accessibleName">
+        <string>Ratio:</string>
+       </property>
       </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="labelSeedingTime">
        <property name="text">
         <string>Seeding time:</string>
+       </property>
+       <property name="buddy">
+        <cstring>comboBoxSeedingTimeMode</cstring>
        </property>
       </widget>
      </item>
@@ -60,12 +69,18 @@
        <property name="value">
         <number>1440</number>
        </property>
+       <property name="accessibleName">
+        <string>Seeding time:</string>
+       </property>
       </widget>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="labelInactiveSeedingTime">
        <property name="text">
         <string>Inactive seeding time:</string>
+       </property>
+       <property name="buddy">
+        <cstring>comboBoxInactiveSeedingTimeMode</cstring>
        </property>
       </widget>
      </item>
@@ -86,6 +101,9 @@
        <property name="value">
         <number>1440</number>
        </property>
+       <property name="accessibleName">
+        <string>Inactive seeding time:</string>
+       </property>
       </widget>
      </item>
     </layout>
@@ -96,6 +114,9 @@
       <widget class="QLabel" name="labelMode">
        <property name="text">
         <string>Mode:</string>
+       </property>
+       <property name="buddy">
+        <cstring>comboBoxMode</cstring>
        </property>
       </widget>
      </item>
@@ -123,6 +144,9 @@
       <widget class="QLabel" name="labelAction">
        <property name="text">
         <string>Action when the limit is reached:</string>
+       </property>
+       <property name="buddy">
+        <cstring>comboBoxAction</cstring>
        </property>
       </widget>
      </item>

--- a/src/gui/trackerentriesdialog.ui
+++ b/src/gui/trackerentriesdialog.ui
@@ -31,6 +31,9 @@
      <property name="tabChangesFocus">
       <bool>true</bool>
      </property>
+     <property name="accessibleName">
+      <string>Tracker URLs</string>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/gui/trackersadditiondialog.ui
+++ b/src/gui/trackersadditiondialog.ui
@@ -19,6 +19,9 @@
      <property name="text">
       <string>List of trackers to add (one per line):</string>
      </property>
+     <property name="buddy">
+      <cstring>textEditTrackersList</cstring>
+     </property>
     </widget>
    </item>
    <item>
@@ -39,6 +42,9 @@
      <property name="text">
       <string>µTorrent compatible list URL:</string>
      </property>
+     <property name="buddy">
+      <cstring>lineEditListURL</cstring>
+     </property>
     </widget>
    </item>
    <item>
@@ -49,6 +55,9 @@
      <item>
       <widget class="QPushButton" name="downloadButton">
        <property name="toolTip">
+        <string>Download trackers list</string>
+       </property>
+       <property name="accessibleName">
         <string>Download trackers list</string>
        </property>
       </widget>

--- a/src/gui/transferlistfilterswidgetitem.cpp
+++ b/src/gui/transferlistfilterswidgetitem.cpp
@@ -79,6 +79,8 @@ TransferListFiltersWidgetItem::TransferListFiltersWidgetItem(const QString &capt
     layout->addWidget(m_caption);
     layout->addWidget(m_filterWidget);
 
+    m_filterWidget->setAccessibleName(caption);
+
     m_filterWidget->setVisible(m_caption->isChecked());
 
     connect(m_caption, &QCheckBox::toggled, m_filterWidget, &QWidget::setVisible);

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -39,6 +39,7 @@
 
 #include <QApplication>
 #include <QDesktopServices>
+#include <QGroupBox>
 #include <QPixmap>
 #include <QPixmapCache>
 #include <QPoint>
@@ -312,4 +313,15 @@ Tag Utils::Gui::widgetTextToTag(const QString &text)
     }
 
     return Tag(cleanedText);
+}
+
+void Utils::Gui::nameNestedGroupBoxes(QWidget *widget)
+{
+    // a nested group box would otherwise be named after the group box that contains it
+    const QList<QGroupBox *> groupBoxes = widget->findChildren<QGroupBox *>();
+    for (QGroupBox *groupBox : groupBoxes)
+    {
+        if (groupBox->accessibleName().isEmpty() && qobject_cast<QGroupBox *>(groupBox->parentWidget()))
+            groupBox->setAccessibleName(groupBox->title().remove(u'&'));
+    }
 }

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -56,4 +56,6 @@ namespace Utils::Gui
 
     QString tagToWidgetText(const Tag &tag);
     Tag widgetTextToTag(const QString &text);
+
+    void nameNestedGroupBoxes(QWidget *widget);
 }


### PR DESCRIPTION
Qt names a widget that has no accessible name of its own after its buddy label, or after the group box it belongs to when there is no buddy. Since no buddy was set anywhere, screen readers announced most controls with the title of their group box instead of their own label: every field of the torrent creator was announced as "Fields", and a nested group box was announced with the title of the outer one.

Set the buddies, and an explicit accessible name where the label is a check box, is shared with another control, or is missing. These reuse the neighboring source string wherever possible, so only ten new translatable strings are added and no existing one is dropped.

FileSystemPathEdit is a composite widget whose inner edit widget is what accessibility clients reach, so it passes its name down to it. The advanced settings page keeps its contents in cell widgets and leaves the model empty, which left nothing to announce while walking the table; its cells now provide Qt::AccessibleTextRole.