### PR TITLE
WebUI: Make path suggestions readable in Safari

### DIFF
--- a/src/webui/www/private/scripts/pathAutofill.js
+++ b/src/webui/www/private/scripts/pathAutofill.js
@@ -40,12 +40,24 @@ window.qBittorrent.pathAutofill ??= (() => {
         };
     };
 
+    // Safari shows only the first line of a wrapped suggestion. For a long
+    // name that line ends at the directory, so a label gives it a line that
+    // starts with the name itself. Touch devices skip the label: the keyboard
+    // bar cuts it off and it doubles the time Safari on iOS blocks input.
+    const showLabels = () => (window.matchMedia?.("(pointer: fine)").matches === true);
+
     const showInputSuggestions = (inputElement, names) => {
         const datalist = document.createElement("datalist");
         datalist.id = `${inputElement.id}Suggestions`;
+        const withLabels = showLabels();
         for (const name of names) {
             const option = document.createElement("option");
             option.value = name;
+            if (withLabels) {
+                const label = name.substring(Math.max(name.lastIndexOf("/"), name.lastIndexOf("\\")) + 1);
+                if (label !== "")
+                    option.setAttribute("label", label);
+            }
             datalist.appendChild(option);
         }
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -119,7 +119,7 @@
         </legend>
         <div class="formRow">
             <label for="filelog_save_path_input">QBT_TR(Save path:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="filelog_save_path_input" class="pathDirectory">
+            <input type="text" id="filelog_save_path_input" class="pathDirectory" style="width: 30em;">
         </div>
         <table>
             <tbody>
@@ -317,7 +317,7 @@
                         <label for="savepath_text">QBT_TR(Default Save Path:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="savepath_text" class="pathDirectory" autocorrect="off" autocapitalize="none">
+                        <input type="text" id="savepath_text" class="pathDirectory" style="width: 30em;" autocorrect="off" autocapitalize="none">
                     </td>
                 </tr>
                 <tr>
@@ -326,7 +326,7 @@
                         <label id="tempPathLabel" for="temppath_checkbox">QBT_TR(Keep incomplete torrents in:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="temppath_text" class="pathDirectory" autocorrect="off" autocapitalize="none" aria-labelledby="tempPathLabel">
+                        <input type="text" id="temppath_text" class="pathDirectory" style="width: 30em;" autocorrect="off" autocapitalize="none" aria-labelledby="tempPathLabel">
                     </td>
                 </tr>
             </tbody>
@@ -1155,7 +1155,7 @@ QBT_TR((best choice if supported))QBT_TR[CONTEXT=OptionsDialog] QBT_TR(Default p
             </legend>
             <div class="formRow">
                 <label for="webui_files_location_textarea">QBT_TR(Files location:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                <input type="text" id="webui_files_location_textarea" class="pathDirectory">
+                <input type="text" id="webui_files_location_textarea" class="pathDirectory" style="width: 30em;">
             </div>
             <div class="formRow">
                 <a href="https://github.com/qbittorrent/qBittorrent/wiki/List-of-known-alternate-WebUIs" target="_blank">QBT_TR(List of alternative WebUI)QBT_TR[CONTEXT=OptionsDialog]</a>

--- a/src/webui/www/test/private/pathAutofill.test.js
+++ b/src/webui/www/test/private/pathAutofill.test.js
@@ -1,0 +1,97 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  Randall Degges <r@rdegges.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import "../../private/scripts/pathAutofill.js";
+
+const attachPathAutofill = window.qBittorrent.pathAutofill.attachPathAutofill;
+
+const listingResponse = (entries) => Promise.resolve(new Response(JSON.stringify(entries)));
+
+// lets the fetch promise chain settle
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+let input;
+let fetchMock;
+let finePointer;
+
+const type = async (value) => {
+    input.value = value;
+    input.dispatchEvent(new Event("input"));
+    await flush();
+};
+
+const options = () => [...document.getElementById("savepathSuggestions").options].map((option) => [option.value, option.getAttribute("label")]);
+
+beforeEach(() => {
+    document.body.innerHTML = `<input type="text" id="savepath" class="pathDirectory">`;
+    input = document.getElementById("savepath");
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    finePointer = true;
+    vi.stubGlobal("matchMedia", (query) => ({ matches: (query === "(pointer: fine)") && finePointer }));
+    attachPathAutofill();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+test("keeps the full path as the value and labels each suggestion with its name", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/movies/Some.Really.Long.Movie.Name.2024.1080p.BluRay.x264-OTHER", "/data/movies/Alien (1979)"]));
+
+    await type("/data/movies/");
+
+    expect(options()).toEqual([
+        ["/data/movies/Some.Really.Long.Movie.Name.2024.1080p.BluRay.x264-OTHER", "Some.Really.Long.Movie.Name.2024.1080p.BluRay.x264-OTHER"],
+        ["/data/movies/Alien (1979)", "Alien (1979)"]
+    ]);
+});
+
+test("labels Windows paths with the last segment", async () => {
+    fetchMock.mockReturnValueOnce(listingResponse(["C:\\Users\\alice\\Downloads", "D:\\"]));
+
+    await type("C:\\Users\\alice\\");
+
+    expect(options()).toEqual([
+        ["C:\\Users\\alice\\Downloads", "Downloads"],
+        ["D:\\", null]
+    ]);
+});
+
+test("does not label suggestions on touch devices", async () => {
+    finePointer = false;
+    fetchMock.mockReturnValueOnce(listingResponse(["/data/movies/Alien (1979)"]));
+
+    await type("/data/movies/");
+
+    expect(options()).toEqual([
+        ["/data/movies/Alien (1979)", null]
+    ]);
+});


### PR DESCRIPTION
Path suggestions in Safari on macOS were useless for long folder names. Every row showed the same thing, `/data/movies/`, and nothing after it. This is what I hit while testing #24888, but it predates it: master shows the same rows.

The cause is how Safari draws the list. Each row is laid out as wrapping text and only the first line is shown. A break is allowed after a slash, a space, or a dot. For a long dotted name the first break after the directory is the slash, so line one is the directory and the name is on a hidden second line. A wider field doesn't help. Chrome sizes its dropdown to the content, so it never had this problem.

Two changes:

- Each suggestion gets a `label` with the name itself, so Safari draws a second line that starts with the name. Only on devices with a mouse or trackpad (`pointer: fine`). On iOS the keyboard bar cuts the label off anyway, and I measured it doubling the time Safari blocks input per update, from about 460 ms to about 1100 ms for 25 options.
- The four path fields in Options that had no width (log file save path, default save path, incomplete torrents path, alternative WebUI folder) get the same `width: 30em` as the backup and SSL fields next to them. At the default 137 px the label line only fits a few characters.

Independent of #24888 and #24893. Either order works and I'll rebase whichever lands later.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/a4e08fc1-3c10-4af3-acd7-22060a0c0113" width="420" alt="before: every row shows only the directory"> | <img src="https://github.com/user-attachments/assets/8d74daf4-3664-4220-b9b5-e877e472f80c" width="420" alt="after: a second line with the folder name"> |

Tested on macOS in Safari on both Options fields (Behavior > log file save path and Downloads > default save path), in Chrome, and in the iOS simulator, where the real script reports no labels and typing cost is unchanged. `npm test` passes with 6 new tests, including the touch case and a Windows path. `npm run lint` and `npm run format` are clean. Firefox is in the support matrix and gets labels, but I could not capture its popup under automation, so that one is untested by me.

