### PR TITLE
WebUI: Refresh path suggestions when typing pauses

### DIFF
--- a/src/webui/www/private/scripts/pathAutofill.js
+++ b/src/webui/www/private/scripts/pathAutofill.js
@@ -40,51 +40,138 @@ window.qBittorrent.pathAutofill ??= (() => {
         };
     };
 
-    const showInputSuggestions = (inputElement, names) => {
-        const datalist = document.createElement("datalist");
-        datalist.id = `${inputElement.id}Suggestions`;
+    // Safari on iOS blocks input for about 18 ms per option whenever the
+    // suggestions of the focused input change, so the list is kept short and
+    // is only refreshed once typing pauses.
+    const MAX_SUGGESTIONS = 10;
+    const REFRESH_DELAY_MS = 400;
+
+    // Per-input state: the datalist, the loaded directory listing and the pending refresh.
+    const states = new WeakMap();
+
+    // Returns the directory part of `path` including its trailing separator,
+    // or an empty string when `path` contains no separator.
+    const parentDirectory = (path) => {
+        const index = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+        return (index === -1) ? "" : path.substring(0, index + 1);
+    };
+
+    // Returns up to MAX_SUGGESTIONS entries that start with `prefix`.
+    // The match is case-insensitive, like the browser's own datalist filtering.
+    const filterSuggestions = (entries, prefix) => {
+        const lowerCasePrefix = prefix.toLowerCase();
+        const matches = [];
+        for (const entry of entries) {
+            if (!entry.toLowerCase().startsWith(lowerCasePrefix))
+                continue;
+            matches.push(entry);
+            if (matches.length >= MAX_SUGGESTIONS)
+                break;
+        }
+        return matches;
+    };
+
+    const refreshSuggestions = (inputElement, state) => {
+        const names = filterSuggestions(state.entries, inputElement.value);
+        const shown = names.join("\n");
+        if (shown === state.shown)
+            return;
+        state.shown = shown;
+
+        const fragment = document.createDocumentFragment();
         for (const name of names) {
             const option = document.createElement("option");
             option.value = name;
-            datalist.appendChild(option);
+            fragment.appendChild(option);
         }
-
-        const oldDatalist = document.getElementById(`${inputElement.id}Suggestions`);
-        if (oldDatalist !== null) {
-            oldDatalist.replaceWith(datalist);
-        }
-        else {
-            inputElement.appendChild(datalist);
-            inputElement.setAttribute("list", datalist.id);
-        }
+        state.datalist.replaceChildren(fragment);
     };
 
-    const showPathSuggestions = (element, mode) => {
-        const partialPath = element.value;
-        if (partialPath === "")
-            return;
+    const scheduleRefresh = (inputElement, state) => {
+        clearTimeout(state.refreshTimer);
+        state.refreshTimer = setTimeout(() => {
+            state.refreshTimer = null;
+            refreshSuggestions(inputElement, state);
+        }, REFRESH_DELAY_MS);
+    };
 
-        fetch(`api/v2/app/getDirectoryContent?dirPath=${partialPath}&mode=${mode}`, {
+    const loadDirectory = (inputElement, state, dirPath, mode) => {
+        state.abortController?.abort();
+        const abortController = new AbortController();
+        state.abortController = abortController;
+        state.dirPath = dirPath;
+        state.entries = [];
+
+        fetch(`api/v2/app/getDirectoryContent?dirPath=${encodeURIComponent(dirPath)}&mode=${mode}`, {
                 method: "GET",
-                cache: "no-store"
+                cache: "no-store",
+                signal: abortController.signal
             })
-            .then(response => response.json())
-            .then(filesList => { showInputSuggestions(element, filesList); })
-            .catch(error => {});
+            .then(response => {
+                if (response.ok)
+                    return response.json();
+                // client errors are final, e.g. the directory does not exist
+                if (response.status < 500)
+                    return [];
+                throw new Error(response.statusText);
+            })
+            .then(entries => {
+                // a newer request replaced this one
+                if (state.abortController !== abortController)
+                    return;
+                state.entries = entries.sort((a, b) => a.localeCompare(b));
+                // while typing continues, the pending refresh picks the entries up
+                if (state.refreshTimer === null)
+                    refreshSuggestions(inputElement, state);
+            })
+            .catch(error => {
+                // forget the failed request so the next keystroke retries it
+                if (state.abortController === abortController)
+                    state.dirPath = null;
+            });
+    };
+
+    const onInput = (inputElement, mode) => {
+        const state = states.get(inputElement);
+        const dirPath = parentDirectory(inputElement.value);
+        if (dirPath !== state.dirPath) {
+            if (dirPath === "") {
+                state.abortController?.abort();
+                state.abortController = null;
+                state.dirPath = dirPath;
+                state.entries = [];
+            }
+            else {
+                loadDirectory(inputElement, state, dirPath, mode);
+            }
+        }
+        scheduleRefresh(inputElement, state);
+    };
+
+    const attach = (inputElement, mode) => {
+        // <input> is a void element, so the datalist goes next to it
+        const datalist = document.createElement("datalist");
+        datalist.id = `${inputElement.id}Suggestions`;
+        inputElement.insertAdjacentElement("afterend", datalist);
+        inputElement.setAttribute("list", datalist.id);
+
+        states.set(inputElement, {
+            datalist: datalist,
+            dirPath: "",
+            entries: [],
+            abortController: null,
+            refreshTimer: null,
+            shown: ""
+        });
+        inputElement.addEventListener("input", () => { onInput(inputElement, mode); });
+        inputElement.classList.add("pathAutoFillInitialized");
     };
 
     const attachPathAutofill = () => {
-        const directoryInputs = document.querySelectorAll(".pathDirectory:not(.pathAutoFillInitialized)");
-        for (const input of directoryInputs) {
-            input.addEventListener("input", function(event) { showPathSuggestions(this, "dirs"); });
-            input.classList.add("pathAutoFillInitialized");
-        }
-
-        const fileInputs = document.querySelectorAll(".pathFile:not(.pathAutoFillInitialized)");
-        for (const input of fileInputs) {
-            input.addEventListener("input", function(event) { showPathSuggestions(this, "all"); });
-            input.classList.add("pathAutoFillInitialized");
-        }
+        for (const input of document.querySelectorAll(".pathDirectory:not(.pathAutoFillInitialized)"))
+            attach(input, "dirs");
+        for (const input of document.querySelectorAll(".pathFile:not(.pathAutoFillInitialized)"))
+            attach(input, "all");
     };
 
     return exports();

--- a/src/webui/www/test/private/pathAutofill.test.js
+++ b/src/webui/www/test/private/pathAutofill.test.js
@@ -1,0 +1,311 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Randall Degges <r@rdegges.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import "../../private/scripts/pathAutofill.js";
+
+const attachPathAutofill = window.qBittorrent.pathAutofill.attachPathAutofill;
+
+// suggestions are refreshed this long after the last keystroke
+const REFRESH_DELAY_MS = 400;
+
+const listingResponse = (entries) => Promise.resolve(new Response(JSON.stringify(entries)));
+const notFoundResponse = () => Promise.resolve(new Response("Directory does not exist", { status: 404 }));
+
+// resolves the fetch mock with a directory listing when `resolve()` is called
+const deferredListing = () => {
+    let resolve;
+    const promise = new Promise((r) => { resolve = r; });
+    return {
+        promise: promise,
+        resolve: (entries) => resolve(new Response(JSON.stringify(entries)))
+    };
+};
+
+// like real fetch, rejects as soon as the request is aborted
+const abortableListing = (entries) => (url, { signal }) => new Promise((resolve, reject) => {
+    signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+    setTimeout(() => resolve(new Response(JSON.stringify(entries))), 1000);
+});
+
+const requestedDirPath = (call) => new URL(call[0], "http://localhost/").searchParams.get("dirPath");
+const requestedMode = (call) => new URL(call[0], "http://localhost/").searchParams.get("mode");
+
+let input;
+let fetchMock;
+
+// types a value without waiting for the refresh
+const typeNow = (value) => {
+    input.value = value;
+    input.dispatchEvent(new Event("input"));
+};
+
+// lets the fetch promise chain settle and the refresh timer fire
+const settle = () => vi.advanceTimersByTimeAsync(REFRESH_DELAY_MS);
+
+const type = async (value) => {
+    typeNow(value);
+    await settle();
+};
+
+const suggestions = () => [...input.list.options].map((option) => option.value);
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `<div><input type="text" id="savepath" class="pathDirectory"><button id="after">x</button></div>`;
+    input = document.getElementById("savepath");
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    attachPathAutofill();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+});
+
+test("attaches an empty datalist next to the input, not inside it", () => {
+    const datalist = document.getElementById("savepathSuggestions");
+
+    expect(input.list).toBe(datalist);
+    expect(input.nextElementSibling).toBe(datalist);
+    expect(input.childElementCount).toBe(0);
+    expect(datalist.options).toHaveLength(0);
+});
+
+test("fetches the typed directory and shows its entries sorted", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/b", "/data/a"]));
+
+    await type("/data/");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestedDirPath(fetchMock.mock.calls[0])).toBe("/data/");
+    expect(requestedMode(fetchMock.mock.calls[0])).toBe("dirs");
+    expect(suggestions()).toEqual(["/data/a", "/data/b"]);
+});
+
+test("requests mode=all for file inputs", async () => {
+    document.body.innerHTML = `<input type="text" id="cert" class="pathFile">`;
+    input = document.getElementById("cert");
+    attachPathAutofill();
+    fetchMock.mockReturnValueOnce(listingResponse(["/etc/ssl/cert.pem"]));
+
+    await type("/etc/ssl/");
+
+    expect(requestedMode(fetchMock.mock.calls[0])).toBe("all");
+    expect(suggestions()).toEqual(["/etc/ssl/cert.pem"]);
+});
+
+test("refreshes suggestions only after typing pauses", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/movies", "/data/music"]));
+    await type("/data/");
+    const replaceChildren = vi.spyOn(input.list, "replaceChildren");
+
+    typeNow("/data/m");
+    typeNow("/data/mu");
+    await vi.advanceTimersByTimeAsync(REFRESH_DELAY_MS - 1);
+    expect(replaceChildren).not.toHaveBeenCalled();
+    expect(suggestions()).toEqual(["/data/movies", "/data/music"]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(replaceChildren).toHaveBeenCalledTimes(1);
+    expect(suggestions()).toEqual(["/data/music"]);
+});
+
+test("does not rewrite the datalist when the suggestions are unchanged", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/movies", "/data/music"]));
+    await type("/data/");
+    const replaceChildren = vi.spyOn(input.list, "replaceChildren");
+
+    await type("/data/m");
+    await type("/data/mo");
+    await type("/data/mov");
+
+    expect(replaceChildren).toHaveBeenCalledTimes(1);
+    expect(suggestions()).toEqual(["/data/movies"]);
+});
+
+test("filters the cached listing locally while typing inside the same directory", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/movies", "/data/music", "/data/Media"]));
+
+    await type("/data/");
+    await type("/data/m");
+    await type("/data/mo");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(suggestions()).toEqual(["/data/movies"]);
+});
+
+test("matches case-insensitively", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/Movies", "/data/music"]));
+
+    await type("/data/");
+    await type("/data/M");
+
+    expect(suggestions()).toEqual(["/data/Movies", "/data/music"]);
+});
+
+test("treats a backslash as a directory separator", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["C:\\Users\\alice", "C:\\Users\\bob"]));
+
+    await type("C:\\Users\\");
+    expect(requestedDirPath(fetchMock.mock.calls[0])).toBe("C:\\Users\\");
+    await type("C:\\Users\\a");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(suggestions()).toEqual(["C:\\Users\\alice"]);
+});
+
+test("applies the cap after filtering so matches are never hidden by unrelated entries", async () => {
+    const entries = [];
+    for (let i = 0; i < 100; ++i)
+        entries.push(`/data/other ${String(i).padStart(3, "0")}`);
+    entries.push("/data/zebra");
+    fetchMock.mockReturnValueOnce(listingResponse(entries));
+
+    await type("/data/");
+    expect(suggestions()).toHaveLength(10);
+
+    await type("/data/z");
+    expect(suggestions()).toEqual(["/data/zebra"]);
+});
+
+test("URL-encodes the directory path", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse([]));
+
+    await type("/data/Foo & Bar#1/");
+
+    expect(fetchMock.mock.calls[0][0]).toBe("api/v2/app/getDirectoryContent?dirPath=%2Fdata%2FFoo%20%26%20Bar%231%2F&mode=dirs");
+});
+
+test("clears suggestions when the directory does not exist and does not ask again", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/a"]));
+    await type("/data/");
+    expect(suggestions()).toEqual(["/data/a"]);
+
+    fetchMock.mockReturnValueOnce(notFoundResponse());
+    await type("/data/nope/");
+    await type("/data/nope/x");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(suggestions()).toEqual([]);
+});
+
+test("shows a listing that arrives after typing has already paused without further delay", async () => {
+    fetchMock.mockImplementationOnce(abortableListing(["/data/a"]));
+
+    await type("/data/");
+    expect(suggestions()).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(suggestions()).toEqual(["/data/a"]);
+});
+
+test("discards the response of a request that was aborted by clearing the value", async () => {
+    fetchMock.mockImplementationOnce(abortableListing(["/data/a"]));
+    await type("/data/");
+
+    await type("");
+    expect(fetchMock.mock.calls[0][1].signal.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(suggestions()).toEqual([]);
+
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/b"]));
+    await type("/data/");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(suggestions()).toEqual(["/data/b"]);
+});
+
+test("clears suggestions when the value has no directory part", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/a"]));
+    await type("/data/");
+
+    await type("data");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(suggestions()).toEqual([]);
+});
+
+test("ignores a stale response that arrives after a newer directory was typed", async () => {
+    const slow = deferredListing();
+    fetchMock.mockReturnValueOnce(slow.promise);
+    await type("/");
+
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/movies"]));
+    await type("/data/");
+    expect(suggestions()).toEqual(["/data/movies"]);
+
+    // the first request was aborted
+    expect(fetchMock.mock.calls[0][1].signal.aborted).toBe(true);
+
+    slow.resolve(["/data", "/etc"]);
+    await settle();
+
+    expect(suggestions()).toEqual(["/data/movies"]);
+});
+
+test("shows the listing filtered by what was typed while the request was in flight", async () => {
+    const slow = deferredListing();
+    fetchMock.mockReturnValueOnce(slow.promise);
+
+    await type("/data/");
+    await type("/data/mu");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    slow.resolve(["/data/movies", "/data/music"]);
+    await settle();
+
+    expect(suggestions()).toEqual(["/data/music"]);
+});
+
+test("retries after a server or network error", async () => {
+    fetchMock.mockReturnValueOnce(Promise.reject(new TypeError("Failed to fetch")));
+    await type("/data/");
+    expect(suggestions()).toEqual([]);
+
+    fetchMock.mockReturnValueOnce(Promise.resolve(new Response("", { status: 500 })));
+    await type("/data/m");
+    expect(suggestions()).toEqual([]);
+
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/movies"]));
+    await type("/data/mo");
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(suggestions()).toEqual(["/data/movies"]);
+});
+
+test("does not attach twice to the same input", () => {
+    const addEventListener = vi.spyOn(input, "addEventListener");
+
+    attachPathAutofill();
+
+    expect(addEventListener).not.toHaveBeenCalled();
+    expect(document.querySelectorAll("datalist")).toHaveLength(1);
+});


