### PR TITLE
macOS: Avoid stale accessibility selection in Contents

### DIFF
--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -242,6 +242,11 @@ bool TorrentContentModel::setItemPriority(const QModelIndex &index, BitTorrent::
     if (currentPriority == priority)
         return false;
 
+#ifdef Q_OS_MACOS
+    emit priorityUpdateStarted();
+    [[maybe_unused]] const auto priorityUpdateGuard = qScopeGuard([this] { emit priorityUpdateFinished(); });
+#endif
+
     item->setPriority(priority);
     m_contentHandler->prioritizeFiles(getFilePriorities());
 

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -89,6 +89,11 @@ public:
 signals:
     void renameFailed(const QString &errorMessage);
 
+#ifdef Q_OS_MACOS
+    void priorityUpdateStarted();
+    void priorityUpdateFinished();
+#endif
+
 private:
     using ColumnInterval = IndexInterval<int>;
 

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -42,6 +42,8 @@
 #include <QShortcut>
 #include <QWheelEvent>
 
+#include <utility>
+
 #include "base/bittorrent/torrentcontenthandler.h"
 #include "base/path.h"
 #include "base/utils/string.h"
@@ -94,6 +96,14 @@ TorrentContentWidget::TorrentContentWidget(QWidget *parent)
     m_filterModel = new TorrentContentFilterModel(this);
     m_filterModel->setSourceModel(m_model);
     QTreeView::setModel(m_filterModel);
+
+#ifdef Q_OS_MACOS
+    // QAccessibleTree caches cells by visible row. A priority change can make the
+    // sorting proxy rearrange those rows while the Cocoa accessibility bridge is
+    // enumerating selected children. Do not expose that transient selection.
+    connect(m_model, &TorrentContentModel::priorityUpdateStarted, this, &TorrentContentWidget::beginPriorityUpdate);
+    connect(m_model, &TorrentContentModel::priorityUpdateFinished, this, &TorrentContentWidget::endPriorityUpdate);
+#endif
 
     auto *itemDelegate = new TorrentContentItemDelegate(this);
     setItemDelegate(itemDelegate);
@@ -361,6 +371,27 @@ void TorrentContentWidget::setModel([[maybe_unused]] QAbstractItemModel *model)
 {
     Q_ASSERT_X(false, Q_FUNC_INFO, "Changing the model of TorrentContentWidget is not allowed.");
 }
+
+#ifdef Q_OS_MACOS
+void TorrentContentWidget::beginPriorityUpdate()
+{
+    Q_ASSERT(m_selectionBeforePriorityUpdate.isEmpty());
+
+    const QModelIndexList selection = selectionModel()->selectedIndexes();
+    m_selectionBeforePriorityUpdate = toPersistentIndexes(selection);
+    selectionModel()->clearSelection();
+}
+
+void TorrentContentWidget::endPriorityUpdate()
+{
+    const QList<QPersistentModelIndex> selection = std::exchange(m_selectionBeforePriorityUpdate, {});
+    for (const QPersistentModelIndex &index : selection)
+    {
+        if (index.isValid())
+            selectionModel()->select(index, QItemSelectionModel::Select);
+    }
+}
+#endif
 
 QModelIndex TorrentContentWidget::currentNameCell() const
 {

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QPersistentModelIndex>
 #include <QTreeView>
 
 #include "base/bittorrent/downloadpriority.h"
@@ -124,6 +125,10 @@ private:
     void applyPrioritiesByOrder();
     Path getFullPath(const QModelIndex &index) const;
     void onItemDoubleClicked(const QModelIndex &index);
+#ifdef Q_OS_MACOS
+    void beginPriorityUpdate();
+    void endPriorityUpdate();
+#endif
     // Expand single-item folders recursively.
     // This will trigger sorting and filtering so do it after all relevant data is loaded.
     void expandRecursively();
@@ -137,4 +142,8 @@ private:
 
     bool m_contentDragAllowed = false;
     bool m_contentDragEnabled = false;
+
+#ifdef Q_OS_MACOS
+    QList<QPersistentModelIndex> m_selectionBeforePriorityUpdate;
+#endif
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,3 +38,11 @@ foreach(testFile ${testFiles})
 
     add_dependencies(check "${testFilename}")
 endforeach()
+
+if (GUI AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_executable(testtorrentcontentwidget testtorrentcontentwidget.cpp)
+    target_link_libraries(testtorrentcontentwidget PRIVATE Qt::Test Qt::Network Qt::Sql qbt_gui qbt_webui)
+    target_compile_features(testtorrentcontentwidget PRIVATE cxx_std_20)
+    add_test(NAME testtorrentcontentwidget COMMAND testtorrentcontentwidget)
+    add_dependencies(check testtorrentcontentwidget)
+endif()

--- a/test/testtorrentcontentwidget.cpp
+++ b/test/testtorrentcontentwidget.cpp
@@ -1,0 +1,121 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2026  The qBittorrent project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <QAccessible>
+#include <QFuture>
+#include <QItemSelectionModel>
+#include <QTest>
+#include <QTemporaryDir>
+
+#include "base/bittorrent/torrentcontenthandler.h"
+#include "base/path.h"
+#include "base/preferences.h"
+#include "base/profile.h"
+#include "base/settingsstorage.h"
+#include "gui/torrentcontentmodel.h"
+#include "gui/torrentcontentmodelitem.h"
+#include "gui/torrentcontentwidget.h"
+#include "gui/uithememanager.h"
+
+namespace
+{
+    class TestTorrentContentHandler final : public BitTorrent::TorrentContentHandler
+    {
+    public:
+        bool hasMetadata() const override { return true; }
+        int filesCount() const override { return 1; }
+        Path filePath(const int index) const override { return Path(QStringLiteral("video.mp4%1").arg(index)); }
+        qlonglong fileSize([[maybe_unused]] const int index) const override { return 1200000000; }
+        Path actualStorageLocation() const override { return {}; }
+        Path actualFilePath(const int index) const override { return filePath(index); }
+        QList<BitTorrent::DownloadPriority> filePriorities() const override { return {BitTorrent::DownloadPriority::Ignored}; }
+        QList<qreal> filesProgress() const override { return {0}; }
+        QFuture<QList<qreal>> fetchAvailableFileFractions() const override { return {}; }
+        void renameFile([[maybe_unused]] int index, [[maybe_unused]] const Path &newPath) override {}
+        void prioritizeFiles(const QList<BitTorrent::DownloadPriority> &priorities) override { m_priorities = priorities; }
+        void flushCache() const override {}
+
+    protected:
+        void doRenameFolder([[maybe_unused]] const Path &oldPath, [[maybe_unused]] const Path &newPath) override {}
+
+    private:
+        QList<BitTorrent::DownloadPriority> m_priorities;
+    };
+}
+
+class TestTorrentContentWidget final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestTorrentContentWidget)
+
+public:
+    TestTorrentContentWidget() = default;
+
+private slots:
+    void initTestCase()
+    {
+        QVERIFY(m_profileDir.isValid());
+        Profile::initInstance(Path(m_profileDir.path()), QStringLiteral("test"), false);
+        SettingsStorage::initInstance();
+        Preferences::initInstance();
+        UIThemeManager::initInstance();
+    }
+
+    void cleanupTestCase()
+    {
+        UIThemeManager::freeInstance();
+        Preferences::freeInstance();
+        SettingsStorage::freeInstance();
+        Profile::freeInstance();
+    }
+
+    void priorityChangeDoesNotExposeTransientSelection()
+    {
+        TestTorrentContentHandler contentHandler;
+        TorrentContentWidget widget;
+        widget.setContentHandler(&contentHandler);
+        widget.show();
+        QVERIFY(QTest::qWaitForWindowExposed(&widget));
+
+        const QModelIndex index = widget.model()->index(0, TorrentContentModelItem::COL_PRIO);
+        QVERIFY(index.isValid());
+        widget.selectionModel()->select(index, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+
+        QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(&widget);
+        QVERIFY(accessible);
+        QAccessibleSelectionInterface *selection = accessible->selectionInterface();
+        QVERIFY(selection);
+        QCOMPARE(selection->selectedItems().size(), TorrentContentModelItem::NB_COL);
+
+        bool selectionWasCleared = false;
+        bool selectionWasRestored = false;
+        const auto *contentModel = widget.findChild<TorrentContentModel *>();
+        QVERIFY(contentModel);
+        connect(contentModel, &TorrentContentModel::priorityUpdateStarted, this, [&widget, &selectionWasCleared]
+        {
+            selectionWasCleared = widget.selectionModel()->selectedIndexes().isEmpty();
+        });
+        connect(contentModel, &TorrentContentModel::priorityUpdateFinished, this, [&widget, &selectionWasRestored]
+        {
+            selectionWasRestored = (widget.selectionModel()->selectedIndexes().size() == TorrentContentModelItem::NB_COL);
+        });
+
+        QVERIFY(widget.model()->setData(index, static_cast<int>(BitTorrent::DownloadPriority::Normal)));
+        QVERIFY(selectionWasCleared);
+        QVERIFY(selectionWasRestored);
+        QCOMPARE(selection->selectedItems().size(), TorrentContentModelItem::NB_COL);
+    }
+
+private:
+    QTemporaryDir m_profileDir;
+};
+
+QTEST_MAIN(TestTorrentContentWidget)
+#include "testtorrentcontentwidget.moc"


### PR DESCRIPTION
Changing priority in the Contents view can rearrange proxy rows while an Accessibility client enumerates selected children. Clear the transient selection for the update and restore only valid persistent indexes afterward.

Add macOS-specific coverage for the priority-update selection lifetime.

Changing priority in the Contents view can rearrange proxy rows while a macOS
Accessibility client enumerates selected children. Qt's Cocoa accessibility
bridge can then access a stale tree cell and crash in
`QMacAccessibilityElement::accessibilitySelectedChildren`.

Save the selection as persistent proxy indexes and clear it during the priority
update. Restore only indexes that remain valid after the update completes.
This is limited to macOS.

## Reproduction

1. Open a multi-file torrent and select the Contents tab.
2. Leave a large media file unselected.
3. Have a macOS Accessibility client inspect the qBittorrent hierarchy.
4. Change that file's download selection or priority.

## Testing

- Built the macOS GUI target.
- Added a macOS-only regression test covering the priority-update selection
  lifetime.
- Ran `ctest --test-dir build-macos-accessibility/test --output-on-failure -R
  testtorrentcontentwidget` successfully.
- Reproduced the Contents workflow locally with Accessibility active.