### PR TITLE
Mark qBittorrent compatible with CET Shadow Stack

### DIFF
--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -97,6 +97,7 @@ if (MSVC)
         /Zc:__cplusplus
     )
     target_link_options(qbt_common_cfg INTERFACE
+        $<$<AND:$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},AMD64>,$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>>:/CETCOMPAT>
         /GUARD:CF
         $<$<NOT:$<CONFIG:Debug>>:/OPT:REF /OPT:ICF>
         # suppress linking warning due to /INCREMENTAL and /OPT:ICF being both ON


### PR DESCRIPTION
This flag enhances security by preventing malicious exploit attempts against qbt. CET Shadow Stack requires modern CPU support, but safely falls back to no-operation (NOP) on older CPUs without causing crashes.
This flag is only enabled for x86-64 CPU targets.

https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat?view=msvc-170

ps. tested, didn't found any issues.