### PR DESCRIPTION
Follow-up to #24848. Closes #23507.

Typing a save path on iOS was still laggy for me with #24848 applied, and some keystrokes never showed up. I use the WebUI from my phone a lot, so I spent some time measuring what Safari is actually doing.

The size of the datalist doesn't matter. A static datalist with 1000 options types as fast as a plain text field. The cost is in changing the suggestions of a focused input: Safari on iOS blocks input for about 18 ms per option each time that happens, and taps that arrive during the block are lost. Before this PR the datalist was replaced on every keystroke, so with 25 options every key cost about 450 ms. The cap also hid most matches because the listing is unsorted. Typing `Movie Title 09` in a folder with 100 matching subfolders showed one of them.

Changes:

- The datalist is created once when the input is attached, as a sibling of the input. The `list` attribute is never toggled after that.
- Suggestions are rewritten only after typing pauses for 400 ms, and only when the filtered set changed.
- A directory listing is fetched once per directory and filtered locally by the typed prefix, sorted, then capped at 10. Previously every keystroke was a request, and every partial name was a 404.
- The in-flight request is aborted when the directory changes and stale responses are ignored. A 5xx or network error is retried on the next keystroke.
- `dirPath` is URL-encoded. A folder named `Foo & Bar` used to send `Bar` as a separate query parameter.

