### PR TITLE
Fix torrent completion handling when ignored files are present

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2361,6 +2361,7 @@ void TorrentImpl::handleFileRenamed(const lt::file_index_t nativeFileIndex, cons
     const int fileIndex = fileIndexFromNative(nativeFileIndex);
     Q_ASSERT(fileIndex >= 0);
 
+    const FileRenameInfo currentFileRenameInfo = m_renamingFiles.dequeue();
     const Path oldFilePath = m_filePaths.at(fileIndex);
     const Path newFilePath = makeUserPath(newActualFilePath);
 
@@ -2412,7 +2413,6 @@ void TorrentImpl::handleFileRenamed(const lt::file_index_t nativeFileIndex, cons
             oldParentPath = oldParentPath.parentPath();
         }
 
-        const FileRenameInfo currentFileRenameInfo = m_renamingFiles.dequeue();
         if (currentFileRenameInfo.folderRenameJobID >= 0)
         {
             m_renamingFolders.head().renamedFiles.insert(fileIndex, oldFilePath);


### PR DESCRIPTION
When excluded files are moved internally, for example into `.unwanted`, qBittorrent can leave a completed file rename in `m_renamingFiles`.

If the old and new physical paths map to the same logical qBittorrent path, `handleFileRenamed()` takes the path-equivalence branch before consuming the corresponding rename entry. The rename queue therefore remains non-empty, which can leave completion callbacks blocked even though the torrent itself has finished.

This is a qBittorrent regression introduced by d63dec1 (`Improve management of torrent content`, #24266).

## What does this PR do?

Consume the completed `m_renamingFiles` entry before handling the logical path comparison in `TorrentImpl::handleFileRenamed()`.

This keeps the existing rename behavior unchanged while ensuring that every completed rename is removed from the pending queue.

## Why is this needed?

Excluded-file handling can involve internal renames such as:

screenshots/file.png
→ screenshots/.unwanted/file.png

Both physical paths can map back to the same logical qBittorrent path through `makeUserPath()`.

Previously, that branch was handled before `m_renamingFiles.dequeue()` was reached. As a result, the completed rename remained in the pending queue indefinitely.

Completion handling waits for pending file renames to finish, so the stale queue entry could prevent `torrentFinished` and the associated completion actions from being released.

A focused regression investigation traced this behavior to d63dec1. The production issue is therefore in qBittorrent's rename bookkeeping rather than a missing `torrent_finished_alert` from libtorrent.

## Testing

Added an integration regression test covering torrent completion with excluded files.

The test:

- creates a torrent where a wanted file and excluded files share a piece;
- enables filename exclusion and `.unwanted`;
- downloads from a local seeder;
- verifies the wanted file is present;
- verifies the excluded files are absent;
- verifies a `.parts` file is created, confirming that the shared-piece excluded-file case is exercised;
- verifies `torrentFinished` is emitted exactly once.

The regression test passes with:

- libtorrent 1.2.19
- libtorrent 1.2.20
- libtorrent 2.0.13

Additional verification:

- focused test target rebuilt successfully;
- test formatting check passed;
- `git diff --check` passed;
- commit check passed.

For libtorrent 1.2, the test explicitly disables its default `optimize_alignment` behavior. Otherwise libtorrent 1.2 can reorder the files in the fixture, invalidating the manually calculated piece hashes.

That compatibility handling is limited to construction of the regression-test torrent and is unrelated to the production bug.

## Previous diagnosis

The original version of this PR attributed the missing completion handling to libtorrent not emitting `torrent_finished_alert`.

Further debugging showed that diagnosis was incorrect. The alert is not the root cause: qBittorrent receives the internal file rename completion but can leave its corresponding entry in `m_renamingFiles`.

The implementation and regression test have been rewritten around that root cause.