### PR TITLE
GHA CI: migrate Markdown format linter to rumdl

### DIFF
--- a/.github/workflows/helper/pre-commit/.markdownlint.yaml
+++ b/.github/workflows/helper/pre-commit/.markdownlint.yaml
@@ -1,3 +1,0 @@
-# https://github.com/updownpress/markdown-lint/tree/master/rules
-
-MD013: false

--- a/.github/workflows/helper/pre-commit/.rumdl.toml
+++ b/.github/workflows/helper/pre-commit/.rumdl.toml
@@ -1,0 +1,13 @@
+# https://rumdl.dev/global-settings/
+# https://rumdl.dev/rules/
+
+[global]
+enable = ["ALL"]
+disable = [
+    "MD013",
+    "MD063",
+    "MD082"
+]
+
+[MD046]
+style = "fenced"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,12 +40,12 @@ repos:
         - svg
         - ts
 
-  - repo: https://github.com/igorshubovych/markdownlint-cli.git
-    rev: v0.49.1
+  - repo: https://github.com/rvben/rumdl-pre-commit.git
+    rev: v0.2.64
     hooks:
-    - id: markdownlint
+    - id: rumdl
       name: Check Markdown files
-      args: ["--config", ".github/workflows/helper/pre-commit/.markdownlint.yaml"]
+      args: ["--config", ".github/workflows/helper/pre-commit/.rumdl.toml", "--fix"]
       exclude: |
         (?x)^(
           doc/.*/qbittorrent\.1\.md |

--- a/src/webui/www/README.md
+++ b/src/webui/www/README.md
@@ -4,12 +4,12 @@
 
 The upper bound will always be the latest stable release.
 
-| Browser           | Lower bound                                            |
-| ----------------- | ------------------------------------------------------ |
-| Chrome            | [The release from 1 year ago][Chrome-lower-bound-link] |
-| Firefox           | [Latest active ESR release][Firefox-ESR-link]          |
-| Microsoft Edge    | [The release from 1 year ago][MSEdge-lower-bound-link] |
-| Safari            | [The release from 1 year ago][Safari-lower-bound-link] |
+| Browser        | Lower bound                                            |
+| -------------- | ------------------------------------------------------ |
+| Chrome         | [The release from 1 year ago][Chrome-lower-bound-link] |
+| Firefox        | [Latest active ESR release][Firefox-ESR-link]          |
+| Microsoft Edge | [The release from 1 year ago][MSEdge-lower-bound-link] |
+| Safari         | [The release from 1 year ago][Safari-lower-bound-link] |
 
 [Supported browsers table](https://browsersl.ist/?results#q=Chrome+%3E+0+and+last+1+year%0AEdge+%3E+0+and+last+1+year%0AFirefox+ESR%0ASafari+%3E+0+and+last+1+year)
 


### PR DESCRIPTION
It provides more linting rules and runs faster.

rumdl home: https://rumdl.dev/