The screenshots only show that the UI still works and that matches are now shown in order. The performance numbers are below.

| Before (master + #24848) | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/50530f94-869f-4110-ba9a-e0563e7d2939" width="320" alt="before: one arbitrary match"> | <img src="https://github.com/user-attachments/assets/2be9e746-ba7a-4bea-940b-cb48e003508a" width="320" alt="after: sorted matches"> |

<details>
<summary>Measurements and tests</summary>

iOS 26.5 simulator, real taps on the software keyboard, 14 characters typed into a field pointing at a directory with 1004 subfolders. Time from the input event to the second animation frame:

| Datalist behavior | p50 / max (ms) | Keys registered |
|---|---|---|
| No datalist (control) | 22 / 41 | 14 of 14 |
| Static datalist, 25 options | 22 / 26 | 14 of 14 |
| Static datalist, 1000 options | 22 / 29 | 14 of 14 |
| Replaced on every keystroke, 25 options (before) | 497 / 1209 | 5 to 7 of 14 |
| Replaced on every keystroke, 8 options | 116 / 141 | 14 of 14 |
| Rewritten after the typing pause (this PR) | 21 to 26 / 28 to 45 | 14 of 14 in twelve runs |

The 400 ms delay is measured. With 250 ms the rewrite landed inside a 340 ms typing gap and dropped the next key in 4 of 8 runs. With 400 ms it never fired while typing.

Desktop, 27 keystrokes of `/data/movies/Movie Title 09`, Chromium and WebKit via Playwright: 27 requests and 1004 options on master, 27 requests and 25 options with 1 match on #24848, 3 requests and 10 matching options with this PR.

Tests: `npm test` 25 passed, 18 new in `test/private/pathAutofill.test.js` (happy-dom, mocked `fetch`, fake timers). `npm run lint` and `npm run format` are clean. I also tested on my iPhone with current Safari.

If you test this yourself, use a private tab or clear site data first. WebUI files are served with a 12-hour cache, so a normal reload keeps running the old script.
</details>

