### PR TITLE
Tracker: Don't create a torrent entry from an unauthenticated announce

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -51,6 +51,8 @@ namespace
     // static limits
     const int MAX_TORRENTS = 10000;
     const int MAX_PEERS_PER_TORRENT = 200;
+    // [BEP-3] the `ip` parameter may hold a DNS name, whose maximum length is 253 characters
+    const int MAX_CLAIMED_ADDRESS_SIZE = 255;
     const int ANNOUNCE_INTERVAL = 1800;  // 30min
 
     // constants
@@ -291,6 +293,8 @@ void Tracker::processAnnounceRequest()
     // ip address
     announceReq.socketAddress = m_env.clientAddress;
     announceReq.claimedAddress = queryParams.value(ANNOUNCE_REQUEST_IP);
+    if (announceReq.claimedAddress.size() > MAX_CLAIMED_ADDRESS_SIZE)
+        throw TrackerError(u"Invalid \"ip\" parameter"_s);
 
     // Enforce using IPv4 if address is indeed IPv4 or if it is an IPv4-mapped IPv6 address
     bool ok = false;
@@ -413,7 +417,8 @@ void Tracker::unregisterPeer(const TrackerAnnounceRequest &announceReq)
 
 void Tracker::prepareAnnounceResponse(const TrackerAnnounceRequest &announceReq)
 {
-    const TorrentStats &torrentStats = m_torrents[announceReq.torrentID];
+    // don't create an entry for an unknown torrent, it would bypass the `MAX_TORRENTS` limit
+    const TorrentStats &torrentStats = m_torrents.value(announceReq.torrentID);
 
     lt::entry::dictionary_type replyDict
     {


### PR DESCRIPTION
This was identified using the claude-security plugin.

---

`prepareAnnounceResponse()` read the per-torrent stats through the non-const `QHash::operator[]`, which default-inserts. On the `event=stopped` path `unregisterPeer()` returns early for an unknown `info_hash`, so the response step created the entry - bypassing the `MAX_TORRENTS` eviction that `registerPeer()` performs. Nothing expires these, so looping announces with fresh random hashes grew `m_torrents` without bound. The same `operator[]` also resurrected an entry immediately after `unregisterPeer()` erased it when the last peer left, making that erase dead code.

Look the torrent up with `constFind` and answer from a local default-constructed `TorrentStats` when it is absent; the bencoded reply is byte-identical. Also cap the self-claimed `ip` parameter, which was bounded only by the request buffer limit and is stored per peer - 255 bytes covers a maximum-length DNS name, which BEP-3 permits here, and any IP literal. Over-long values are rejected rather than truncated, since `peer.address` is half of the peer's identity key.
