### PR TITLE
WebUI: Add setting to turn off path suggestions

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -73,6 +73,7 @@ window.qBittorrent.Client ??= (() => {
             "display_density",
             "full_url_tracker_column",
             "hide_zero_status_filters",
+            "path_autocomplete_enabled",
             "qbt_selected_log_levels",
             "search_in_filter",
             "show_filters_sidebar",

--- a/src/webui/www/private/scripts/pathAutofill.js
+++ b/src/webui/www/private/scripts/pathAutofill.js
@@ -59,7 +59,18 @@ window.qBittorrent.pathAutofill ??= (() => {
         }
     };
 
+    // Dialogs run in iframes and read the client data of the main window.
+    const isEnabled = () => {
+        const clientData = window.qBittorrent.ClientData ?? window.parent.qBittorrent?.ClientData;
+        return clientData?.get("path_autocomplete_enabled") ?? true;
+    };
+
     const showPathSuggestions = (element, mode) => {
+        if (!isEnabled()) {
+            document.getElementById(`${element.id}Suggestions`)?.remove();
+            return;
+        }
+
         const partialPath = element.value;
         if (partialPath === "")
             return;
@@ -69,7 +80,11 @@ window.qBittorrent.pathAutofill ??= (() => {
                 cache: "no-store"
             })
             .then(response => response.json())
-            .then(filesList => { showInputSuggestions(element, filesList); })
+            .then(filesList => {
+                // the setting may have been turned off while the request was in flight
+                if (isEnabled())
+                    showInputSuggestions(element, filesList);
+            })
             .catch(error => {});
     };
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -163,6 +163,10 @@
             <input type="checkbox" id="useVirtualList">
             <label for="useVirtualList">QBT_TR(Enable optimized table rendering)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
+        <div class="formRow" style="margin-bottom: 3px;">
+            <input type="checkbox" id="pathAutocompleteEnabled">
+            <label for="pathAutocompleteEnabled">QBT_TR(Suggest existing paths while typing)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
     </fieldset>
 </div>
 
@@ -2435,6 +2439,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     const dblclickFilter = clientData.get("dblclick_filter") ?? "1";
                     const useAltRowColors = clientData.get("use_alt_row_colors");
                     const addTorrentWindowEnabled = clientData.get("add_new_torrent_dialog_enabled") ?? true;
+                    const pathAutocompleteEnabled = clientData.get("path_autocomplete_enabled") ?? true;
 
                     // Behavior tab
                     // Localization
@@ -2457,6 +2462,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     document.getElementById("performanceWarning").checked = pref.performance_warning;
                     document.getElementById("displayFullURLTrackerColumn").checked = fullUrlTrackerColumn === true;
                     document.getElementById("useVirtualList").checked = useVirtualList === true;
+                    document.getElementById("pathAutocompleteEnabled").checked = pathAutocompleteEnabled === true;
                     document.getElementById("hideZeroFiltersCheckbox").checked = hideZeroStatusFilters === true;
                     document.getElementById("dblclickDownloadSelect").value = dblclickDownload;
                     document.getElementById("dblclickCompleteSelect").value = dblclickComplete;
@@ -2905,6 +2911,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["performance_warning"] = document.getElementById("performanceWarning").checked;
             clientData.full_url_tracker_column = document.getElementById("displayFullURLTrackerColumn").checked;
             clientData.use_virtual_list = document.getElementById("useVirtualList").checked;
+            clientData.path_autocomplete_enabled = document.getElementById("pathAutocompleteEnabled").checked;
             clientData.add_new_torrent_dialog_enabled = document.getElementById("addTorrentWindowEnabled").checked;
             clientData.hide_zero_status_filters = document.getElementById("hideZeroFiltersCheckbox").checked;
             clientData.dblclick_download = document.getElementById("dblclickDownloadSelect").value;

--- a/src/webui/www/test/private/pathAutofill.test.js
+++ b/src/webui/www/test/private/pathAutofill.test.js
@@ -1,0 +1,147 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Randall Degges <r@rdegges.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import "../../private/scripts/pathAutofill.js";
+
+const attachPathAutofill = window.qBittorrent.pathAutofill.attachPathAutofill;
+
+const listingResponse = (entries) => Promise.resolve(new Response(JSON.stringify(entries)));
+
+// lets the fetch promise chain settle
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+let input;
+let fetchMock;
+let clientData;
+
+const type = async (value) => {
+    input.value = value;
+    input.dispatchEvent(new Event("input"));
+    await flush();
+};
+
+const suggestions = () => {
+    const datalist = document.getElementById("savepathSuggestions");
+    return (datalist === null) ? null : [...datalist.options].map((option) => option.value);
+};
+
+beforeEach(() => {
+    document.body.innerHTML = `<input type="text" id="savepath" class="pathDirectory">`;
+    input = document.getElementById("savepath");
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    // the main window exposes the client data singleton; dialogs reach it through window.parent
+    clientData = new Map();
+    window.qBittorrent.ClientData = clientData;
+    attachPathAutofill();
+});
+
+afterEach(() => {
+    delete window.qBittorrent.ClientData;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+test("suggests paths by default when the setting was never stored", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/a"]));
+
+    await type("/data/");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(suggestions()).toEqual(["/data/a"]);
+});
+
+test("reads the setting from the main window when running inside a dialog iframe", async () => {
+    // dialogs do not load client-data.js; the singleton lives on window.parent
+    delete window.qBittorrent.ClientData;
+    const parentClientData = new Map([
+        ["path_autocomplete_enabled", false]
+    ]);
+    vi.spyOn(window, "parent", "get").mockReturnValue({ qBittorrent: { ClientData: parentClientData } });
+
+    await type("/data/");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(suggestions()).toBeNull();
+});
+
+test("neither requests nor shows suggestions when the setting is disabled", async () => {
+    clientData.set("path_autocomplete_enabled", false);
+
+    await type("/data/");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(suggestions()).toBeNull();
+});
+
+test("discards a listing that arrives after the setting was disabled", async () => {
+    let resolveListing;
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolveListing = resolve; }));
+    await type("/data/");
+
+    clientData.set("path_autocomplete_enabled", false);
+    resolveListing(new Response(JSON.stringify(["/data/a"])));
+    await flush();
+
+    expect(suggestions()).toBeNull();
+});
+
+test("removes existing suggestions once the setting is disabled", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/a"]));
+    await type("/data/");
+    expect(suggestions()).toEqual(["/data/a"]);
+
+    clientData.set("path_autocomplete_enabled", false);
+    await type("/data/a");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(suggestions()).toBeNull();
+});
+
+test("resumes suggesting once the setting is enabled again", async () => {
+    clientData.set("path_autocomplete_enabled", false);
+    await type("/data/");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    clientData.set("path_autocomplete_enabled", true);
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/a"]));
+    await type("/data/");
+
+    expect(suggestions()).toEqual(["/data/a"]);
+});
+
+test("stays enabled when no client data is available", async () => {
+    delete window.qBittorrent.ClientData;
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/a"]));
+
+    await type("/data/");
+
+    expect(suggestions()).toEqual(["/data/a"]);
+});


### PR DESCRIPTION
Adds a "Suggest existing paths while typing" checkbox to the Custom WebUI settings on the Behavior tab. It's on by default, stored in client data like the other options in that group, and applies to every path field, including the Add Torrent dialog, without a reload. When it's off, path fields don't request or show suggestions.

@sunflower-green asked for this while testing #24888: on iOS the native suggestion popup can cover the field while you type, and there was no way to turn the feature off short of downgrading. I kept it out of #24888 so that one stays a plain bug fix. The two are independent and either can merge first. I'll rebase whichever lands second.

<img width="1404" height="268" alt="toggle-setting" src="https://github.com/user-attachments/assets/48d7b1a0-8d24-4b4e-8b28-71f68ed7f598" />

Tested in Chromium and WebKit: the checkbox loads and saves, turning it off stops requests in a field that was already open and in the Add Torrent dialog, and turning it back on restores them. Also tried it on my iPhone. npm test passes with 7 new tests in test/private/pathAutofill.test.js, including the dialog case where the setting is read from the main window. npm run lint and npm run format are clean.