### PR TITLE
GHA CI: temporarily pin zizmor to the latest working version

### DIFF
--- a/.github/workflows/ci_file_health.yaml
+++ b/.github/workflows/ci_file_health.yaml
@@ -52,7 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip install zizmor
+          pip install zizmor==1.29.0
           IGNORE_RULEID='(.ruleId != "zizmor/template-injection")
             and (.ruleId != "zizmor/unpinned-uses")'
           IGNORE_ID='(.id != "zizmor/template-injection")


### PR DESCRIPTION
I was hoping the situation would resolve itself, as upstream has already [committed a fix](https://github.com/zizmorcore/zizmor/pull/2363) but has not yet published a new release. Therefore, I am temporarily pinning the version to the latest working one.